### PR TITLE
fix: address PR #6 review comments for compilable README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,10 @@ The SDK can read configuration from any `IConfiguration` source (appsettings.jso
 
 Pass the section to the client:
 
-<!-- snippet:AppSettingsConfig -->
+<!-- snippet:UsingDirective+AppSettingsConfig -->
 ```csharp
+using Camunda.Orchestration.Sdk;
+
 var builder = WebApplication.CreateBuilder(args);
 
 using var client = CamundaClient.Create(new CamundaOptions
@@ -200,24 +202,30 @@ For ASP.NET Core and other DI-based applications, use the `AddCamundaClient()` e
 
 **Zero-config** (environment variables only):
 
-<!-- snippet:DIZeroConfig -->
+<!-- snippet:UsingDirective+DIZeroConfig -->
 ```csharp
+using Camunda.Orchestration.Sdk;
+
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCamundaClient();
 ```
 
 **With `appsettings.json`**:
 
-<!-- snippet:DIAppSettings -->
+<!-- snippet:UsingDirective+DIAppSettings -->
 ```csharp
+using Camunda.Orchestration.Sdk;
+
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCamundaClient(builder.Configuration.GetSection("Camunda"));
 ```
 
 **With options callback** (full control):
 
-<!-- snippet:DIOptionsCallback -->
+<!-- snippet:UsingDirective+DIOptionsCallback -->
 ```csharp
+using Camunda.Orchestration.Sdk;
+
 builder.Services.AddCamundaClient(options =>
 {
     options.Configuration = builder.Configuration.GetSection("Camunda");
@@ -246,8 +254,10 @@ public class OrderController(CamundaClient camunda) : ControllerBase
 
 ### Custom HttpClient
 
-<!-- snippet:CustomHttpClient -->
+<!-- snippet:UsingDirective+CustomHttpClient -->
 ```csharp
+using Camunda.Orchestration.Sdk;
+
 var httpClient = new HttpClient { BaseAddress = new Uri("https://my-cluster/v2/") };
 using var client = CamundaClient.Create(new CamundaOptions
 {
@@ -435,8 +445,10 @@ When an `ILoggerFactory` is provided, `CAMUNDA_SDK_LOG_LEVEL` is ignored — fil
 
 When using `AddCamundaClient()`, the SDK automatically resolves `ILoggerFactory` from the DI container — no manual wiring needed:
 
-<!-- snippet:DILogging -->
+<!-- snippet:UsingDirective+DILogging -->
 ```csharp
+using Camunda.Orchestration.Sdk;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Logging configuration
@@ -533,7 +545,7 @@ foreach (var process in result.Processes)
 
 The recommended pattern is to obtain keys from a prior API response (e.g. a deployment) and pass them directly — no manual conversion needed:
 
-<!-- snippet:UsingDirective+CreateProcessInstance -->
+<!-- snippet:UsingDirective+ReadmeCreateProcessInstance -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 

--- a/docs/examples/ReadmeExamples.cs
+++ b/docs/examples/ReadmeExamples.cs
@@ -199,7 +199,7 @@ internal static class ReadmeExamples
 
     private static async Task CreateProcessInstanceExample()
     {
-        // <CreateProcessInstance>
+        // <ReadmeCreateProcessInstance>
         using var client = CamundaClient.Create();
 
         var deployment = await client.DeployResourcesFromFilesAsync(["process.bpmn"]);
@@ -212,7 +212,7 @@ internal static class ReadmeExamples
             });
 
         Console.WriteLine($"Process instance key: {result.ProcessInstanceKey}");
-        // </CreateProcessInstance>
+        // </ReadmeCreateProcessInstance>
     }
 
     private static async Task CreateProcessFromStorageExample()

--- a/scripts/sync-readme-snippets.py
+++ b/scripts/sync-readme-snippets.py
@@ -97,6 +97,7 @@ def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
     i = 0
     changed = False
     missing: list[str] = []
+    errors: list[str] = []
 
     while i < len(lines):
         line = lines[i].rstrip("\n")
@@ -127,7 +128,7 @@ def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
 
         # Expect opening fence
         if i >= len(lines) or not lines[i].strip().startswith("```"):
-            print(f"WARNING: snippet:{region_name} — expected ``` after marker, skipping")
+            errors.append(f"snippet:{region_name} — expected ``` after marker")
             continue
 
         fence_lang = lines[i].strip()  # e.g. ```csharp
@@ -138,7 +139,7 @@ def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
             close_idx += 1
 
         if close_idx >= len(lines):
-            print(f"WARNING: snippet:{region_name} — no closing ``` found, skipping")
+            errors.append(f"snippet:{region_name} — no closing ``` found")
             out.append(lines[i])
             i += 1
             continue
@@ -153,9 +154,15 @@ def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
         out.append(new_block)
         i = close_idx + 1
 
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+
     if missing:
         print(f"ERROR: missing regions: {', '.join(missing)}", file=sys.stderr)
-        return True  # treat as failure
+
+    if errors or missing:
+        sys.exit(1)
 
     new_text = "".join(out)
 


### PR DESCRIPTION
Addresses all 8 review comments from PR #6.

## Changes

### Script error handling (`scripts/sync-readme-snippets.py`)
- **Malformed snippet blocks** (missing opening/closing fences) are now tracked in an `errors` list and cause `sys.exit(1)` in both normal and `--check` modes — previously these were warnings that let CI pass silently
- **Missing regions** now `sys.exit(1)` regardless of `--check` mode — previously only returned `True` without actually exiting the process

### Region name collision (`docs/examples/ReadmeExamples.cs`)
- Renamed `CreateProcessInstance` → `ReadmeCreateProcessInstance` to avoid collision with the same region name in `ProcessInstanceExamples.cs` (which could cause nondeterministic behavior in `generate-docusaurus-md.py`)

### UsingDirective composition (`README.md`)
Added `UsingDirective+` prefix to 6 snippet markers so all code blocks include `using Camunda.Orchestration.Sdk;` and are copy-paste compilable:
- `AppSettingsConfig` → `UsingDirective+AppSettingsConfig`
- `DIZeroConfig` → `UsingDirective+DIZeroConfig`
- `DIAppSettings` → `UsingDirective+DIAppSettings`
- `DIOptionsCallback` → `UsingDirective+DIOptionsCallback`
- `CustomHttpClient` → `UsingDirective+CustomHttpClient`
- `DILogging` → `UsingDirective+DILogging`

## Verification
- ✅ `dotnet build docs/examples/Examples.csproj` — compiles with 0 warnings
- ✅ `python3 scripts/sync-readme-snippets.py --check` — passes (idempotent)
