### PR TITLE
feat: support job corrections and denial in worker handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ The handler return value determines the job outcome:
 |---|---|
 | Return `object` | Auto-complete with those variables |
 | Return `null` | Auto-complete with no variables |
+| Return `JobCompletionRequest` | Complete with structured result (corrections, denial) |
 | Throw `BpmnErrorException` | Trigger a BPMN error boundary event |
 | Throw `JobFailureException` | Fail with custom retries / back-off |
 | Throw any other exception | Auto-fail with `retries - 1` |
@@ -710,6 +711,46 @@ throw new BpmnErrorException("INVALID_ORDER", "Order not found");
 
 // Explicit failure with retry control
 throw new JobFailureException("Service unavailable", retries: 2, retryBackOffMs: 5000);
+```
+
+### Job Corrections (User Task Listeners)
+
+When handling jobs from [user task listeners](https://docs.camunda.io/docs/components/concepts/user-task-listeners/), you can return a `JobCompletionRequest` to apply corrections to the task or deny the action. Return a `JobCompletionRequest` from the handler instead of a plain variables object:
+
+```csharp
+client.CreateJobWorker(config, async (job, ct) =>
+{
+    // Apply corrections to the user task
+    return new JobCompletionRequest
+    {
+        Variables = new { reviewed = true },
+        Result = new JobResultUserTask
+        {
+            Corrections = new JobResultCorrections
+            {
+                Assignee = "new-assignee",
+                Priority = 75,
+                CandidateGroups = new List<string> { "managers" },
+            },
+        },
+    };
+});
+```
+
+To deny the user task action (e.g. reject a completion):
+
+```csharp
+client.CreateJobWorker(config, async (job, ct) =>
+{
+    return new JobCompletionRequest
+    {
+        Result = new JobResultUserTask
+        {
+            Denied = true,
+            DeniedReason = "Missing required fields",
+        },
+    };
+});
 ```
 
 ### Void Handler (No Output Variables)

--- a/src/Camunda.Orchestration.Sdk/Runtime/JobWorker.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/JobWorker.cs
@@ -6,6 +6,8 @@ namespace Camunda.Orchestration.Sdk;
 /// <summary>
 /// Delegate for job handler functions. Return the output variables to complete the
 /// job with, or <c>null</c> to complete with no output variables.
+/// Return a <see cref="JobCompletionRequest"/> to send a structured completion
+/// (e.g. with job corrections or a task denial).
 ///
 /// <para>To signal a BPMN error, throw <see cref="BpmnErrorException"/>.</para>
 /// <para>To explicitly fail a job with custom retries, throw <see cref="JobFailureException"/>.</para>
@@ -373,11 +375,14 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
         {
             var result = await _handler(job, ct).ConfigureAwait(false);
 
-            // Auto-complete with the returned variables
-            await _client.CompleteJobAsync(job.JobKey, new JobCompletionRequest
-            {
-                Variables = result,
-            }, ct: ct).ConfigureAwait(false);
+            // If the handler returned a full JobCompletionRequest (e.g. with
+            // corrections or a denial), forward it as-is. Otherwise treat the
+            // return value as output variables.
+            var completionRequest = result is JobCompletionRequest req
+                ? req
+                : new JobCompletionRequest { Variables = result };
+
+            await _client.CompleteJobAsync(job.JobKey, completionRequest, ct: ct).ConfigureAwait(false);
 
             if (_logger.IsEnabled(LogLevel.Debug))
                 _logger.LogDebug("JobWorker '{Name}': completed job {JobKey}", _name, job.JobKey);

--- a/test/Camunda.Orchestration.Sdk.Tests/JobWorkerTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/JobWorkerTests.cs
@@ -305,6 +305,94 @@ public class JobWorkerTests
         worker.IsRunning.Should().BeFalse();
     }
 
+    // ---- JobCompletionRequest detection ----
+
+    [Fact]
+    public void Handler_Returning_JobCompletionRequest_Is_Forwarded_AsIs()
+    {
+        // Mirrors the pattern in ExecuteJobAsync: when the handler returns a
+        // JobCompletionRequest, it should be forwarded directly (not wrapped).
+        var corrections = new JobResultCorrections
+        {
+            Assignee = "new-assignee",
+            Priority = 75,
+            CandidateGroups = new List<string> { "managers" },
+        };
+        var completionRequest = new JobCompletionRequest
+        {
+            Variables = new { approved = true },
+            Result = new JobResultUserTask
+            {
+                Corrections = corrections,
+            },
+        };
+        object? result = completionRequest;
+
+        var actual = result is JobCompletionRequest req
+            ? req
+            : new JobCompletionRequest { Variables = result };
+
+        actual.Should().BeSameAs(completionRequest);
+        actual.Result.Should().BeOfType<JobResultUserTask>();
+
+        var userTask = (JobResultUserTask)actual.Result!;
+        userTask.Corrections!.Assignee.Should().Be("new-assignee");
+        userTask.Corrections.Priority.Should().Be(75);
+        userTask.Corrections.CandidateGroups.Should().ContainSingle().Which.Should().Be("managers");
+    }
+
+    [Fact]
+    public void Handler_Returning_PlainObject_Is_Wrapped_As_Variables()
+    {
+        // When the handler returns a plain object (not JobCompletionRequest),
+        // it should be wrapped in a new JobCompletionRequest as Variables.
+        var output = new OrderOutput(true, "INV-001");
+        object? result = output;
+
+        var actual = result is JobCompletionRequest req
+            ? req
+            : new JobCompletionRequest { Variables = result };
+
+        actual.Variables.Should().BeSameAs(output);
+        actual.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Handler_Returning_Null_Is_Wrapped_As_Empty_Variables()
+    {
+        object? result = null;
+
+        var actual = result is JobCompletionRequest req
+            ? req
+            : new JobCompletionRequest { Variables = result };
+
+        actual.Variables.Should().BeNull();
+        actual.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Handler_Returning_Denial_Is_Forwarded()
+    {
+        var completionRequest = new JobCompletionRequest
+        {
+            Result = new JobResultUserTask
+            {
+                Denied = true,
+                DeniedReason = "Missing required fields",
+            },
+        };
+        object? result = completionRequest;
+
+        var actual = result is JobCompletionRequest req
+            ? req
+            : new JobCompletionRequest { Variables = result };
+
+        actual.Should().BeSameAs(completionRequest);
+        var userTask = (JobResultUserTask)actual.Result!;
+        userTask.Denied.Should().BeTrue();
+        userTask.DeniedReason.Should().Be("Missing required fields");
+    }
+
     // ---- Helpers ----
 
     private static readonly JsonSerializerOptions s_testJsonOptions = new()


### PR DESCRIPTION
## Summary

When a job handler returns a `JobCompletionRequest`, it is now forwarded directly to the Camunda API instead of being wrapped as output variables. This enables **user task listener** handlers to:

- **Apply corrections** to task attributes (assignee, priority, due date, follow-up date, candidate users/groups)
- **Deny** user task actions (e.g. reject a task completion)

Plain object returns and `null` continue to work exactly as before.

## Changes

### `JobWorker.cs`
- `ExecuteJobAsync`: Added `is JobCompletionRequest` pattern match — if the handler returns a `JobCompletionRequest`, it is forwarded as-is; otherwise the return value is wrapped as `Variables`
- `JobHandler` delegate: Updated doc comment to mention `JobCompletionRequest` as a valid return type

### `JobWorkerTests.cs`
- Added 4 tests covering the completion request detection pattern:
  - `Handler_Returning_JobCompletionRequest_Is_Forwarded_AsIs` — corrections flow through
  - `Handler_Returning_PlainObject_Is_Wrapped_As_Variables` — backward compatible
  - `Handler_Returning_Null_Is_Wrapped_As_Empty_Variables` — backward compatible
  - `Handler_Returning_Denial_Is_Forwarded` — denial flow through

### `README.md`
- Added `JobCompletionRequest` row to the Handler Contract table
- Added "Job Corrections (User Task Listeners)" section with examples for corrections and denial

## Usage

```csharp
// Apply corrections
client.CreateJobWorker(config, async (job, ct) =>
{
    return new JobCompletionRequest
    {
        Variables = new { reviewed = true },
        Result = new JobResultUserTask
        {
            Corrections = new JobResultCorrections
            {
                Assignee = "new-assignee",
                Priority = 75,
            },
        },
    };
});

// Deny a user task action
client.CreateJobWorker(config, async (job, ct) =>
{
    return new JobCompletionRequest
    {
        Result = new JobResultUserTask
        {
            Denied = true,
            DeniedReason = "Missing required fields",
        },
    };
});
```

Closes #33 (partial — job corrections portion)