### PR TITLE
feat: heritable worker defaults via CAMUNDA_WORKER_* env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,14 +773,63 @@ client.CreateJobWorker(config, async (job, ct) =>
 | Property | Default | Description |
 |---|---|---|
 | `JobType` | *(required)* | BPMN task type to subscribe to |
-| `JobTimeoutMs` | *(required)* | Job lock duration (ms) |
-| `MaxConcurrentJobs` | `10` | Max in-flight jobs per worker |
+| `JobTimeoutMs` | *(env / required)* | Job lock duration (ms). Falls back to `CAMUNDA_WORKER_TIMEOUT` env var. |
+| `MaxConcurrentJobs` | `10` | Max in-flight jobs per worker. Falls back to `CAMUNDA_WORKER_MAX_CONCURRENT_JOBS` env var, then `10`. |
 | `PollIntervalMs` | `500` | Delay between polls when idle |
-| `PollTimeoutMs` | `null` | Long-poll timeout (null = broker default) |
+| `PollTimeoutMs` | `null` | Long-poll timeout (null = broker default). Falls back to `CAMUNDA_WORKER_REQUEST_TIMEOUT` env var. |
 | `FetchVariables` | `null` | Variable names to fetch (null = all) |
-| `WorkerName` | auto | Worker name for logging |
+| `WorkerName` | auto | Worker name for logging. Falls back to `CAMUNDA_WORKER_NAME` env var. |
 | `AutoStart` | `true` | Start polling on creation |
-| `StartupJitterMaxSeconds` | `0` | Max random delay (seconds) before first poll. Spreads out activation requests when multiple instances restart simultaneously. `0` = no delay. |
+| `StartupJitterMaxSeconds` | `0` | Max random delay (seconds) before first poll. Falls back to `CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS` env var. |
+
+### Heritable Worker Defaults
+
+When running many workers with the same base configuration, you can set global defaults via environment variables. These apply to every worker created by the client unless the individual `JobWorkerConfig` explicitly overrides them.
+
+| Environment Variable | Config Property | Type |
+|---|---|---|
+| `CAMUNDA_WORKER_TIMEOUT` | `JobTimeoutMs` | long |
+| `CAMUNDA_WORKER_MAX_CONCURRENT_JOBS` | `MaxConcurrentJobs` | int |
+| `CAMUNDA_WORKER_REQUEST_TIMEOUT` | `PollTimeoutMs` | long |
+| `CAMUNDA_WORKER_NAME` | `WorkerName` | string |
+| `CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS` | `StartupJitterMaxSeconds` | int |
+
+**Precedence:** explicit `JobWorkerConfig` value > environment variable > hardcoded default.
+
+```bash
+export CAMUNDA_WORKER_TIMEOUT=30000
+export CAMUNDA_WORKER_MAX_CONCURRENT_JOBS=8
+export CAMUNDA_WORKER_NAME=order-service
+```
+
+```csharp
+// Workers inherit timeout, concurrency, and name from environment
+client.CreateJobWorker(
+    new JobWorkerConfig { JobType = "validate-order" },
+    async (job, ct) => null);
+
+client.CreateJobWorker(
+    new JobWorkerConfig { JobType = "ship-order" },
+    async (job, ct) => null);
+
+// Per-worker override: this worker uses 32 concurrent jobs instead of the global 8
+client.CreateJobWorker(
+    new JobWorkerConfig { JobType = "bulk-import", MaxConcurrentJobs = 32 },
+    async (job, ct) => null);
+```
+
+You can also pass defaults programmatically via the client constructor:
+
+```csharp
+var client = CamundaClient.Create(new CamundaOptions
+{
+    Config = new Dictionary<string, string>
+    {
+        ["CAMUNDA_WORKER_TIMEOUT"] = "30000",
+        ["CAMUNDA_WORKER_MAX_CONCURRENT_JOBS"] = "8",
+    },
+});
+```
 
 ### Concurrency
 

--- a/src/Camunda.Orchestration.Sdk/CamundaClient.Workers.cs
+++ b/src/Camunda.Orchestration.Sdk/CamundaClient.Workers.cs
@@ -23,7 +23,22 @@ public partial class CamundaClient : IAsyncDisposable
     /// <returns>The running <see cref="JobWorker"/> instance.</returns>
     public JobWorker CreateJobWorker(JobWorkerConfig config, JobHandler handler)
     {
-        var worker = new JobWorker(this, config, handler, _loggerFactory, _jsonOptions);
+        var defaults = _config.WorkerDefaults;
+        var merged = new JobWorkerConfig
+        {
+            JobType = config.JobType,
+            JobTimeoutMs = config.JobTimeoutMs ?? defaults?.JobTimeoutMs,
+            MaxConcurrentJobs = config.MaxConcurrentJobs ?? defaults?.MaxConcurrentJobs ?? 10,
+            PollIntervalMs = config.PollIntervalMs,
+            PollTimeoutMs = config.PollTimeoutMs ?? defaults?.PollTimeoutMs,
+            FetchVariables = config.FetchVariables,
+            WorkerName = config.WorkerName ?? defaults?.WorkerName,
+            AutoStart = config.AutoStart,
+            StartupJitterMaxSeconds = config.StartupJitterMaxSeconds > 0
+                ? config.StartupJitterMaxSeconds
+                : defaults?.StartupJitterMaxSeconds ?? 0,
+        };
+        var worker = new JobWorker(this, merged, handler, _loggerFactory, _jsonOptions);
         _workers.Add(worker);
         return worker;
     }

--- a/src/Camunda.Orchestration.Sdk/Runtime/CamundaConfig.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/CamundaConfig.cs
@@ -37,6 +37,7 @@ public sealed class CamundaConfig
     public ValidationConfig Validation { get; init; } = new();
     public string LogLevel { get; init; } = "error";
     public EventualConfig? Eventual { get; init; }
+    public WorkerDefaultsConfig? WorkerDefaults { get; init; }
 }
 
 public sealed class HttpRetryConfig
@@ -100,4 +101,13 @@ public sealed class ValidationConfig
 public sealed class EventualConfig
 {
     public int PollDefaultMs { get; init; } = 500;
+}
+
+public sealed class WorkerDefaultsConfig
+{
+    public long? JobTimeoutMs { get; init; }
+    public int? MaxConcurrentJobs { get; init; }
+    public long? PollTimeoutMs { get; init; }
+    public string? WorkerName { get; init; }
+    public double? StartupJitterMaxSeconds { get; init; }
 }

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -104,7 +104,10 @@ public static class ConfigurationHydrator
                          "CAMUNDA_CLIENT_ID", "CAMUNDA_CLIENT_SECRET",
                          "CAMUNDA_BASIC_AUTH_USERNAME", "CAMUNDA_BASIC_AUTH_PASSWORD",
                          "CAMUNDA_OAUTH_SCOPE", "CAMUNDA_OAUTH_CACHE_DIR",
-                         "ZEEBE_REST_ADDRESS"
+                         "ZEEBE_REST_ADDRESS",
+                         "CAMUNDA_WORKER_TIMEOUT", "CAMUNDA_WORKER_MAX_CONCURRENT_JOBS",
+                         "CAMUNDA_WORKER_REQUEST_TIMEOUT", "CAMUNDA_WORKER_NAME",
+                         "CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS"
                      })
             {
                 var v = Environment.GetEnvironmentVariable(extra);
@@ -246,6 +249,23 @@ public static class ConfigurationHydrator
         var oauthRetryBaseDelayMs = ParseInt("CAMUNDA_OAUTH_RETRY_BASE_DELAY_MS", 1000);
         var eventualPollDefaultMs = ParseInt("CAMUNDA_SDK_EVENTUAL_POLL_DEFAULT_MS", 500);
 
+        // Parse optional worker defaults
+        int? workerTimeout = rawMap.ContainsKey("CAMUNDA_WORKER_TIMEOUT")
+            ? ParseInt("CAMUNDA_WORKER_TIMEOUT", 0)
+            : null;
+        int? workerMaxConcurrent = rawMap.ContainsKey("CAMUNDA_WORKER_MAX_CONCURRENT_JOBS")
+            ? ParseInt("CAMUNDA_WORKER_MAX_CONCURRENT_JOBS", 0)
+            : null;
+        int? workerRequestTimeout = rawMap.ContainsKey("CAMUNDA_WORKER_REQUEST_TIMEOUT")
+            ? ParseInt("CAMUNDA_WORKER_REQUEST_TIMEOUT", 0)
+            : null;
+        var workerName = rawMap.GetValueOrDefault("CAMUNDA_WORKER_NAME");
+        int? workerJitter = rawMap.ContainsKey("CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS")
+            ? ParseInt("CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS", 0)
+            : null;
+        var hasWorkerDefaults = workerTimeout != null || workerMaxConcurrent != null
+            || workerRequestTimeout != null || workerName != null || workerJitter != null;
+
         if (errors.Count > 0)
             throw new CamundaConfigurationException(errors);
 
@@ -313,6 +333,16 @@ public static class ConfigurationHydrator
             {
                 PollDefaultMs = eventualPollDefaultMs,
             },
+            WorkerDefaults = hasWorkerDefaults
+                ? new WorkerDefaultsConfig
+                {
+                    JobTimeoutMs = workerTimeout,
+                    MaxConcurrentJobs = workerMaxConcurrent,
+                    PollTimeoutMs = workerRequestTimeout,
+                    WorkerName = workerName,
+                    StartupJitterMaxSeconds = workerJitter,
+                }
+                : null,
         };
     }
 
@@ -430,6 +460,13 @@ public static class ConfigurationHydrator
 
         // Eventual consistency
         ["Eventual:PollDefaultMs"] = "CAMUNDA_SDK_EVENTUAL_POLL_DEFAULT_MS",
+
+        // Worker defaults
+        ["Worker:Timeout"] = "CAMUNDA_WORKER_TIMEOUT",
+        ["Worker:MaxConcurrentJobs"] = "CAMUNDA_WORKER_MAX_CONCURRENT_JOBS",
+        ["Worker:RequestTimeout"] = "CAMUNDA_WORKER_REQUEST_TIMEOUT",
+        ["Worker:Name"] = "CAMUNDA_WORKER_NAME",
+        ["Worker:StartupJitterMaxSeconds"] = "CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS",
     };
 
     /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Runtime/JobWorker.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/JobWorker.cs
@@ -28,8 +28,9 @@ public sealed class JobWorkerConfig
     /// <summary>
     /// How long (in ms) the job is reserved for this worker before the broker
     /// makes it available to other workers.
+    /// Falls back to <c>CAMUNDA_WORKER_TIMEOUT</c> environment variable.
     /// </summary>
-    public required long JobTimeoutMs { get; init; }
+    public long? JobTimeoutMs { get; init; }
 
     /// <summary>
     /// Maximum number of jobs that may be in-flight (activated and being handled)
@@ -45,8 +46,9 @@ public sealed class JobWorkerConfig
     /// to avoid over-subscribing the thread pool.
     /// </para>
     /// <para>Set to <c>1</c> for sequential (single-job-at-a-time) processing.</para>
+    /// <para>Falls back to <c>CAMUNDA_WORKER_MAX_CONCURRENT_JOBS</c> environment variable, then <c>10</c>.</para>
     /// </summary>
-    public int MaxConcurrentJobs { get; init; } = 10;
+    public int? MaxConcurrentJobs { get; init; }
 
     /// <summary>
     /// Delay (in ms) between poll cycles when no jobs are available or when at capacity.
@@ -191,6 +193,8 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
     private readonly string _name;
     private readonly ILogger _logger;
     private readonly JsonSerializerOptions _jsonOptions;
+    private readonly long _jobTimeoutMs;
+    private readonly int _maxConcurrentJobs;
 
     private CancellationTokenSource? _cts;
     private Task? _pollTask;
@@ -207,6 +211,18 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
         _config = config;
         _handler = handler;
         _jsonOptions = jsonOptions;
+
+        if (config.JobTimeoutMs is null)
+            throw new ArgumentException(
+                "JobTimeoutMs is required: set it on JobWorkerConfig or via CAMUNDA_WORKER_TIMEOUT environment variable.",
+                nameof(config));
+        if (config.MaxConcurrentJobs is null)
+            throw new ArgumentException(
+                "MaxConcurrentJobs is required: set it on JobWorkerConfig, via CAMUNDA_WORKER_MAX_CONCURRENT_JOBS environment variable, or accept the default (10).",
+                nameof(config));
+
+        _jobTimeoutMs = config.JobTimeoutMs.Value;
+        _maxConcurrentJobs = config.MaxConcurrentJobs.Value;
         _name = config.WorkerName ?? $"worker-{config.JobType}-{Interlocked.Increment(ref _counter)}";
         _logger = loggerFactory.CreateLogger($"Camunda.Orchestration.Sdk.JobWorker.{_name}");
 
@@ -306,7 +322,7 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
         {
             while (!ct.IsCancellationRequested)
             {
-                var capacity = _config.MaxConcurrentJobs - ActiveJobs;
+                var capacity = _maxConcurrentJobs - ActiveJobs;
                 if (capacity <= 0)
                 {
                     await Task.Delay(_config.PollIntervalMs, ct).ConfigureAwait(false);
@@ -319,7 +335,7 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
                     {
                         Type = _config.JobType,
                         Worker = _name,
-                        Timeout = _config.JobTimeoutMs,
+                        Timeout = _jobTimeoutMs,
                         MaxJobsToActivate = capacity,
                         FetchVariable = _config.FetchVariables,
                         RequestTimeout = _config.PollTimeoutMs ?? 0,

--- a/test/Camunda.Orchestration.Sdk.Tests/JobWorkerTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/JobWorkerTests.cs
@@ -77,10 +77,10 @@ public class JobWorkerTests
         var config = new JobWorkerConfig
         {
             JobType = "my-type",
-            JobTimeoutMs = 30000,
         };
 
-        config.MaxConcurrentJobs.Should().Be(10);
+        config.MaxConcurrentJobs.Should().BeNull();
+        config.JobTimeoutMs.Should().BeNull();
         config.PollIntervalMs.Should().Be(500);
         config.PollTimeoutMs.Should().BeNull();
         config.FetchVariables.Should().BeNull();

--- a/test/Camunda.Orchestration.Sdk.Tests/WorkerDefaultsTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/WorkerDefaultsTests.cs
@@ -1,0 +1,247 @@
+using FluentAssertions;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Tests for heritable worker defaults (CAMUNDA_WORKER_* env vars).
+/// Validates hydration, merge precedence, and validation behavior.
+/// </summary>
+public class WorkerDefaultsTests
+{
+    // ---- Hydration ----
+
+    [Fact]
+    public void Hydrate_WorkerTimeout_PopulatesWorkerDefaults()
+    {
+        var config = ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?> { ["CAMUNDA_WORKER_TIMEOUT"] = "30000" });
+
+        config.WorkerDefaults.Should().NotBeNull();
+        config.WorkerDefaults!.JobTimeoutMs.Should().Be(30000);
+    }
+
+    [Fact]
+    public void Hydrate_WorkerMaxConcurrentJobs_PopulatesWorkerDefaults()
+    {
+        var config = ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?> { ["CAMUNDA_WORKER_MAX_CONCURRENT_JOBS"] = "8" });
+
+        config.WorkerDefaults.Should().NotBeNull();
+        config.WorkerDefaults!.MaxConcurrentJobs.Should().Be(8);
+    }
+
+    [Fact]
+    public void Hydrate_WorkerRequestTimeout_PopulatesWorkerDefaults()
+    {
+        var config = ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?> { ["CAMUNDA_WORKER_REQUEST_TIMEOUT"] = "15000" });
+
+        config.WorkerDefaults.Should().NotBeNull();
+        config.WorkerDefaults!.PollTimeoutMs.Should().Be(15000);
+    }
+
+    [Fact]
+    public void Hydrate_WorkerName_PopulatesWorkerDefaults()
+    {
+        var config = ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?> { ["CAMUNDA_WORKER_NAME"] = "my-worker" });
+
+        config.WorkerDefaults.Should().NotBeNull();
+        config.WorkerDefaults!.WorkerName.Should().Be("my-worker");
+    }
+
+    [Fact]
+    public void Hydrate_WorkerJitter_PopulatesWorkerDefaults()
+    {
+        var config = ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?> { ["CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS"] = "5" });
+
+        config.WorkerDefaults.Should().NotBeNull();
+        config.WorkerDefaults!.StartupJitterMaxSeconds.Should().Be(5);
+    }
+
+    [Fact]
+    public void Hydrate_NoWorkerVars_WorkerDefaultsIsNull()
+    {
+        var config = ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?>());
+
+        config.WorkerDefaults.Should().BeNull();
+    }
+
+    [Fact]
+    public void Hydrate_MultipleWorkerVars_PopulatesAll()
+    {
+        var config = ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?>
+            {
+                ["CAMUNDA_WORKER_TIMEOUT"] = "60000",
+                ["CAMUNDA_WORKER_MAX_CONCURRENT_JOBS"] = "16",
+                ["CAMUNDA_WORKER_NAME"] = "batch-worker",
+            });
+
+        config.WorkerDefaults.Should().NotBeNull();
+        config.WorkerDefaults!.JobTimeoutMs.Should().Be(60000);
+        config.WorkerDefaults!.MaxConcurrentJobs.Should().Be(16);
+        config.WorkerDefaults!.WorkerName.Should().Be("batch-worker");
+        config.WorkerDefaults!.PollTimeoutMs.Should().BeNull();
+        config.WorkerDefaults!.StartupJitterMaxSeconds.Should().BeNull();
+    }
+
+    // ---- Merge: defaults applied when per-worker config omits fields ----
+
+    [Fact]
+    public void CreateJobWorker_AppliesWorkerDefaults_WhenPerWorkerOmits()
+    {
+        using var client = CreateClientWithWorkerDefaults();
+
+        var worker = client.CreateJobWorker(
+            new JobWorkerConfig { JobType = "test", AutoStart = false },
+            (job, ct) => Task.FromResult<object?>(null));
+
+        // Worker should be created successfully — timeout and concurrency from defaults
+        worker.Should().NotBeNull();
+
+    }
+
+    [Fact]
+    public void CreateJobWorker_ExplicitConfig_OverridesDefaults()
+    {
+        using var client = CreateClientWithWorkerDefaults(
+            workerName: "default-name");
+
+        var worker = client.CreateJobWorker(
+            new JobWorkerConfig
+            {
+                JobType = "test",
+                JobTimeoutMs = 60000,
+                MaxConcurrentJobs = 32,
+                WorkerName = "explicit-name",
+                AutoStart = false,
+            },
+            (job, ct) => Task.FromResult<object?>(null));
+
+        worker.Name.Should().Be("explicit-name");
+
+    }
+
+    [Fact]
+    public void CreateJobWorker_DefaultName_InheritsFromWorkerDefaults()
+    {
+        using var client = CreateClientWithWorkerDefaults(
+            workerName: "global-worker");
+
+        var worker = client.CreateJobWorker(
+            new JobWorkerConfig { JobType = "test", AutoStart = false },
+            (job, ct) => Task.FromResult<object?>(null));
+
+        worker.Name.Should().Be("global-worker");
+
+    }
+
+    // ---- Validation ----
+
+    [Fact]
+    public void CreateJobWorker_Throws_WhenJobTimeoutMs_NotSetAnywhere()
+    {
+        using var client = CamundaClient.Create(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "http://localhost:8080/v2",
+                ["CAMUNDA_AUTH_STRATEGY"] = "NONE",
+                ["CAMUNDA_WORKER_MAX_CONCURRENT_JOBS"] = "4",
+            },
+        });
+
+        var act = () => client.CreateJobWorker(
+            new JobWorkerConfig { JobType = "test", AutoStart = false },
+            (job, ct) => Task.FromResult<object?>(null));
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*JobTimeoutMs is required*");
+    }
+
+    [Fact]
+    public void CreateJobWorker_Succeeds_WhenBothRequired_FromEnvDefaults()
+    {
+        using var client = CreateClientWithWorkerDefaults();
+
+        var worker = client.CreateJobWorker(
+            new JobWorkerConfig { JobType = "test", AutoStart = false },
+            (job, ct) => Task.FromResult<object?>(null));
+
+        worker.Should().NotBeNull();
+
+    }
+
+    [Fact]
+    public void CreateJobWorker_Succeeds_WhenBothRequired_SetPerWorker()
+    {
+        using var client = CamundaClient.Create(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "http://localhost:8080/v2",
+                ["CAMUNDA_AUTH_STRATEGY"] = "NONE",
+            },
+        });
+
+        var worker = client.CreateJobWorker(
+            new JobWorkerConfig
+            {
+                JobType = "test",
+                JobTimeoutMs = 30000,
+                MaxConcurrentJobs = 4,
+                AutoStart = false,
+            },
+            (job, ct) => Task.FromResult<object?>(null));
+
+        worker.Should().NotBeNull();
+
+    }
+
+    [Fact]
+    public void CreateJobWorker_MaxConcurrentJobs_DefaultsTo10_WhenNotSetAnywhere()
+    {
+        using var client = CamundaClient.Create(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "http://localhost:8080/v2",
+                ["CAMUNDA_AUTH_STRATEGY"] = "NONE",
+            },
+        });
+
+        // Should not throw — MaxConcurrentJobs defaults to 10
+        var worker = client.CreateJobWorker(
+            new JobWorkerConfig
+            {
+                JobType = "test",
+                JobTimeoutMs = 30000,
+                AutoStart = false,
+            },
+            (job, ct) => Task.FromResult<object?>(null));
+
+        worker.Should().NotBeNull();
+
+    }
+
+    // ---- Helpers ----
+
+    private static CamundaClient CreateClientWithWorkerDefaults(
+        string? workerName = null)
+    {
+        var config = new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "http://localhost:8080/v2",
+            ["CAMUNDA_AUTH_STRATEGY"] = "NONE",
+            ["CAMUNDA_WORKER_TIMEOUT"] = "30000",
+            ["CAMUNDA_WORKER_MAX_CONCURRENT_JOBS"] = "4",
+        };
+        if (workerName != null)
+            config["CAMUNDA_WORKER_NAME"] = workerName;
+
+        return CamundaClient.Create(new CamundaOptions { Config = config });
+    }
+}


### PR DESCRIPTION
## Summary

Add support for global worker configuration defaults that apply to all workers created by a `CamundaClient` instance. Individual `JobWorkerConfig` values override these defaults.

Resolves the C# SDK equivalent of camunda/orchestration-cluster-api-python#25.

## Environment Variables

| Environment Variable | Config Property | Type |
|---|---|---|
| `CAMUNDA_WORKER_TIMEOUT` | `JobTimeoutMs` | long |
| `CAMUNDA_WORKER_MAX_CONCURRENT_JOBS` | `MaxConcurrentJobs` | int |
| `CAMUNDA_WORKER_REQUEST_TIMEOUT` | `PollTimeoutMs` | long |
| `CAMUNDA_WORKER_NAME` | `WorkerName` | string |
| `CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS` | `StartupJitterMaxSeconds` | int |

**Precedence:** explicit `JobWorkerConfig` value > environment variable > hardcoded default.

## Changes

- **`Runtime/CamundaConfig.cs`**: Added `WorkerDefaultsConfig` class and `WorkerDefaults?` property to `CamundaConfig`
- **`Runtime/ConfigurationHydrator.cs`**: Parse `CAMUNDA_WORKER_*` env vars, populate `WorkerDefaults`, added `Worker:*` entries to `ConfigKeyMap` for `appsettings.json` support
- **`Runtime/JobWorker.cs`**: Made `JobTimeoutMs` (`long?`) and `MaxConcurrentJobs` (`int?`) nullable on `JobWorkerConfig`, added validation with clear error messages in `JobWorker` constructor, uses resolved private fields in poll loop
- **`CamundaClient.Workers.cs`**: `CreateJobWorker` always merges defaults — `MaxConcurrentJobs` falls back to env var then `10`
- **`WorkerDefaultsTests.cs`**: 14 unit tests covering hydration, merge precedence, and validation
- **`README.md`**: Updated configuration table and added "Heritable Worker Defaults" section

## Testing

```bash
dotnet test --filter "FullyQualifiedName~Camunda.Orchestration.Sdk.Tests"
# 170 tests passed, 0 failed
```