### PR TITLE
fix: harden README code injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In the vast majority of use-cases, this will not be an issue; but you should be 
 
 Keep configuration out of application code. Let the factory read `CAMUNDA_*` variables from the environment (12-factor style). This makes rotation, secret management, and environment promotion safer and simpler.
 
-<!-- snippet:UsingDirective+QuickStart -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+QuickStart -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -88,7 +88,7 @@ CAMUNDA_DEFAULT_TENANT_ID=<default>            # optional: override default tena
 
 Use only when you must supply or mutate configuration dynamically (e.g. multi-tenant routing, tests, ephemeral preview environments). Keys mirror their `CAMUNDA_*` env names:
 
-<!-- snippet:UsingDirective+ProgrammaticOverrides -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+ProgrammaticOverrides -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -131,7 +131,7 @@ The SDK can read configuration from any `IConfiguration` source (appsettings.jso
 
 Pass the section to the client:
 
-<!-- snippet:UsingDirective+AppSettingsConfig -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+AppSettingsConfig -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -209,7 +209,7 @@ For ASP.NET Core and other DI-based applications, use the `AddCamundaClient()` e
 
 **Zero-config** (environment variables only):
 
-<!-- snippet:UsingDirective+DIZeroConfig -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+DIZeroConfig -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -219,7 +219,7 @@ builder.Services.AddCamundaClient();
 
 **With `appsettings.json`**:
 
-<!-- snippet:UsingDirective+DIAppSettings -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+DIAppSettings -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -229,7 +229,7 @@ builder.Services.AddCamundaClient(builder.Configuration.GetSection("Camunda"));
 
 **With options callback** (full control):
 
-<!-- snippet:UsingDirective+DIOptionsCallback -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+DIOptionsCallback -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -242,7 +242,7 @@ builder.Services.AddCamundaClient(options =>
 
 Inject the client anywhere via constructor injection:
 
-<!-- snippet:DIControllerInjection -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: DIControllerInjection -->
 ```csharp
 public class OrderController(CamundaClient camunda) : ControllerBase
 {
@@ -261,7 +261,7 @@ public class OrderController(CamundaClient camunda) : ControllerBase
 
 ### Custom HttpClient
 
-<!-- snippet:UsingDirective+CustomHttpClient -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+CustomHttpClient -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -388,7 +388,7 @@ The `LEGACY` profile disables adaptive gating entirely — signals are still tra
 
 #### Inspecting State Programmatically
 
-<!-- snippet:BackpressureState -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: BackpressureState -->
 ```csharp
 var state = client.GetBackpressureState();
 // state.Severity: "healthy", "soft", or "severe"
@@ -429,7 +429,7 @@ Output uses a tagged format matching the JS SDK:
 
 Pass an `ILoggerFactory` via `CamundaOptions` to integrate with your application's logging:
 
-<!-- snippet:UsingDirective+InjectLogger -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+InjectLogger -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -452,7 +452,7 @@ When an `ILoggerFactory` is provided, `CAMUNDA_SDK_LOG_LEVEL` is ignored — fil
 
 When using `AddCamundaClient()`, the SDK automatically resolves `ILoggerFactory` from the DI container — no manual wiring needed:
 
-<!-- snippet:UsingDirective+DILogging -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+DILogging -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -469,11 +469,8 @@ All SDK log entries appear alongside your application logs with proper category 
 
 ### Serilog Integration
 
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: SerilogIntegration -->
 ```csharp
-using Camunda.Orchestration.Sdk;
-using Serilog;
-using Serilog.Extensions.Logging;
-
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.Console()
@@ -506,7 +503,7 @@ using var client = CamundaClient.Create(new CamundaOptions
 
 All domain identifiers (process definition keys, job keys, user task keys, etc.) are `readonly record struct` types rather than plain strings. This prevents accidentally mixing different key types at compile time — the same pattern as the JS SDK's branded types.
 
-<!-- snippet:UsingDirective+DomainKeys -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+DomainKeys -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -533,7 +530,7 @@ Key types implement `ICamundaKey` (string-backed) or `ICamundaLongKey` (long-bac
 
 Deploy BPMN, DMN, or Form files from disk:
 
-<!-- snippet:UsingDirective+DeployResources -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+DeployResources -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -552,7 +549,7 @@ foreach (var process in result.Processes)
 
 The recommended pattern is to obtain keys from a prior API response (e.g. a deployment) and pass them directly — no manual conversion needed:
 
-<!-- snippet:UsingDirective+ReadmeCreateProcessInstance -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+ReadmeCreateProcessInstance -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -572,7 +569,7 @@ Console.WriteLine($"Process instance key: {result.ProcessInstanceKey}");
 
 If you need to restore a key from external storage (database, message queue, config file), wrap the raw value with the domain key constructor:
 
-<!-- snippet:UsingDirective+CreateProcessFromStorage -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+CreateProcessFromStorage -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -590,7 +587,7 @@ Console.WriteLine($"Process instance key: {result.ProcessInstanceKey}");
 
 You can also start a process instance by BPMN process ID (which uses the latest deployed version):
 
-<!-- snippet:CreateProcessById -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: CreateProcessById -->
 ```csharp
 var result = await client.CreateProcessInstanceAsync(
     new ProcessInstanceCreationInstructionById
@@ -607,7 +604,7 @@ Camunda API operations use dynamic `variables` and `customHeaders` payloads. By 
 
 Assign any DTO or dictionary to the `Variables` property — `System.Text.Json` serializes the runtime type automatically:
 
-<!-- snippet:UsingDirective+SendingVariables+SendingVariablesBody -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+SendingVariables+SendingVariablesBody -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -632,7 +629,7 @@ await client.CompleteJobAsync(jobKey, new JobCompletionRequest
 
 Use `DeserializeAs<T>()` to extract typed DTOs from API responses:
 
-<!-- snippet:UsingDirective+ReceivingVariables+ReceivingVariablesBody -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+ReceivingVariables+ReceivingVariablesBody -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -661,7 +658,7 @@ Job workers subscribe to a specific job type and process jobs as they become ava
 
 ### Basic Worker
 
-<!-- snippet:UsingDirective+BasicWorker+BasicWorkerBody -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+BasicWorker+BasicWorkerBody -->
 ```csharp
 using Camunda.Orchestration.Sdk;
 
@@ -704,7 +701,7 @@ The handler return value determines the job outcome:
 | Throw `JobFailureException` | Fail with custom retries / back-off |
 | Throw any other exception | Auto-fail with `retries - 1` |
 
-<!-- snippet:ErrorHandling+ErrorHandlingFailure -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: ErrorHandling+ErrorHandlingFailure -->
 ```csharp
 // BPMN error — caught by error boundary events in the process model
 throw new BpmnErrorException("INVALID_ORDER", "Order not found");
@@ -717,7 +714,7 @@ throw new JobFailureException("Service unavailable", retries: 2, retryBackOffMs:
 
 When handling jobs from [user task listeners](https://docs.camunda.io/docs/components/concepts/user-task-listeners/), you can return a `JobCompletionRequest` to apply corrections to the task or deny the action. Return a `JobCompletionRequest` from the handler instead of a plain variables object:
 
-<!-- snippet:JobCorrections -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: JobCorrections -->
 ```csharp
 client.CreateJobWorker(config, async (job, ct) =>
 {
@@ -740,7 +737,7 @@ client.CreateJobWorker(config, async (job, ct) =>
 
 To deny the user task action (e.g. reject a completion):
 
-<!-- snippet:JobCorrectionsDenied -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: JobCorrectionsDenied -->
 ```csharp
 client.CreateJobWorker(config, async (job, ct) =>
 {
@@ -759,7 +756,7 @@ client.CreateJobWorker(config, async (job, ct) =>
 
 For handlers that don't return output variables, use the void overload:
 
-<!-- snippet:VoidHandler+VoidHandlerBody -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: VoidHandler+VoidHandlerBody -->
 ```csharp
 public record NotificationInput(string Message);
 
@@ -804,7 +801,7 @@ export CAMUNDA_WORKER_MAX_CONCURRENT_JOBS=8
 export CAMUNDA_WORKER_NAME=order-service
 ```
 
-<!-- snippet:WorkerDefaultsEnv -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: WorkerDefaultsEnv -->
 ```csharp
 // Workers inherit timeout, concurrency, and name from environment
 client.CreateJobWorker(
@@ -823,7 +820,7 @@ client.CreateJobWorker(
 
 You can also pass defaults programmatically via the client constructor:
 
-<!-- snippet:WorkerDefaultsClient -->
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: WorkerDefaultsClient -->
 ```csharp
 var client = CamundaClient.Create(new CamundaOptions
 {
@@ -845,9 +842,10 @@ Jobs are dispatched as concurrent `Task`s on the .NET thread pool. `MaxConcurren
 
 ### Lifecycle
 
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: WorkerLifecycle -->
 ```csharp
 // Manual start/stop
-var worker = client.CreateJobWorker(config with { AutoStart = false }, handler);
+var worker = client.CreateJobWorker(new JobWorkerConfig { JobType = "example", JobTimeoutMs = 30_000, AutoStart = false }, handler);
 worker.Start();
 
 // Graceful stop — waits up to 10s for in-flight jobs to finish

--- a/docs/examples/Examples.csproj
+++ b/docs/examples/Examples.csproj
@@ -16,6 +16,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="../../examples/*.cs" Link="ApiExamples/%(Filename)%(Extension)" />
   </ItemGroup>
 

--- a/docs/examples/ReadmeExamples.cs
+++ b/docs/examples/ReadmeExamples.cs
@@ -15,6 +15,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace Camunda.Orchestration.Sdk.Examples;
 
@@ -441,5 +443,43 @@ internal static class ReadmeExamples
             },
         });
         // </WorkerDefaultsClient>
+    }
+
+    private static void SerilogIntegrationExample()
+    {
+        // <SerilogIntegration>
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Console()
+            .CreateLogger();
+
+        using var loggerFactory = new SerilogLoggerFactory();
+        using var client = CamundaClient.Create(new CamundaOptions
+        {
+            LoggerFactory = loggerFactory,
+        });
+        // </SerilogIntegration>
+    }
+
+    private static async Task WorkerLifecycleExample()
+    {
+        using var client = CamundaClient.Create();
+        Func<ActivatedJob, CancellationToken, Task<object?>> handler = (_, _) => Task.FromResult<object?>(null);
+
+        // <WorkerLifecycle>
+        // Manual start/stop
+        var worker = client.CreateJobWorker(new JobWorkerConfig { JobType = "example", JobTimeoutMs = 30_000, AutoStart = false }, handler);
+        worker.Start();
+
+        // Graceful stop — waits up to 10s for in-flight jobs to finish
+        var result = await worker.StopAsync(gracePeriod: TimeSpan.FromSeconds(10));
+        // result.RemainingJobs, result.TimedOut
+
+        // Or stop all workers at once
+        await client.StopAllWorkersAsync(TimeSpan.FromSeconds(10));
+
+        // DisposeAsync stops workers automatically
+        await using var disposableClient = CamundaClient.Create();
+        // </WorkerLifecycle>
     }
 }

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -33,10 +33,10 @@ echo ""
 echo "--- Step 5: Build examples ---"
 dotnet build docs/examples/Examples.csproj --configuration Release
 
-# Step 6: Sync README snippets
+# Step 6: Check README snippet sync (does not modify README)
 echo ""
-echo "--- Step 6: Sync README snippets ---"
-python3 scripts/sync-readme-snippets.py
+echo "--- Step 6: Check README snippet sync ---"
+python3 scripts/sync-readme-snippets.py --check
 
 # Step 7: Lint check (verify formatting matches .editorconfig)
 echo ""

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,10 +43,10 @@ echo ""
 echo "--- Step 6: Lint check ---"
 dotnet format --verify-no-changes
 
-# Step 7: Sync README snippets
+# Step 7: Check README snippets are in sync (no auto-sync)
 echo ""
-echo "--- Step 7: Sync README snippets ---"
-python3 scripts/sync-readme-snippets.py
+echo "--- Step 7: Check README snippets are in sync ---"
+python3 scripts/sync-readme-snippets.py --check
 
 # Step 8: Unit tests (acceptance gate — integration tests are separate)
 echo ""

--- a/scripts/sync-readme-snippets.py
+++ b/scripts/sync-readme-snippets.py
@@ -2,20 +2,23 @@
 """
 Synchronize code snippets in README.md from compilable example files.
 
-Replaces code blocks between ``<!-- snippet:RegionName -->`` markers in
-README.md with the corresponding region-tagged code from docs/examples/*.cs.
+Replaces code blocks between snippet markers in README.md with the
+corresponding region-tagged code from docs/examples/*.cs.
 
 Usage:
     python3 scripts/sync-readme-snippets.py          # update README.md in-place
     python3 scripts/sync-readme-snippets.py --check   # CI mode: exit 1 if out of sync
 
 Region tags in .cs files use ``// <RegionName>`` ... ``// </RegionName>``.
-Markers in README.md use ``<!-- snippet:RegionName -->`` before a fenced
-code block, which ends at the next ````` `` ``` ``````.  The script replaces
-everything between the marker and the closing fence (inclusive of both
-fences) with freshly extracted content.
+Markers in README.md use the descriptive format::
 
-Composite regions: ``<!-- snippet:A+B+C -->`` concatenates multiple regions
+    <!-- snippet-source: docs/examples/File.cs | regions: RegionName -->
+
+before a fenced code block.  The script replaces everything between the
+marker and the closing fence (inclusive of both fences) with freshly
+extracted content.
+
+Composite regions: ``regions: A+B+C`` concatenates multiple regions
 separated by blank lines.
 """
 
@@ -58,20 +61,52 @@ def parse_region_tags(cs_path: Path) -> dict[str, str]:
     return regions
 
 
-def load_all_regions() -> dict[str, str]:
-    """Load regions from all .cs files under docs/examples/."""
+def load_all_regions() -> tuple[dict[str, str], dict[str, str]]:
+    """Load regions from all .cs files under docs/examples/.
+
+    Returns (region_content, region_source) where region_source maps
+    region name → relative source file path.
+    """
     all_regions: dict[str, str] = {}
+    region_source: dict[str, str] = {}
     for cs_file in sorted(EXAMPLES_DIR.glob("*.cs")):
-        all_regions.update(parse_region_tags(cs_file))
-    return all_regions
+        rel = cs_file.relative_to(REPO_ROOT).as_posix()
+        for name, content in parse_region_tags(cs_file).items():
+            all_regions[name] = content
+            region_source[name] = rel
+    return all_regions, region_source
 
 
 # ---------------------------------------------------------------------------
 # README rewriting
 # ---------------------------------------------------------------------------
 
-# Matches: <!-- snippet:RegionName --> or <!-- snippet:Region1+Region2 -->
-SNIPPET_MARKER = re.compile(r"^<!--\s*snippet:([\w+]+)\s*-->$")
+# New descriptive format:
+#   <!-- snippet-source: docs/examples/File.cs | regions: RegionName -->
+_NEW_MARKER = re.compile(
+    r"^<!--\s*snippet-source:\s*\S+\s*\|\s*regions:\s*([\w+]+)\s*-->$"
+)
+# Legacy format (for migration):
+#   <!-- snippet:RegionName -->
+_OLD_MARKER = re.compile(r"^<!--\s*snippet:([\w+]+)\s*-->$")
+
+
+def _match_marker(line: str) -> re.Match[str] | None:
+    """Match either new or legacy snippet marker."""
+    return _NEW_MARKER.match(line) or _OLD_MARKER.match(line)
+
+
+def _build_marker(region_name: str, region_source: dict[str, str]) -> str:
+    """Build a descriptive snippet marker line for *region_name*."""
+    parts = region_name.split("+") if "+" in region_name else [region_name]
+    sources = {region_source.get(p) for p in parts if region_source.get(p) is not None}
+    if not sources:
+        source_file = "docs/examples/?.cs"
+    elif len(sources) == 1:
+        source_file = next(iter(sources))
+    else:
+        source_file = ",".join(sorted(sources))
+    return f"<!-- snippet-source: {source_file} | regions: {region_name} -->"
 
 
 def resolve_region(name: str, regions: dict[str, str]) -> str | None:
@@ -85,8 +120,16 @@ def resolve_region(name: str, regions: dict[str, str]) -> str | None:
     return "\n\n".join(r for r in resolved if r)
 
 
-def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
+def sync_readme(
+    regions: dict[str, str],
+    region_source: dict[str, str],
+    *,
+    check: bool = False,
+) -> bool:
     """Replace snippet-marked code blocks in README.md.
+
+    Also upgrades legacy ``<!-- snippet:X -->`` markers to the new
+    ``<!-- snippet-source: file | regions: X -->`` format.
 
     Returns True if the file was (or would be) changed.
     """
@@ -98,10 +141,11 @@ def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
     changed = False
     missing: list[str] = []
     errors: list[str] = []
+    snippet_count = 0
 
     while i < len(lines):
         line = lines[i].rstrip("\n")
-        m = SNIPPET_MARKER.match(line.strip())
+        m = _match_marker(line.strip())
 
         if not m:
             out.append(lines[i])
@@ -117,8 +161,13 @@ def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
             i += 1
             continue
 
-        # Keep the marker line
-        out.append(lines[i])
+        snippet_count += 1
+
+        # Upgrade legacy marker to the new descriptive format
+        new_marker = _build_marker(region_name, region_source) + "\n"
+        if lines[i] != new_marker:
+            changed = True
+        out.append(new_marker)
         i += 1
 
         # Skip whitespace between marker and opening fence
@@ -174,19 +223,79 @@ def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
 
     if changed:
         README_PATH.write_text(new_text, encoding="utf-8", newline="")
-        print(f"README.md updated ({sum(1 for l in out if SNIPPET_MARKER.match(l.strip()))} snippets synced)")
+        print(f"README.md updated ({snippet_count} snippets synced)")
     else:
         print("README.md is already up to date")
 
     return changed
 
 
+# ---------------------------------------------------------------------------
+# Un-injected code block detection
+# ---------------------------------------------------------------------------
+
+# Languages that should always be snippet-injected (functional code samples)
+_CHECKED_LANGUAGES = {"csharp", "c#", "cs"}
+
+
+def detect_uninjected_code_blocks(readme_path: Path) -> list[tuple[int, str]]:
+    """Find fenced code blocks in *readme_path* that use a checked language
+    but are NOT preceded by a snippet marker.
+
+    Returns a list of ``(line_number, fence_line)`` tuples (1-based).
+    """
+    text = readme_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    uninjected: list[tuple[int, str]] = []
+
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("```"):
+            continue
+        # Extract language from opening fence (e.g. ```csharp)
+        lang = stripped.removeprefix("```").strip().lower()
+        if lang not in _CHECKED_LANGUAGES:
+            continue
+        # Look backward for a snippet marker or exempt marker (skip blank lines)
+        prev = idx - 1
+        while prev >= 0 and lines[prev].strip() == "":
+            prev -= 1
+        if prev >= 0:
+            prev_stripped = lines[prev].strip()
+            if _match_marker(prev_stripped):
+                continue
+            if re.match(r"^<!--\s*snippet-exempt:.*-->$", prev_stripped):
+                continue
+        uninjected.append((idx + 1, stripped))
+
+    return uninjected
+
+
 def main() -> None:
     check = "--check" in sys.argv
-    regions = load_all_regions()
+    regions, region_source = load_all_regions()
     print(f"Loaded {len(regions)} regions from docs/examples/*.cs")
 
-    changed = sync_readme(regions, check=check)
+    changed = sync_readme(regions, region_source, check=check)
+
+    # Detect un-injected C# code blocks
+    uninjected = detect_uninjected_code_blocks(README_PATH)
+    if uninjected:
+        print(
+            f"\nWARNING: {len(uninjected)} C# code block(s) in README.md are NOT "
+            "snippet-injected (not type-checked):",
+            file=sys.stderr,
+        )
+        for lineno, fence in uninjected:
+            print(f"  line {lineno}: {fence}", file=sys.stderr)
+        if check:
+            print(
+                "\nAll C# code blocks must be injected from compilable examples in "
+                "docs/examples/. Add a snippet marker above each block, or move the "
+                "code to docs/examples/ with region tags.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     if check and changed:
         sys.exit(1)


### PR DESCRIPTION
## Summary

Hardens the README snippet injection pipeline to address all three points from #36:

### 1. Descriptive snippet markers

Snippet markers now include the source file and region name(s), making it clear to both human editors and AI assistants that code blocks are injected:

```html
<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+QuickStart -->
```

Legacy `<!-- snippet:RegionName -->` markers are automatically migrated on sync.

### 2. Build-time drift detection

Both `build.sh` and `build-local.sh` now run the sync script in `--check` mode. If a README code block has been directly edited and no longer matches its source snippet, the build fails with a clear diff.

### 3. Un-injected code block detection

The sync script now scans for C# code blocks that lack a snippet marker. On `--check`, any un-injected blocks cause a build failure — ensuring all code examples are type-checked via the compilable examples project.

Blocks that intentionally can't be type-checked (e.g. pseudo-code, external dependencies) can be marked with `<!-- snippet-exempt: reason -->`.

### Changes

- **`scripts/sync-readme-snippets.py`** — Rewritten with descriptive marker format, legacy migration, un-injected block detection, and exempt marker support
- **`README.md`** — All 27 markers upgraded to descriptive format, 0 un-injected C# blocks remaining
- **`docs/examples/ReadmeExamples.cs`** — Added `SerilogIntegration` and `WorkerLifecycle` regions (previously un-injected)
- **`docs/examples/Examples.csproj`** — Added Serilog package references for type-checking
- **`scripts/build.sh`** + **`scripts/build-local.sh`** — Sync step changed to `--check` mode

Closes #36