### PR TITLE
fix: make build warnings fatal, suppress known example warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,9 +5,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
 
-    <!-- Treat all analyzer warnings as warnings (not errors) during build.
-         CI will gate separately via dotnet format with verify-no-changes. -->
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <!-- Make all warnings fatal so builds fail on any warning (local + CI). -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/docs/examples/Examples.csproj
+++ b/docs/examples/Examples.csproj
@@ -9,6 +9,8 @@
     <OutputType>Library</OutputType>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
     <RootNamespace>Camunda.Orchestration.Sdk.Examples</RootNamespace>
+    <!-- Suppress analyser rules that aren't meaningful for compile-only example code -->
+    <NoWarn>CA1050;CA1305</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Makes all C# build warnings fatal so that any new warning breaks the build (locally and in CI).

## Changes

- **`Directory.Build.props`**: set `TreatWarningsAsErrors` to `true` (applies to all projects)
- **`docs/examples/Examples.csproj`**: add `<NoWarn>CA1050;CA1305</NoWarn>` to suppress the two known warnings that only apply to compile-only example code

## Why suppress CA1050 and CA1305 for examples?

- **CA1050** ("Declare types in namespaces"): example files are intentionally namespace-free to keep README snippets clean
- **CA1305** ("Provide IFormatProvider"): triggered by Serilog `.WriteTo.Console()` where a format provider is not applicable

These are compile-only type-check files, never shipped as library code.

## Verification

- `bash scripts/build-local.sh` passes with **0 warnings**, 172/172 tests green
- Any future warning in any project will now fail the build

Closes #49