### PR TITLE
fix: sort required query params before optional in generator

### DIFF
--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -7185,7 +7185,7 @@
         ],
         "operationId": "getGlobalJobStatistics",
         "summary": "Global job statistics",
-        "description": "Returns global aggregated counts for jobs. Optionally filter by the creation time window and/or jobType.\n",
+        "description": "Returns global aggregated counts for jobs. Filter by the creation time window (required) and optionally by jobType.\n",
         "parameters": [
           {
             "name": "from",

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -90,6 +90,7 @@ internal static class CSharpClientGenerator
                     .ToList();
                 var queryParams = op.Parameters
                     .Where(p => p.In == ParameterLocation.Query)
+                    .OrderByDescending(p => p.Required)
                     .Select(p => new ParamMeta(p.Name, MapType(p.Schema), p.Required))
                     .ToList();
 

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -1894,7 +1894,7 @@ public partial class CamundaClient
 
     /// <summary>
     /// Global job statistics
-    /// Returns global aggregated counts for jobs. Optionally filter by the creation time window and/or jobType.
+    /// Returns global aggregated counts for jobs. Filter by the creation time window (required) and optionally by jobType.
     /// 
     /// </summary>
     /// <remarks>Operation: getGlobalJobStatistics</remarks>

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:ce28935d7c5d940ac3249eca6c65a20aaa50286c20c365ad00deb315534d2a16";
+    public const string SpecHash = "sha256:5de81e6b2d3f152265e6f6f042a776f0bc2ca73572e9f5a8c54eee460f5c6161";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/ParameterOrderingTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ParameterOrderingTests.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Regression test: generated methods must not have optional parameters
+/// before required ones (CS1737). This validates the entire CamundaClient
+/// surface, not a single method — catching any future spec ordering issues.
+/// </summary>
+public class ParameterOrderingTests
+{
+    [Fact]
+    public void AllPublicMethods_HaveRequiredParamsBeforeOptional()
+    {
+        var methods = typeof(CamundaClient)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName); // exclude property getters/setters
+
+        var violations = new List<string>();
+
+        foreach (var method in methods)
+        {
+            var parameters = method.GetParameters();
+            var seenOptional = false;
+
+            foreach (var param in parameters)
+            {
+                if (param.HasDefaultValue || param.IsOptional)
+                {
+                    seenOptional = true;
+                }
+                else if (seenOptional)
+                {
+                    violations.Add(
+                        $"{method.Name}: required parameter '{param.Name}' appears after optional parameter");
+                    break;
+                }
+            }
+        }
+
+        Assert.Empty(violations);
+    }
+}


### PR DESCRIPTION
Fixes #62

## Problem

The generator emitted query parameters in OpenAPI spec order. When an optional parameter appeared before a required one in the spec, the generated C# method signature was invalid:

```csharp
// Before (invalid C#):
public async Task<DocumentLink> CreateDocumentLinkAsync(
    DocumentId documentId, DocumentLinkRequest body,
    string? storeId = null, string contentHash, ...)  // CS1737
```

This surfaced with `SPEC_REF=stable/8.8` where `storeId` (optional) appeared before `contentHash` (required) in the `getDocument` and `createDocumentLink` operations.

On `stable/8.9` the bug was latent because `contentHash` was relaxed to optional.

## Fix

Add `.OrderByDescending(p => p.Required)` when building the query parameter list in the generator, so required parameters always precede optional ones:

```csharp
// After (valid C#):
public async Task<DocumentLink> CreateDocumentLinkAsync(
    DocumentId documentId, DocumentLinkRequest body,
    string contentHash, string? storeId = null, ...)
```

**One-line change** in `CSharpClientGenerator.cs`.

## Regression test

Added `ParameterOrderingTests.cs` — uses reflection to check **every** public method on `CamundaClient` for correct required-before-optional ordering. This catches the class of defect, not just the two specific methods.

## Verified

- `SPEC_REF=stable/8.8 bash scripts/build.sh` — SDK compiles (CS1737 resolved)
- `bash scripts/build.sh` — full green build on main spec (0 warnings, 0 errors, all tests pass)