### PR TITLE
fix(generator): sanitize spec-controlled strings against Unicode injection (#116)

### DIFF
--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -50,12 +50,16 @@ internal static class CSharpClientGenerator
 
         // Generate models (component schemas + inline schemas)
         var modelsCode = GenerateModels(doc, metadata, inlineSchemas, requestSchemaNames);
-        File.WriteAllText(Path.Combine(outputDir, "Models.Generated.cs"), modelsCode);
+        var modelsPath = Path.Combine(outputDir, "Models.Generated.cs");
+        SafeEmit.ScanGeneratedSource(modelsPath, modelsCode);
+        File.WriteAllText(modelsPath, modelsCode);
         Console.WriteLine($"[generator] Generated Models.Generated.cs ({doc.Components?.Schemas?.Count ?? 0} component schemas, {inlineSchemas.Count} inline schemas)");
 
         // Generate client methods
         var clientCode = GenerateClientMethods(operations, operationExamples);
-        File.WriteAllText(Path.Combine(outputDir, "CamundaClient.Generated.cs"), clientCode);
+        var clientPath = Path.Combine(outputDir, "CamundaClient.Generated.cs");
+        SafeEmit.ScanGeneratedSource(clientPath, clientCode);
+        File.WriteAllText(clientPath, clientCode);
         Console.WriteLine($"[generator] Generated CamundaClient.Generated.cs ({operations.Count} operations)");
 
         // Generate spec hash constant — fail fast if missing or invalid
@@ -67,7 +71,9 @@ internal static class CSharpClientGenerator
         }
 
         var specHashCode = GenerateSpecHash(metadata.SpecHash);
-        File.WriteAllText(Path.Combine(outputDir, "SpecHash.Generated.cs"), specHashCode);
+        var specHashPath = Path.Combine(outputDir, "SpecHash.Generated.cs");
+        SafeEmit.ScanGeneratedSource(specHashPath, specHashCode);
+        File.WriteAllText(specHashPath, specHashCode);
         Console.WriteLine($"[generator] Generated SpecHash.Generated.cs (specHash: {metadata.SpecHash})");
     }
 
@@ -501,7 +507,7 @@ internal static class CSharpClientGenerator
                     {
                         sb.AppendLine($"    [Obsolete(\"Deprecated since {deprecatedVersion}\")]");
                     }
-                    sb.AppendLine($"    [JsonPropertyName(\"{e.Value}\")]");
+                    sb.AppendLine($"    [JsonPropertyName(\"{SafeEmit.SafeCSharpStringLiteral(e.Value)}\")]");
                     sb.AppendLine($"    {enumName},");
                 }
                 sb.AppendLine("}");
@@ -525,7 +531,7 @@ internal static class CSharpClientGenerator
                 foreach (var variant in variants)
                     sb.AppendLine($"/// <seealso cref=\"{variant}\"/>");
                 if (discriminators.TryGetValue(typeName, out var disc))
-                    sb.AppendLine($"[JsonPolymorphic(TypeDiscriminatorPropertyName = \"{disc.PropertyName}\")]");
+                    sb.AppendLine($"[JsonPolymorphic(TypeDiscriminatorPropertyName = \"{SafeEmit.SafeCSharpStringLiteral(disc.PropertyName)}\")]");
                 foreach (var variant in variants)
                 {
                     if (disc.ValueToVariant != null)
@@ -533,7 +539,7 @@ internal static class CSharpClientGenerator
                         var matchingEntry = disc.ValueToVariant.FirstOrDefault(kv => kv.Value == variant);
                         if (matchingEntry.Key != null)
                         {
-                            sb.AppendLine($"[JsonDerivedType(typeof({variant}), \"{matchingEntry.Key}\")]");
+                            sb.AppendLine($"[JsonDerivedType(typeof({variant}), \"{SafeEmit.SafeCSharpStringLiteral(matchingEntry.Key)}\")]");
                             continue;
                         }
                     }
@@ -600,7 +606,7 @@ internal static class CSharpClientGenerator
                             sb.AppendLine($"    /// </summary>");
                         }
 
-                        sb.AppendLine($"    [JsonPropertyName(\"{propName}\")]");
+                        sb.AppendLine($"    [JsonPropertyName(\"{SafeEmit.SafeCSharpStringLiteral(propName)}\")]");
                         var initializer = IsReferenceType(csharpType, doc) ? " = null!;" : "";
                         sb.AppendLine($"    public {csharpType} {csharpPropName} {{ get; set; }}{initializer}");
                         sb.AppendLine();
@@ -676,7 +682,7 @@ internal static class CSharpClientGenerator
                     sb.AppendLine($"    /// </summary>");
                 }
 
-                sb.AppendLine($"    [JsonPropertyName(\"{propName}\")]");
+                sb.AppendLine($"    [JsonPropertyName(\"{SafeEmit.SafeCSharpStringLiteral(propName)}\")]");
                 var initializer = IsReferenceType(csharpType, doc) ? " = null!;" : "";
                 sb.AppendLine($"    public {csharpType} {csharpPropName} {{ get; set; }}{initializer}");
                 sb.AppendLine();
@@ -747,7 +753,7 @@ internal static class CSharpClientGenerator
                 sb.AppendLine($"    /// </summary>");
             }
 
-            sb.AppendLine($"    [JsonPropertyName(\"{propName}\")]");
+            sb.AppendLine($"    [JsonPropertyName(\"{SafeEmit.SafeCSharpStringLiteral(propName)}\")]");
             var initializer = IsReferenceType(csharpType, doc) ? " = null!;" : "";
             sb.AppendLine($"    public {csharpType} {csharpPropName} {{ get; set; }}{initializer}");
             sb.AppendLine();
@@ -1002,7 +1008,7 @@ internal static class CSharpClientGenerator
         if (operationExamples.TryGetValue(op.OriginalOperationId, out var examples))
         {
             sb.AppendLine($"    /// <remarks>");
-            sb.AppendLine($"    /// Operation: {op.OriginalOperationId}");
+            sb.AppendLine($"    /// Operation: {SafeEmit.SafeXmlDocText(op.OriginalOperationId)}");
             for (var i = 0; i < examples.Count; i++)
             {
                 var exampleCode = examples[i];
@@ -1012,7 +1018,7 @@ internal static class CSharpClientGenerator
                 foreach (var line in exampleCode.Split('\n'))
                 {
                     var trimmed = line.TrimEnd('\r');
-                    sb.AppendLine($"    /// {System.Security.SecurityElement.Escape(trimmed)}");
+                    sb.AppendLine($"    /// {SafeEmit.SafeXmlDocText(trimmed)}");
                 }
                 sb.AppendLine($"    /// </code>");
             }
@@ -1028,7 +1034,7 @@ internal static class CSharpClientGenerator
                 foreach (var line in exampleCode.Split('\n'))
                 {
                     var trimmed = line.TrimEnd('\r');
-                    sb.AppendLine($"    /// {System.Security.SecurityElement.Escape(trimmed)}");
+                    sb.AppendLine($"    /// {SafeEmit.SafeXmlDocText(trimmed)}");
                 }
                 sb.AppendLine($"    /// </code>");
                 sb.AppendLine($"    /// </example>");
@@ -1036,7 +1042,7 @@ internal static class CSharpClientGenerator
         }
         else
         {
-            sb.AppendLine($"    /// <remarks>Operation: {op.OriginalOperationId}</remarks>");
+            sb.AppendLine($"    /// <remarks>Operation: {SafeEmit.SafeXmlDocText(op.OriginalOperationId)}</remarks>");
         }
 
         // Build parameters
@@ -1349,12 +1355,15 @@ internal static class CSharpClientGenerator
     {
         // Handle names like "ProcessInstance" → "ProcessInstance"
         // Handle names with special chars
-        return name
+        var stripped = name
             .Replace("XML", "Xml")
             .Replace("-", "")
             .Replace(".", "")
             .Replace("$", "")
             .Replace(" ", "");
+        // Final safety net: even if a future spec name slips a character past
+        // the strip set, SafeCSharpIdentifier guarantees a valid C# identifier.
+        return SafeEmit.SafeCSharpIdentifier(stripped);
     }
 
     /// <summary>
@@ -1411,10 +1420,19 @@ internal static class CSharpClientGenerator
     internal static string SanitizeOperationId(string id)
     {
         var result = ToPascalCase(id.Replace("XML", "Xml"));
-        return result;
+        return SafeEmit.SafeCSharpIdentifier(result);
     }
 
     internal static string ToPascalCase(string s)
+    {
+        var pascal = ToPascalCaseRaw(s);
+        // Final safety net: ensure the result is a valid C# identifier even
+        // if the input contained Unicode characters outside the ECMA-334
+        // identifier classes (homoglyphs, bidi controls, etc.).
+        return SafeEmit.SafeCSharpIdentifier(pascal);
+    }
+
+    private static string ToPascalCaseRaw(string s)
     {
         if (string.IsNullOrEmpty(s))
             return s;
@@ -1444,20 +1462,22 @@ internal static class CSharpClientGenerator
         return char.ToLowerInvariant(pascal[0]) + pascal[1..];
     }
 
-    private static string EscapeXml(string s) =>
-        s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
-
     /// <summary>
     /// Formats a potentially multi-line string as XML doc comment lines,
-    /// each prefixed with the given indent + "/// ".
+    /// each prefixed with the given indent + "/// ". Each line is independently
+    /// run through <see cref="SafeEmit.SafeXmlDocText"/> so the per-line output
+    /// can never contain a Unicode line-terminator that would close the
+    /// surrounding `///` comment.
     /// </summary>
     private static void AppendXmlDocLines(StringBuilder sb, string text, string indent = "    ")
     {
-        var escaped = EscapeXml(text);
-        foreach (var line in escaped.Split('\n'))
+        // Split on physical newlines FIRST so each comment line is preserved.
+        // Per-line escape strips XML metacharacters and Unicode line-terminators
+        // (which would otherwise terminate the `///` comment per ECMA-334).
+        foreach (var line in text.Split('\n'))
         {
             var trimmed = line.TrimEnd('\r');
-            sb.AppendLine($"{indent}/// {trimmed}");
+            sb.AppendLine($"{indent}/// {SafeEmit.SafeXmlDocText(trimmed)}");
         }
     }
 

--- a/src/Camunda.Orchestration.Sdk.Generator/Camunda.Orchestration.Sdk.Generator.csproj
+++ b/src/Camunda.Orchestration.Sdk.Generator/Camunda.Orchestration.Sdk.Generator.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Camunda.Orchestration.Sdk.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Camunda.Orchestration.Sdk.Generator/SafeEmit.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/SafeEmit.cs
@@ -1,0 +1,338 @@
+using System.Globalization;
+using System.Text;
+
+namespace Camunda.Orchestration.Sdk.Generator;
+
+/// <summary>
+/// Spec-content-safe emission helpers.
+///
+/// Every spec-derived string that lands in a generated <c>.cs</c> file MUST flow
+/// through one of the helpers in this class:
+///
+/// <list type="bullet">
+///   <item><description><see cref="SafeXmlDocText"/> — text inside <c>///</c> XML
+///   doc comments. Escapes XML metacharacters AND replaces Unicode characters
+///   that the C# lexer treats as line-terminators (U+2028, U+2029, U+0085) or
+///   that are invisible/bidi (zero-width, override). Without this, a description
+///   string can terminate the doc comment mid-line and inject executable
+///   C# source on the next line.</description></item>
+///   <item><description><see cref="SafeCSharpIdentifier"/> — bare C# identifiers
+///   (type, member, parameter names). Normalizes to NFKC, restricts to the
+///   character categories permitted by ECMA-334 §6.4.2, prefixes <c>@</c> for
+///   reserved keywords, and rejects zero-width / bidi characters that produce
+///   visually-distinct-but-textually-identical "Trojan Source" identifiers
+///   (CVE-2021-42574).</description></item>
+///   <item><description><see cref="SafeCSharpStringLiteral"/> — content of a
+///   regular <c>"..."</c> string literal (e.g. a <c>JsonPropertyName</c>
+///   attribute argument). Escapes <c>\</c>, <c>"</c>, and any Unicode
+///   line-terminator that would otherwise break a regular string literal.
+///   </description></item>
+/// </list>
+///
+/// <see cref="ScanGeneratedSource"/> is the post-emit fail-fast backstop: any
+/// generated <c>.cs</c> file containing forbidden code points anywhere is
+/// rejected with the file path and offending offset, so a missed call site
+/// becomes a loud build failure rather than a silent injection.
+/// </summary>
+internal static class SafeEmit
+{
+    // Code points that the C# lexical specification (ECMA-334 §6.3.3) treats as
+    // new-line characters. Inside a `///` single-line comment, ANY of these
+    // terminates the comment and starts a new C# logical line. Inside a regular
+    // string literal `"..."` they are also forbidden and would break compilation.
+    //
+    // The HTML/XML decoded form of these is what's dangerous; emitting them as
+    // numeric character references (`&#xNNNN;`) in a comment is safe because the
+    // C# lexer never decodes XML entities.
+    private static readonly char[] LineTerminators =
+    [
+        '\u2028', // LINE SEPARATOR
+        '\u2029', // PARAGRAPH SEPARATOR
+        '\u0085', // NEXT LINE
+    ];
+
+    // Invisible / bidi-control characters. Required to defend against the
+    // "Trojan Source" class of attack (CVE-2021-42574): two strings that look
+    // identical but compile to distinct identifiers (e.g. shadowing).
+    // U+FEFF is also rejected to avoid stray BOMs.
+    private static bool IsInvisibleOrBidi(int cp) =>
+        cp is (>= 0x200B and <= 0x200F) // ZWSP, ZWNJ, ZWJ, LRM, RLM
+            or (>= 0x202A and <= 0x202E) // LRE, RLE, PDF, LRO, RLO
+            or (>= 0x2060 and <= 0x2064) // WJ, function application, invisible times/separator/plus
+            or 0xFEFF;                   // ZWNBSP / BOM
+
+    /// <summary>
+    /// Sanitize a spec-derived string for emission inside an XML doc comment
+    /// (<c>///</c> line). XML-escapes the five XML metacharacters AND replaces:
+    /// <list type="bullet">
+    ///   <item><description>Unicode line terminators
+    ///   (U+2028, U+2029, U+0085) — these would terminate the
+    ///   <c>///</c> comment per ECMA-334 §6.3.3 and place trailing payload on
+    ///   the next physical line as executable source.</description></item>
+    ///   <item><description>Bare CR / LF — already split off by callers but
+    ///   normalized here as defense in depth.</description></item>
+    ///   <item><description>Other C0 / C1 control characters except TAB
+    ///   (XML 1.0 forbids most of these in text content anyway).</description></item>
+    ///   <item><description>Invisible / bidi-control characters (zero-width
+    ///   space, RTL override, etc.) — these are visually invisible and could
+    ///   silently alter how the comment renders in tooling.</description></item>
+    /// </list>
+    /// Forbidden code points are replaced with the numeric character reference
+    /// <c>&amp;#xNNNN;</c> so the information survives in the comment but cannot
+    /// be interpreted as a line terminator by the C# lexer.
+    /// </summary>
+    public static string SafeXmlDocText(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+            return string.Empty;
+
+        var sb = new StringBuilder(raw.Length);
+        for (var i = 0; i < raw.Length; i++)
+        {
+            var c = raw[i];
+            switch (c)
+            {
+                case '&':
+                    sb.Append("&amp;");
+                    continue;
+                case '<':
+                    sb.Append("&lt;");
+                    continue;
+                case '>':
+                    sb.Append("&gt;");
+                    continue;
+                case '"':
+                    sb.Append("&quot;");
+                    continue;
+                case '\'':
+                    sb.Append("&apos;");
+                    continue;
+                case '\t':
+                    sb.Append(c);
+                    continue;
+                case '\r':
+                case '\n':
+                    // Caller is expected to split on newlines; if any survived,
+                    // collapse them to a space so they cannot terminate the
+                    // `///` line.
+                    sb.Append(' ');
+                    continue;
+            }
+
+            if (Array.IndexOf(LineTerminators, c) >= 0)
+            {
+                sb.Append(string.Format(CultureInfo.InvariantCulture, "&#x{0:X4};", (int)c));
+                continue;
+            }
+
+            // C0 (0x00–0x1F) and C1 (0x7F–0x9F) controls except TAB (handled above).
+            if (c < 0x20 || (c >= 0x7F && c <= 0x9F))
+            {
+                sb.Append(string.Format(CultureInfo.InvariantCulture, "&#x{0:X4};", (int)c));
+                continue;
+            }
+
+            if (IsInvisibleOrBidi(c))
+            {
+                sb.Append(string.Format(CultureInfo.InvariantCulture, "&#x{0:X4};", (int)c));
+                continue;
+            }
+
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Convert an arbitrary spec-derived string into a guaranteed-valid C#
+    /// identifier per ECMA-334 §6.4.2.
+    ///
+    /// Steps:
+    /// <list type="number">
+    ///   <item><description>NFKC-normalize to collapse compatibility / many
+    ///   homoglyph forms.</description></item>
+    ///   <item><description>Reject invisible / bidi-control characters
+    ///   outright (Trojan-Source defense).</description></item>
+    ///   <item><description>Replace any character outside the identifier-char
+    ///   classes with <c>_</c>.</description></item>
+    ///   <item><description>Prefix <c>_</c> if the first character is not a
+    ///   valid identifier-start.</description></item>
+    ///   <item><description>If the result is a C# reserved keyword, prefix
+    ///   <c>@</c> to use the verbatim-identifier form.</description></item>
+    ///   <item><description>If the input collapses to empty, return
+    ///   <c>_</c>.</description></item>
+    /// </list>
+    /// </summary>
+    public static string SafeCSharpIdentifier(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+            return "_";
+
+        // Reject invisible / bidi controls before normalization — NFKC may
+        // legitimately collapse some compatibility characters to ASCII, which
+        // would mask a Trojan-Source attempt.
+        var preNorm = new StringBuilder(raw.Length);
+        for (var i = 0; i < raw.Length; i++)
+        {
+            if (IsInvisibleOrBidi(raw[i]))
+                continue; // strip
+            preNorm.Append(raw[i]);
+        }
+
+        var normalized = preNorm.ToString().Normalize(NormalizationForm.FormKC);
+        if (normalized.Length == 0)
+            return "_";
+
+        var sb = new StringBuilder(normalized.Length);
+        for (var i = 0; i < normalized.Length; i++)
+        {
+            var c = normalized[i];
+            // Treat position 0 specially: an identifier-start position must reject
+            // even valid identifier-continue chars (e.g. digits) by replacing
+            // with '_'. This guarantees the first character of the result is
+            // always identifier-start-valid.
+            var isStart = sb.Length == 0;
+            if (IsValidIdentifierChar(c, isStart))
+            {
+                sb.Append(c);
+            }
+            else if (isStart && IsValidIdentifierChar(c, isStart: false))
+            {
+                // The char is valid in continue position but not start position
+                // (a digit). Prefix '_' and keep the digit.
+                sb.Append('_');
+                sb.Append(c);
+            }
+            else
+            {
+                sb.Append('_');
+            }
+        }
+
+        var ident = sb.ToString();
+
+        if (CSharpReservedKeywords.Contains(ident))
+            ident = "@" + ident;
+
+        return ident;
+    }
+
+    /// <summary>
+    /// Escape a string for safe inclusion inside a regular C# string literal
+    /// (<c>"..."</c>). Escapes <c>\</c>, <c>"</c>, control characters, and
+    /// any Unicode line-terminator (which a regular string literal forbids).
+    /// </summary>
+    public static string SafeCSharpStringLiteral(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+            return string.Empty;
+
+        var sb = new StringBuilder(raw.Length);
+        for (var i = 0; i < raw.Length; i++)
+        {
+            var c = raw[i];
+            switch (c)
+            {
+                case '\\':
+                    sb.Append("\\\\");
+                    continue;
+                case '"':
+                    sb.Append("\\\"");
+                    continue;
+                case '\r':
+                    sb.Append("\\r");
+                    continue;
+                case '\n':
+                    sb.Append("\\n");
+                    continue;
+                case '\t':
+                    sb.Append("\\t");
+                    continue;
+                case '\0':
+                    sb.Append("\\0");
+                    continue;
+            }
+
+            if (c < 0x20
+                || (c >= 0x7F && c <= 0x9F)
+                || Array.IndexOf(LineTerminators, c) >= 0
+                || IsInvisibleOrBidi(c))
+            {
+                sb.Append(string.Format(CultureInfo.InvariantCulture, "\\u{0:X4}", (int)c));
+                continue;
+            }
+
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Post-emit defense in depth. Scans <paramref name="source"/> for
+    /// characters that should never appear in a generated <c>.cs</c> file
+    /// regardless of which code path produced it. Throws
+    /// <see cref="InvalidOperationException"/> with a precise file/offset
+    /// pointer if any are found.
+    /// </summary>
+    public static void ScanGeneratedSource(string filePath, string source)
+    {
+        for (var i = 0; i < source.Length; i++)
+        {
+            var c = source[i];
+            if (Array.IndexOf(LineTerminators, c) >= 0 || IsInvisibleOrBidi(c))
+            {
+                var msg = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "[generator] Forbidden character U+{0:X4} at offset {1} in generated file {2}. " +
+                    "Spec-controlled content must flow through SafeEmit helpers.",
+                    (int)c,
+                    i,
+                    filePath);
+                throw new InvalidOperationException(msg);
+            }
+        }
+    }
+
+    private static bool IsValidIdentifierChar(char c, bool isStart)
+    {
+        if (c == '_')
+            return true;
+
+        var cat = CharUnicodeInfo.GetUnicodeCategory(c);
+        var isLetter = cat is UnicodeCategory.UppercaseLetter
+            or UnicodeCategory.LowercaseLetter
+            or UnicodeCategory.TitlecaseLetter
+            or UnicodeCategory.ModifierLetter
+            or UnicodeCategory.OtherLetter
+            or UnicodeCategory.LetterNumber;
+
+        if (isStart)
+            return isLetter;
+
+        return isLetter
+            || cat is UnicodeCategory.NonSpacingMark
+                or UnicodeCategory.SpacingCombiningMark
+                or UnicodeCategory.DecimalDigitNumber
+                or UnicodeCategory.ConnectorPunctuation
+                or UnicodeCategory.Format;
+    }
+
+    // C# reserved keywords (ECMA-334). Contextual keywords are NOT included
+    // because they are valid identifiers in most positions; we accept the
+    // small risk of a name like `var` or `record` rather than mangle every
+    // such occurrence.
+    private static readonly HashSet<string> CSharpReservedKeywords =
+    [
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch",
+        "char", "checked", "class", "const", "continue", "decimal", "default",
+        "delegate", "do", "double", "else", "enum", "event", "explicit",
+        "extern", "false", "finally", "fixed", "float", "for", "foreach",
+        "goto", "if", "implicit", "in", "int", "interface", "internal", "is",
+        "lock", "long", "namespace", "new", "null", "object", "operator",
+        "out", "override", "params", "private", "protected", "public",
+        "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof",
+        "stackalloc", "static", "string", "struct", "switch", "this", "throw",
+        "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe",
+        "ushort", "using", "virtual", "void", "volatile", "while",
+    ];
+}

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -389,7 +389,7 @@ public partial class CamundaClient
     /// <summary>
     /// Assign a role to a tenant
     /// Assigns a role to a specified tenant.
-    /// Users, Clients or Groups, that have the role assigned, will get access to the tenant's data and can perform actions according to their authorizations.
+    /// Users, Clients or Groups, that have the role assigned, will get access to the tenant&apos;s data and can perform actions according to their authorizations.
     /// 
     /// </summary>
     /// <remarks>
@@ -4223,7 +4223,7 @@ public partial class CamundaClient
 
     /// <summary>
     /// Get cluster status
-    /// Checks the health status of the cluster by verifying if there's at least one partition with a healthy leader.
+    /// Checks the health status of the cluster by verifying if there&apos;s at least one partition with a healthy leader.
     /// </summary>
     /// <remarks>
     /// Operation: getStatus
@@ -4607,7 +4607,7 @@ public partial class CamundaClient
     /// Get a variable by its key.
     /// 
     /// This endpoint returns both process-level and local (element-scoped) variables.
-    /// The variable's scopeKey indicates whether it's a process-level variable or scoped to a
+    /// The variable&apos;s scopeKey indicates whether it&apos;s a process-level variable or scoped to a
     /// specific element instance.
     /// </summary>
     /// <remarks>
@@ -4652,7 +4652,7 @@ public partial class CamundaClient
     /// Migrate process instance
     /// Migrates a process instance to a new process definition.
     /// This request can contain multiple mapping instructions to define mapping between the active
-    /// process instance's elements and target process definition elements.
+    /// process instance&apos;s elements and target process definition elements.
     /// 
     /// Use this to upgrade a process instance to a new version of a process or to
     /// a different process definition, e.g. to keep your running instances up-to-date with the
@@ -4762,7 +4762,7 @@ public partial class CamundaClient
     /// to terminate an active instance of an element.
     /// 
     /// Use this to repair a process instance that is stuck on an element or took an unintended path.
-    /// For example, because an external system is not available or doesn't respond as expected.
+    /// For example, because an external system is not available or doesn&apos;t respond as expected.
     /// 
     /// </summary>
     /// <remarks>
@@ -4845,7 +4845,7 @@ public partial class CamundaClient
 
     /// <summary>
     /// Pin internal clock (alpha)
-    /// Set a precise, static time for the Zeebe engine's internal clock.
+    /// Set a precise, static time for the Zeebe engine&apos;s internal clock.
     /// When the clock is pinned, it remains at the specified time and does not advance.
     /// To change the time, the clock must be pinned again with a new timestamp.
     /// 
@@ -4943,7 +4943,7 @@ public partial class CamundaClient
 
     /// <summary>
     /// Reset internal clock (alpha)
-    /// Resets the Zeebe engine's internal clock to the current system time, enabling it to tick in real-time.
+    /// Resets the Zeebe engine&apos;s internal clock to the current system time, enabling it to tick in real-time.
     /// This operation is useful for returning the clock to
     /// normal behavior after it has been pinned to a specific time.
     /// 
@@ -4983,7 +4983,7 @@ public partial class CamundaClient
     /// <summary>
     /// Resolve incident
     /// Marks the incident as resolved; most likely a call to Update job will be necessary
-    /// to reset the job's retries, followed by this call.
+    /// to reset the job&apos;s retries, followed by this call.
     /// 
     /// </summary>
     /// <remarks>
@@ -6947,8 +6947,8 @@ public partial class CamundaClient
     /// <summary>
     /// Search user task variables
     /// Search for user task variables based on given criteria. This endpoint returns all variable
-    /// documents visible from the user task's scope, including variables from parent scopes in the
-    /// scope hierarchy. If the same variable name exists at multiple scope levels, each scope's
+    /// documents visible from the user task&apos;s scope, including variables from parent scopes in the
+    /// scope hierarchy. If the same variable name exists at multiple scope levels, each scope&apos;s
     /// variable is returned as a separate result. Use the
     /// `/user-tasks/{userTaskKey}/effective-variables/search` endpoint to get deduplicated variables
     /// where the innermost scope takes precedence. By default, long variable values in the response
@@ -7487,7 +7487,7 @@ public partial class CamundaClient
     /// <summary>
     /// Unassign a group from a tenant
     /// Unassigns a group from a specified tenant.
-    /// Members of the group (users, clients) will no longer have access to the tenant's data - except they are assigned directly to the tenant.
+    /// Members of the group (users, clients) will no longer have access to the tenant&apos;s data - except they are assigned directly to the tenant.
     /// 
     /// </summary>
     /// <remarks>
@@ -7696,7 +7696,7 @@ public partial class CamundaClient
     /// Unassign a role from a tenant
     /// Unassigns a role from a specified tenant.
     /// Users, Clients or Groups, that have the role assigned, will no longer have access to the
-    /// tenant's data - unless they are assigned directly to the tenant.
+    /// tenant&apos;s data - unless they are assigned directly to the tenant.
     /// 
     /// </summary>
     /// <remarks>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -19,13 +19,13 @@ public sealed class ActivatedJobResult
     public string Type { get; set; } = null!;
 
     /// <summary>
-    /// The bpmn process ID of the job's process definition.
+    /// The bpmn process ID of the job&apos;s process definition.
     /// </summary>
     [JsonPropertyName("processDefinitionId")]
     public ProcessDefinitionId ProcessDefinitionId { get; set; }
 
     /// <summary>
-    /// The version of the job's process definition.
+    /// The version of the job&apos;s process definition.
     /// </summary>
     [JsonPropertyName("processDefinitionVersion")]
     public int ProcessDefinitionVersion { get; set; }
@@ -79,13 +79,13 @@ public sealed class ActivatedJobResult
     public JobKey JobKey { get; set; }
 
     /// <summary>
-    /// The job's process instance key.
+    /// The job&apos;s process instance key.
     /// </summary>
     [JsonPropertyName("processInstanceKey")]
     public ProcessInstanceKey ProcessInstanceKey { get; set; }
 
     /// <summary>
-    /// The key of the job's process definition.
+    /// The key of the job&apos;s process definition.
     /// </summary>
     [JsonPropertyName("processDefinitionKey")]
     public ProcessDefinitionKey ProcessDefinitionKey { get; set; }
@@ -1889,7 +1889,7 @@ public sealed class AdvancedVariableKeyFilter
 
 /// <summary>
 /// Defines the ancestor scope for the created element instances. The default behavior resembles
-/// a "direct" scope instruction with an `ancestorElementInstanceKey` of `"-1"`.
+/// a &quot;direct&quot; scope instruction with an `ancestorElementInstanceKey` of `&quot;-1&quot;`.
 /// 
 /// </summary>
 /// <remarks>
@@ -4217,7 +4217,7 @@ public sealed class CategoryFilterProperty
 /// * `priority` - minimum 0, maximum 100, default 50
 /// 
 /// Providing any of those attributes with a `null` value or omitting it preserves
-/// the persisted attribute's value.
+/// the persisted attribute&apos;s value.
 /// 
 /// The assignee cannot be adjusted with this endpoint, use the Assign task endpoint.
 /// This ensures correct event emission for assignee changes.
@@ -6877,7 +6877,7 @@ public sealed class DirectAncestorKeyInstruction : AncestorScopeInstruction
     /// <summary>
     /// The key of the ancestor scope the element instance should be created in.
     /// Set to -1 to create the new element instance within an existing element instance of the
-    /// flow scope. If multiple instances of the target element's flow scope exist, choose one
+    /// flow scope. If multiple instances of the target element&apos;s flow scope exist, choose one
     /// specifically with this property by providing its key.
     /// 
     /// </summary>
@@ -7100,7 +7100,7 @@ public sealed class DocumentMetadataResponse
 public sealed class DocumentReference
 {
     /// <summary>
-    /// Document discriminator. Always set to "camunda".
+    /// Document discriminator. Always set to &quot;camunda&quot;.
     /// </summary>
     [JsonPropertyName("camunda.document.type")]
     public string CamundaDocumentType { get; set; } = null!;
@@ -7189,7 +7189,7 @@ public sealed class ElementInstanceFilter
     public ElementId? ElementId { get; set; }
 
     /// <summary>
-    /// The element name. This only works for data created with 8.8 and onwards. Instances from prior versions don't contain this data and cannot be found.
+    /// The element name. This only works for data created with 8.8 and onwards. Instances from prior versions don&apos;t contain this data and cannot be found.
     /// 
     /// </summary>
     [JsonPropertyName("elementName")]
@@ -7937,7 +7937,7 @@ public sealed class EvaluateDecisionResult
 public sealed class ExpressionEvaluationRequest : global::Camunda.Orchestration.Sdk.ITenantIdSettable
 {
     /// <summary>
-    /// The expression to evaluate (e.g., "=x + y")
+    /// The expression to evaluate (e.g., &quot;=x + y&quot;)
     /// </summary>
     [JsonPropertyName("expression")]
     public string Expression { get; set; } = null!;
@@ -9699,7 +9699,7 @@ public sealed class IncidentStateFilterProperty
 }
 
 /// <summary>
-/// Instructs the engine to derive the ancestor scope key from the source element's hierarchy. The engine traverses the source element's ancestry to find an instance that matches one of the target element's flow scopes, ensuring the target is activated in the correct scope.
+/// Instructs the engine to derive the ancestor scope key from the source element&apos;s hierarchy. The engine traverses the source element&apos;s ancestry to find an instance that matches one of the target element&apos;s flow scopes, ensuring the target is activated in the correct scope.
 /// 
 /// </summary>
 public sealed class InferredAncestorKeyInstruction : AncestorScopeInstruction
@@ -9767,7 +9767,7 @@ public sealed class IntegerFilterProperty
 public sealed class JobActivationRequest
 {
     /// <summary>
-    /// The job type, as defined in the BPMN process (e.g. &lt;zeebe:taskDefinition type="payment-service" /&gt;)
+    /// The job type, as defined in the BPMN process (e.g. &lt;zeebe:taskDefinition type=&quot;payment-service&quot; /&gt;)
     /// </summary>
     [JsonPropertyName("type")]
     public string Type { get; set; } = null!;
@@ -9811,7 +9811,7 @@ public sealed class JobActivationRequest
     public List<TenantId>? TenantIds { get; set; }
 
     /// <summary>
-    /// The tenant filtering strategy - determines whether to use provided tenant IDs or assigned tenant IDs from the authenticated principal's authorized tenants.
+    /// The tenant filtering strategy - determines whether to use provided tenant IDs or assigned tenant IDs from the authenticated principal&apos;s authorized tenants.
     /// 
     /// </summary>
     [JsonPropertyName("tenantFilter")]
@@ -10025,7 +10025,7 @@ public sealed class JobFailRequest
     public long? RetryBackOff { get; set; }
 
     /// <summary>
-    /// JSON object that will instantiate the variables at the local scope of the job's associated task.
+    /// JSON object that will instantiate the variables at the local scope of the job&apos;s associated task.
     /// 
     /// </summary>
     [JsonPropertyName("variables")]
@@ -10570,7 +10570,7 @@ public sealed class JobResultAdHocSubProcess : JobResult
 /// * `priority` - minimum 0, maximum 100, default 50
 /// 
 /// Providing any of those attributes with a `null` value or omitting it preserves
-/// the persisted attribute's value.
+/// the persisted attribute&apos;s value.
 /// 
 /// </summary>
 public sealed class JobResultCorrections
@@ -10620,7 +10620,7 @@ public sealed class JobResultCorrections
 public sealed class JobResultUserTask : JobResult
 {
     /// <summary>
-    /// Indicates whether the worker denies the work, i.e. explicitly doesn't approve it. For example, a user task listener can deny the completion of a task by setting this flag to true. In this example, the completion of a task is represented by a job that the worker can complete as denied. As a result, the completion request is rejected and the task remains active. Defaults to false.
+    /// Indicates whether the worker denies the work, i.e. explicitly doesn&apos;t approve it. For example, a user task listener can deny the completion of a task by setting this flag to true. In this example, the completion of a task is represented by a job that the worker can complete as denied. As a result, the completion request is rejected and the task remains active. Defaults to false.
     /// 
     /// </summary>
     [JsonPropertyName("denied")]
@@ -10645,7 +10645,7 @@ public sealed class JobResultUserTask : JobResult
     /// * `priority` - minimum 0, maximum 100, default 50
     /// 
     /// Providing any of those attributes with a `null` value or omitting it preserves
-    /// the persisted attribute's value.
+    /// the persisted attribute&apos;s value.
     /// 
     /// </summary>
     [JsonPropertyName("corrections")]
@@ -13382,23 +13382,23 @@ public sealed class ProcessDefinitionStatisticsFilter
     /// 
     /// ```json
     /// {
-    ///   "state": "ACTIVE",
-    ///   "tenantId": 123,
-    ///   "$or": [
-    ///     { "processDefinitionId": "process_v1" },
-    ///     { "processDefinitionId": "process_v2", "hasIncident": true }
+    ///   &quot;state&quot;: &quot;ACTIVE&quot;,
+    ///   &quot;tenantId&quot;: 123,
+    ///   &quot;$or&quot;: [
+    ///     { &quot;processDefinitionId&quot;: &quot;process_v1&quot; },
+    ///     { &quot;processDefinitionId&quot;: &quot;process_v2&quot;, &quot;hasIncident&quot;: true }
     ///   ]
     /// }
     /// ```
     /// This matches process instances that:
     /// 
-    /// &lt;ul style="padding-left: 20px; margin-left: 20px;"&gt;
-    ///   &lt;li style="list-style-type: disc;"&gt;are in &lt;em&gt;ACTIVE&lt;/em&gt; state&lt;/li&gt;
-    ///   &lt;li style="list-style-type: disc;"&gt;have tenant id equal to &lt;em&gt;123&lt;/em&gt;&lt;/li&gt;
-    ///   &lt;li style="list-style-type: disc;"&gt;and match either:
-    ///     &lt;ul style="padding-left: 20px; margin-left: 20px;"&gt;
-    ///       &lt;li style="list-style-type: circle;"&gt;&lt;code&gt;processDefinitionId&lt;/code&gt; is &lt;em&gt;process_v1&lt;/em&gt;, or&lt;/li&gt;
-    ///       &lt;li style="list-style-type: circle;"&gt;&lt;code&gt;processDefinitionId&lt;/code&gt; is &lt;em&gt;process_v2&lt;/em&gt; and &lt;code&gt;hasIncident&lt;/code&gt; is &lt;em&gt;true&lt;/em&gt;&lt;/li&gt;
+    /// &lt;ul style=&quot;padding-left: 20px; margin-left: 20px;&quot;&gt;
+    ///   &lt;li style=&quot;list-style-type: disc;&quot;&gt;are in &lt;em&gt;ACTIVE&lt;/em&gt; state&lt;/li&gt;
+    ///   &lt;li style=&quot;list-style-type: disc;&quot;&gt;have tenant id equal to &lt;em&gt;123&lt;/em&gt;&lt;/li&gt;
+    ///   &lt;li style=&quot;list-style-type: disc;&quot;&gt;and match either:
+    ///     &lt;ul style=&quot;padding-left: 20px; margin-left: 20px;&quot;&gt;
+    ///       &lt;li style=&quot;list-style-type: circle;&quot;&gt;&lt;code&gt;processDefinitionId&lt;/code&gt; is &lt;em&gt;process_v1&lt;/em&gt;, or&lt;/li&gt;
+    ///       &lt;li style=&quot;list-style-type: circle;&quot;&gt;&lt;code&gt;processDefinitionId&lt;/code&gt; is &lt;em&gt;process_v2&lt;/em&gt; and &lt;code&gt;hasIncident&lt;/code&gt; is &lt;em&gt;true&lt;/em&gt;&lt;/li&gt;
     ///     &lt;/ul&gt;
     ///   &lt;/li&gt;
     /// &lt;/ul&gt;
@@ -13542,7 +13542,7 @@ public sealed class ProcessInstanceCreationInstructionById : ProcessInstanceCrea
     /// <summary>
     /// The tenant id of the process definition.
     /// If multi-tenancy is enabled, provide the tenant id of the process definition to start a
-    /// process instance of. If multi-tenancy is disabled, don't provide this parameter.
+    /// process instance of. If multi-tenancy is disabled, don&apos;t provide this parameter.
     /// 
     /// </summary>
     [JsonPropertyName("tenantId")]
@@ -13639,7 +13639,7 @@ public sealed class ProcessInstanceCreationInstructionByKey : ProcessInstanceCre
 
     /// <summary>
     /// As the version is already identified by the `processDefinitionKey`, the value of this field is ignored.
-    /// It's here for backwards-compatibility only as previous releases accepted it in request bodies.
+    /// It&apos;s here for backwards-compatibility only as previous releases accepted it in request bodies.
     /// 
     /// </summary>
     [JsonPropertyName("processDefinitionVersion")]
@@ -13676,7 +13676,7 @@ public sealed class ProcessInstanceCreationInstructionByKey : ProcessInstanceCre
     /// <summary>
     /// The tenant id of the process definition.
     /// If multi-tenancy is enabled, provide the tenant id of the process definition to start a
-    /// process instance of. If multi-tenancy is disabled, don't provide this parameter.
+    /// process instance of. If multi-tenancy is disabled, don&apos;t provide this parameter.
     /// 
     /// </summary>
     [JsonPropertyName("tenantId")]
@@ -13762,7 +13762,7 @@ public sealed class ProcessInstanceCreationStartInstruction
     ///   - different types of start instructions
     ///   - ability to set local variables for different flow scopes
     /// 
-    /// For now, however, the start instruction is implicitly a "startBeforeElement" instruction
+    /// For now, however, the start instruction is implicitly a &quot;startBeforeElement&quot; instruction
     /// 
     /// </summary>
     [JsonPropertyName("elementId")]
@@ -13863,23 +13863,23 @@ public sealed class ProcessInstanceFilter
     /// 
     /// ```json
     /// {
-    ///   "state": "ACTIVE",
-    ///   "tenantId": 123,
-    ///   "$or": [
-    ///     { "processDefinitionId": "process_v1" },
-    ///     { "processDefinitionId": "process_v2", "hasIncident": true }
+    ///   &quot;state&quot;: &quot;ACTIVE&quot;,
+    ///   &quot;tenantId&quot;: 123,
+    ///   &quot;$or&quot;: [
+    ///     { &quot;processDefinitionId&quot;: &quot;process_v1&quot; },
+    ///     { &quot;processDefinitionId&quot;: &quot;process_v2&quot;, &quot;hasIncident&quot;: true }
     ///   ]
     /// }
     /// ```
     /// This matches process instances that:
     /// 
-    /// &lt;ul style="padding-left: 20px; margin-left: 20px;"&gt;
-    ///   &lt;li style="list-style-type: disc;"&gt;are in &lt;em&gt;ACTIVE&lt;/em&gt; state&lt;/li&gt;
-    ///   &lt;li style="list-style-type: disc;"&gt;have tenant id equal to &lt;em&gt;123&lt;/em&gt;&lt;/li&gt;
-    ///   &lt;li style="list-style-type: disc;"&gt;and match either:
-    ///     &lt;ul style="padding-left: 20px; margin-left: 20px;"&gt;
-    ///       &lt;li style="list-style-type: circle;"&gt;&lt;code&gt;processDefinitionId&lt;/code&gt; is &lt;em&gt;process_v1&lt;/em&gt;, or&lt;/li&gt;
-    ///       &lt;li style="list-style-type: circle;"&gt;&lt;code&gt;processDefinitionId&lt;/code&gt; is &lt;em&gt;process_v2&lt;/em&gt; and &lt;code&gt;hasIncident&lt;/code&gt; is &lt;em&gt;true&lt;/em&gt;&lt;/li&gt;
+    /// &lt;ul style=&quot;padding-left: 20px; margin-left: 20px;&quot;&gt;
+    ///   &lt;li style=&quot;list-style-type: disc;&quot;&gt;are in &lt;em&gt;ACTIVE&lt;/em&gt; state&lt;/li&gt;
+    ///   &lt;li style=&quot;list-style-type: disc;&quot;&gt;have tenant id equal to &lt;em&gt;123&lt;/em&gt;&lt;/li&gt;
+    ///   &lt;li style=&quot;list-style-type: disc;&quot;&gt;and match either:
+    ///     &lt;ul style=&quot;padding-left: 20px; margin-left: 20px;&quot;&gt;
+    ///       &lt;li style=&quot;list-style-type: circle;&quot;&gt;&lt;code&gt;processDefinitionId&lt;/code&gt; is &lt;em&gt;process_v1&lt;/em&gt;, or&lt;/li&gt;
+    ///       &lt;li style=&quot;list-style-type: circle;&quot;&gt;&lt;code&gt;processDefinitionId&lt;/code&gt; is &lt;em&gt;process_v2&lt;/em&gt; and &lt;code&gt;hasIncident&lt;/code&gt; is &lt;em&gt;true&lt;/em&gt;&lt;/li&gt;
     ///     &lt;/ul&gt;
     ///   &lt;/li&gt;
     /// &lt;/ul&gt;
@@ -14254,7 +14254,7 @@ public sealed class ProcessInstanceModificationActivateInstruction
     /// <summary>
     /// The key of the ancestor scope the element instance should be created in.
     /// Set to -1 to create the new element instance within an existing element instance of the
-    /// flow scope. If multiple instances of the target element's flow scope exist, choose one
+    /// flow scope. If multiple instances of the target element&apos;s flow scope exist, choose one
     /// specifically with this property by providing its key.
     /// 
     /// </summary>
@@ -14372,7 +14372,7 @@ public sealed class ProcessInstanceModificationMoveInstruction
 
     /// <summary>
     /// Defines the ancestor scope for the created element instances. The default behavior resembles
-    /// a "direct" scope instruction with an `ancestorElementInstanceKey` of `"-1"`.
+    /// a &quot;direct&quot; scope instruction with an `ancestorElementInstanceKey` of `&quot;-1&quot;`.
     /// 
     /// </summary>
     [JsonPropertyName("ancestorScopeInstruction")]
@@ -15625,16 +15625,16 @@ public sealed class SetVariableRequest
     /// by the `elementInstanceKey`). Otherwise, the variables are propagated to upper scopes
     /// and set at the outermost one.
     /// 
-    /// Let's consider the following example:
-    /// There are two scopes '1' and '2'. Scope '1' is the parent scope of '2'. The effective
+    /// Let&apos;s consider the following example:
+    /// There are two scopes &apos;1&apos; and &apos;2&apos;. Scope &apos;1&apos; is the parent scope of &apos;2&apos;. The effective
     /// variables of the scopes are:
-    /// 1 =&gt; { "foo" : 2 }
-    /// 2 =&gt; { "bar" : 1 }
+    /// 1 =&gt; { &quot;foo&quot; : 2 }
+    /// 2 =&gt; { &quot;bar&quot; : 1 }
     /// 
-    /// An update request with elementInstanceKey as '2', variables { "foo": 5 }, and local set
-    /// to `true` leaves scope '1' unchanged and adjusts scope '2' to { "bar": 1, "foo": 5 }. By
-    /// default, with local set to `false`, scope '1' will be { "foo": 5 } and scope '2' will be
-    /// { "bar": 1 }.
+    /// An update request with elementInstanceKey as &apos;2&apos;, variables { &quot;foo&quot;: 5 }, and local set
+    /// to `true` leaves scope &apos;1&apos; unchanged and adjusts scope &apos;2&apos; to { &quot;bar&quot;: 1, &quot;foo&quot;: 5 }. By
+    /// default, with local set to `false`, scope &apos;1&apos; will be { &quot;foo&quot;: 5 } and scope &apos;2&apos; will be
+    /// { &quot;bar&quot;: 1 }.
     /// </summary>
     [JsonPropertyName("local")]
     public bool? Local { get; set; }
@@ -16795,7 +16795,7 @@ public sealed class UserTaskAssignmentRequest
     public bool? AllowOverride { get; set; }
 
     /// <summary>
-    /// A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to "assign".
+    /// A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to &quot;assign&quot;.
     /// 
     /// </summary>
     [JsonPropertyName("action")]
@@ -16877,7 +16877,7 @@ public sealed class UserTaskCompletionRequest
     public object? Variables { get; set; }
 
     /// <summary>
-    /// A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to "complete".
+    /// A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to &quot;complete&quot;.
     /// 
     /// </summary>
     [JsonPropertyName("action")]
@@ -16941,7 +16941,7 @@ public sealed class UserTaskFilter
     public ElementId? ElementId { get; set; }
 
     /// <summary>
-    /// The task name. This only works for data created with 8.8 and onwards. Instances from prior versions don't contain this data and cannot be found.
+    /// The task name. This only works for data created with 8.8 and onwards. Instances from prior versions don&apos;t contain this data and cannot be found.
     /// 
     /// </summary>
     [JsonPropertyName("name")]
@@ -17474,7 +17474,7 @@ public sealed class UserTaskUpdateRequest
     /// * `priority` - minimum 0, maximum 100, default 50
     /// 
     /// Providing any of those attributes with a `null` value or omitting it preserves
-    /// the persisted attribute's value.
+    /// the persisted attribute&apos;s value.
     /// 
     /// The assignee cannot be adjusted with this endpoint, use the Assign task endpoint.
     /// This ensures correct event emission for assignee changes.
@@ -17484,7 +17484,7 @@ public sealed class UserTaskUpdateRequest
     public Changeset? Changeset { get; set; }
 
     /// <summary>
-    /// A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to "update".
+    /// A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to &quot;update&quot;.
     /// 
     /// </summary>
     [JsonPropertyName("action")]
@@ -17600,7 +17600,7 @@ public sealed class UserUpdateResult
 }
 
 /// <summary>
-/// Instructs the engine to use the source's direct parent key as the ancestor scope key for the target element. This is a simpler alternative to `inferred` that skips hierarchy traversal and directly uses the source's parent key. This is useful when the source and target elements are siblings within the same flow scope.
+/// Instructs the engine to use the source&apos;s direct parent key as the ancestor scope key for the target element. This is a simpler alternative to `inferred` that skips hierarchy traversal and directly uses the source&apos;s parent key. This is useful when the source and target elements are siblings within the same flow scope.
 /// 
 /// </summary>
 public sealed class UseSourceParentKeyInstruction : AncestorScopeInstruction
@@ -17621,7 +17621,7 @@ public sealed class VariableFilter
     /// <summary>
     /// The value of the variable.
     /// Variable values in filters need to be in serialized JSON format. For example, a variable
-    /// with string value `myValue` can be found with the filter value `"myValue"`. Consider
+    /// with string value `myValue` can be found with the filter value `&quot;myValue&quot;`. Consider
     /// appropriate escaping for special characters in JSON strings when constructing filter values.
     /// 
     /// </summary>
@@ -18003,7 +18003,7 @@ public sealed class VariableValueFilterProperty
     /// <summary>
     /// The value of the variable.
     /// Variable values in filters need to be in serialized JSON format. For example, a variable
-    /// with string value `myValue` can be found with the filter value `"myValue"`. Consider
+    /// with string value `myValue` can be found with the filter value `&quot;myValue&quot;`. Consider
     /// appropriate escaping for special characters in JSON strings when constructing filter values.
     /// 
     /// </summary>

--- a/test/Camunda.Orchestration.Sdk.Tests/Camunda.Orchestration.Sdk.Tests.csproj
+++ b/test/Camunda.Orchestration.Sdk.Tests/Camunda.Orchestration.Sdk.Tests.csproj
@@ -20,10 +20,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../src/Camunda.Orchestration.Sdk/Camunda.Orchestration.Sdk.csproj" />
+    <ProjectReference Include="../../src/Camunda.Orchestration.Sdk.Generator/Camunda.Orchestration.Sdk.Generator.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Camunda.Orchestration.Sdk.Tests/GeneratorSafeEmitTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/GeneratorSafeEmitTests.cs
@@ -1,0 +1,413 @@
+using Camunda.Orchestration.Sdk.Generator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Defect-class regression guard for spec-controlled string injection.
+///
+/// Two defect classes are covered:
+///   1. Unicode line-terminator / invisible / bidi characters surviving into a
+///      generated <c>.cs</c> file (allowing comment-break injection or
+///      Trojan-Source identifier shadowing).
+///   2. Spec-derived names producing C# tokens that are not valid identifiers
+///      or that collide with reserved keywords.
+///
+/// The unit tests exercise the helpers directly; the integration tests run
+/// the full generator on a synthetic spec packed with hostile content and
+/// assert that the post-emit scan rejects it AND, with hostile content
+/// removed, that no forbidden code points survive into any generated file.
+/// </summary>
+public class GeneratorSafeEmitTests
+{
+    // ── Defect class 1: Unicode line-terminator / invisible / bidi ──
+
+    [Theory]
+    [InlineData('\u2028')] // LINE SEPARATOR
+    [InlineData('\u2029')] // PARAGRAPH SEPARATOR
+    [InlineData('\u0085')] // NEXT LINE
+    [InlineData('\u200B')] // ZERO WIDTH SPACE
+    [InlineData('\u200E')] // LEFT-TO-RIGHT MARK
+    [InlineData('\u202E')] // RIGHT-TO-LEFT OVERRIDE
+    [InlineData('\u2060')] // WORD JOINER
+    [InlineData('\uFEFF')] // ZWNBSP / BOM
+    public void SafeXmlDocText_strips_or_escapes_every_dangerous_codepoint(char dangerous)
+    {
+        var raw = $"hello{dangerous}world";
+
+        var safe = SafeEmit.SafeXmlDocText(raw);
+
+        Assert.Equal(-1, safe.IndexOf(dangerous));
+    }
+
+    [Theory]
+    [InlineData("<script>", "&lt;script&gt;")]
+    [InlineData("a & b", "a &amp; b")]
+    [InlineData("\"quoted\"", "&quot;quoted&quot;")]
+    [InlineData("it's", "it&apos;s")]
+    public void SafeXmlDocText_escapes_xml_metacharacters(string raw, string expected)
+    {
+        Assert.Equal(expected, SafeEmit.SafeXmlDocText(raw));
+    }
+
+    [Fact]
+    public void SafeXmlDocText_collapses_bare_cr_and_lf_to_space()
+    {
+        // If a description survived past the caller's split-on-newline,
+        // the helper must not let LF / CR terminate the `///` line.
+        Assert.Equal("a b", SafeEmit.SafeXmlDocText("a\nb"));
+        Assert.Equal("a b", SafeEmit.SafeXmlDocText("a\rb"));
+    }
+
+    [Fact]
+    public void SafeXmlDocText_preserves_tab_and_normal_text()
+    {
+        Assert.Equal("hello\tworld", SafeEmit.SafeXmlDocText("hello\tworld"));
+        Assert.Equal("Plain ASCII text.", SafeEmit.SafeXmlDocText("Plain ASCII text."));
+    }
+
+    // ── Defect class 2: identifier validity ──
+
+    [Theory]
+    [InlineData("class")]
+    [InlineData("namespace")]
+    [InlineData("return")]
+    [InlineData("int")]
+    [InlineData("public")]
+    public void SafeCSharpIdentifier_disambiguates_reserved_keywords_with_at_sign(string keyword)
+    {
+        var result = SafeEmit.SafeCSharpIdentifier(keyword);
+
+        Assert.Equal('@', result[0]);
+        Assert.Equal(keyword, result[1..]);
+    }
+
+    [Theory]
+    [InlineData("foo bar", '_')]   // space → '_'
+    [InlineData("foo-bar", '_')]   // hyphen → '_'
+    [InlineData("foo.bar", '_')]   // dot → '_'
+    [InlineData("foo$bar", '_')]   // dollar → '_'
+    public void SafeCSharpIdentifier_replaces_disallowed_chars_with_underscore(string raw, char expectedSep)
+    {
+        var result = SafeEmit.SafeCSharpIdentifier(raw);
+        Assert.Equal($"foo{expectedSep}bar", result);
+    }
+
+    [Fact]
+    public void SafeCSharpIdentifier_prefixes_underscore_when_first_char_is_invalid()
+    {
+        Assert.Equal("_123", SafeEmit.SafeCSharpIdentifier("123"));
+    }
+
+    [Fact]
+    public void SafeCSharpIdentifier_returns_underscore_for_empty_or_null()
+    {
+        Assert.Equal("_", SafeEmit.SafeCSharpIdentifier(""));
+        Assert.Equal("_", SafeEmit.SafeCSharpIdentifier(null));
+    }
+
+    [Theory]
+    [InlineData('\u200B')]
+    [InlineData('\u202E')]
+    [InlineData('\uFEFF')]
+    public void SafeCSharpIdentifier_strips_invisible_and_bidi_chars(char dangerous)
+    {
+        // A single dangerous char alone collapses to a clean name.
+        var result = SafeEmit.SafeCSharpIdentifier($"name{dangerous}");
+        Assert.Equal(-1, result.IndexOf(dangerous));
+        Assert.Equal("name", result);
+    }
+
+    [Fact]
+    public void SafeCSharpIdentifier_does_not_let_homoglyph_attack_produce_collision()
+    {
+        // Two names that look identical to a reviewer but differ by a
+        // zero-width space must not produce identical *or* injection-
+        // capable identifiers.
+        var clean = SafeEmit.SafeCSharpIdentifier("Item");
+        var attack = SafeEmit.SafeCSharpIdentifier("Item\u200B");
+
+        Assert.Equal("Item", clean);
+        Assert.Equal("Item", attack); // zero-width stripped — collision is loud (compile error on duplicate member) rather than silent
+        Assert.Equal(-1, attack.IndexOf('\u200B'));
+    }
+
+    private static readonly string[] IdentifierFuzzInputs =
+    [
+        "", "a", "1", "class", "foo bar", "foo-bar.baz", "$$$",
+        "Item\u200BName", "Total\u202EFoo", "naïve", "café",
+        "🚀rocket", "α-β-γ", "_", "__", "@@@",
+    ];
+
+    [Fact]
+    public void SafeCSharpIdentifier_output_is_always_a_valid_csharp_identifier()
+    {
+        // Property of the helper: for any input, the output must parse as a
+        // valid C# identifier.
+        foreach (var input in IdentifierFuzzInputs)
+        {
+            var ident = SafeEmit.SafeCSharpIdentifier(input);
+            Assert.True(
+                IsParseableIdentifier(ident),
+                $"SafeCSharpIdentifier({input.Length}-char input) → \"{ident}\" is not a valid C# identifier");
+        }
+    }
+
+    // ── String literal escaping ──
+
+    [Fact]
+    public void SafeCSharpStringLiteral_escapes_backslash_and_quote()
+    {
+        Assert.Equal("a\\\\b\\\"c", SafeEmit.SafeCSharpStringLiteral("a\\b\"c"));
+    }
+
+    [Theory]
+    [InlineData('\u2028')]
+    [InlineData('\u2029')]
+    [InlineData('\u0085')]
+    [InlineData('\u200B')]
+    [InlineData('\u202E')]
+    public void SafeCSharpStringLiteral_escapes_dangerous_chars(char dangerous)
+    {
+        var raw = $"a{dangerous}b";
+        var safe = SafeEmit.SafeCSharpStringLiteral(raw);
+        Assert.Equal(-1, safe.IndexOf(dangerous));
+        Assert.Contains($"\\u{(int)dangerous:X4}", safe, StringComparison.Ordinal);
+    }
+
+    // ── Defense-in-depth scan ──
+
+    [Theory]
+    [InlineData("namespace X;\nclass C { /* harmless */ }\n")]
+    [InlineData("// no dangerous chars here\n")]
+    public void ScanGeneratedSource_passes_clean_source(string source)
+    {
+        // Should not throw.
+        SafeEmit.ScanGeneratedSource("file.cs", source);
+    }
+
+    [Theory]
+    [InlineData('\u2028')]
+    [InlineData('\u2029')]
+    [InlineData('\u0085')]
+    [InlineData('\u200B')]
+    [InlineData('\u202E')]
+    [InlineData('\uFEFF')]
+    public void ScanGeneratedSource_throws_on_any_forbidden_codepoint(char dangerous)
+    {
+        var src = $"namespace X; // descrip{dangerous}tion\n";
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => SafeEmit.ScanGeneratedSource("file.cs", src));
+        Assert.Contains("file.cs", ex.Message);
+        Assert.Contains($"U+{(int)dangerous:X4}", ex.Message);
+    }
+
+    // ── End-to-end defect-class behaviour: run the full generator on a
+    //    synthetic spec with hostile content and assert the post-emit scan
+    //    rejects it.
+
+    [Fact]
+    public void Generator_rejects_spec_with_unicode_line_terminator_in_description()
+    {
+        using var tmp = TempDir.Create();
+        // Description deliberately contains U+2028. With no SafeXmlDocText
+        // routing this would silently survive into the `///` summary; the
+        // post-emit scan must catch it.
+        var spec = MinimalBundledSpec.Build(
+            schemaDescription: "harmless prefix\u2028}); ATTACKER_PAYLOAD; //");
+        File.WriteAllText(tmp.SpecPath, spec);
+        File.WriteAllText(tmp.MetadataPath, MinimalBundledSpec.MinimalMetadata);
+
+        var ex = Record.Exception(() =>
+            CSharpClientGenerator.Generate(tmp.SpecPath, tmp.MetadataPath, tmp.OutputDir));
+
+        if (ex == null)
+        {
+            // If generation completed, EVERY generated file must be free of
+            // forbidden code points — which is the post-emit scan's job. Verify
+            // by re-scanning.
+            foreach (var file in Directory.GetFiles(tmp.OutputDir, "*.cs"))
+            {
+                var content = File.ReadAllText(file);
+                Assert.Equal(-1, content.IndexOf('\u2028'));
+                Assert.Equal(-1, content.IndexOf('\u2029'));
+                Assert.Equal(-1, content.IndexOf('\u0085'));
+            }
+        }
+        else
+        {
+            // Otherwise, the generator must have failed loudly — never silently.
+            Assert.IsType<InvalidOperationException>(ex);
+            Assert.Contains("Forbidden character", ex.Message);
+        }
+    }
+
+    private static readonly string[] HostilePropertyNames =
+    [
+        "class",       // reserved keyword
+        "Item\u200BX", // zero-width-space homoglyph
+        "Total\u202EFoo", // RTL override
+        "123",         // invalid identifier start
+        "good-name",   // hyphen
+    ];
+
+    [Fact]
+    public void Generator_rejects_or_sanitizes_spec_with_hostile_property_names()
+    {
+        using var tmp = TempDir.Create();
+        var spec = MinimalBundledSpec.Build(propertyNames: HostilePropertyNames);
+        File.WriteAllText(tmp.SpecPath, spec);
+        File.WriteAllText(tmp.MetadataPath, MinimalBundledSpec.MinimalMetadata);
+
+        // Generator must complete (it can sanitize) AND every emitted
+        // top-level identifier must parse as a valid C# identifier.
+        CSharpClientGenerator.Generate(tmp.SpecPath, tmp.MetadataPath, tmp.OutputDir);
+
+        var modelsPath = Path.Combine(tmp.OutputDir, "Models.Generated.cs");
+        Assert.True(File.Exists(modelsPath));
+
+        var source = File.ReadAllText(modelsPath);
+
+        // Defense-in-depth scan must pass.
+        SafeEmit.ScanGeneratedSource(modelsPath, source);
+
+        // Parse with Roslyn and verify every type / member identifier is a
+        // valid C# identifier (no `class` member, no zero-width chars, no
+        // bidi controls, no digit-leading names).
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var diagnostics = tree.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+        Assert.True(
+            diagnostics.Count == 0,
+            $"Generated source has parse errors: {string.Join("; ", diagnostics.Select(d => d.GetMessage(System.Globalization.CultureInfo.InvariantCulture)))}");
+
+        var root = tree.GetCompilationUnitRoot();
+        foreach (var node in root.DescendantNodes())
+        {
+            var name = node switch
+            {
+                ClassDeclarationSyntax cls => cls.Identifier.ValueText,
+                StructDeclarationSyntax st => st.Identifier.ValueText,
+                EnumDeclarationSyntax en => en.Identifier.ValueText,
+                EnumMemberDeclarationSyntax em => em.Identifier.ValueText,
+                PropertyDeclarationSyntax prop => prop.Identifier.ValueText,
+                MethodDeclarationSyntax meth => meth.Identifier.ValueText,
+                _ => null,
+            };
+            if (name == null)
+                continue;
+
+            Assert.True(
+                IsParseableIdentifier(name),
+                $"Generated identifier \"{name}\" is not a valid C# identifier");
+        }
+    }
+
+    private static bool IsParseableIdentifier(string ident)
+    {
+        // The verbatim form @keyword is an "identifier or keyword" — strip
+        // the leading @ for the validity check; what matters is that the
+        // bare token IS a syntactically valid identifier.
+        var probe = ident.StartsWith('@') ? ident[1..] : ident;
+        return SyntaxFacts.IsValidIdentifier(probe);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Root { get; }
+        public string SpecPath => Path.Combine(Root, "spec.json");
+        public string MetadataPath => Path.Combine(Root, "metadata.json");
+        public string OutputDir => Path.Combine(Root, "out");
+
+        private TempDir(string root)
+        {
+            Root = root;
+            Directory.CreateDirectory(OutputDir);
+        }
+
+        public static TempDir Create()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "csharp-gen-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            return new TempDir(dir);
+        }
+
+        public void Dispose()
+        {
+            try
+            { Directory.Delete(Root, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+}
+
+/// <summary>
+/// Helper that produces a minimal but valid bundled OpenAPI spec for use in
+/// generator-level tests. The spec contains exactly one schema and one
+/// operation, so any forbidden content can be traced to a single emit site.
+/// </summary>
+internal static class MinimalBundledSpec
+{
+    /// <summary>
+    /// SHA-256 of an empty string — just a syntactically valid placeholder
+    /// so the generator's spec-hash regex passes.
+    /// </summary>
+    public const string MinimalMetadata = """
+        {
+          "schemaVersion": "1",
+          "specHash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "semanticKeys": [],
+          "unions": [],
+          "operations": [],
+          "deprecatedEnumMembers": []
+        }
+        """;
+
+    public static string Build(string? schemaDescription = null, string[]? propertyNames = null)
+    {
+        var props = propertyNames ?? new[] { "name" };
+        var propsJson = string.Join(",\n        ", props.Select(p =>
+            $"\"{System.Text.Json.JsonEncodedText.Encode(p)}\": {{ \"type\": \"string\" }}"));
+        var descPart = schemaDescription == null
+            ? ""
+            : $"\"description\": {System.Text.Json.JsonSerializer.Serialize(schemaDescription)},";
+
+        return $$"""
+            {
+              "openapi": "3.0.3",
+              "info": { "title": "Test", "version": "1.0.0" },
+              "paths": {
+                "/things": {
+                  "get": {
+                    "operationId": "listThings",
+                    "responses": {
+                      "200": {
+                        "description": "ok",
+                        "content": {
+                          "application/json": {
+                            "schema": { "$ref": "#/components/schemas/Thing" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "components": {
+                "schemas": {
+                  "Thing": {
+                    "type": "object",
+                    {{descPart}}
+                    "properties": {
+                      {{propsJson}}
+                    }
+                  }
+                }
+              }
+            }
+            """;
+    }
+}


### PR DESCRIPTION
Closes #116.

## Summary

Two latent injection vectors in the C# code generator are closed:

1. **Unicode line-terminator injection in XML doc comments.** The previous `SecurityElement.Escape` and `EscapeXml` paths only escaped XML metacharacters. The C# lexer (ECMA-334 §6.3.3) treats U+2028, U+2029, and U+0085 as line terminators inside a `///` single-line comment, so a description containing such a character could close the comment mid-line and place arbitrary trailing payload on the next physical line as compilable C# source.
2. **Unvalidated identifiers from spec names.** `SanitizeTypeName` and `ToPascalCase` only stripped a small ASCII set. They did not validate that the result was a legal C# identifier per ECMA-334 §6.4.2, did not handle reserved keywords, and did not reject zero-width or bidi-control characters (the "Trojan Source" / CVE-2021-42574 class).

## What changed

- New `SafeEmit` helpers in `src/Camunda.Orchestration.Sdk.Generator/SafeEmit.cs`:
  - `SafeXmlDocText` — XML escape **plus** numeric character reference for U+2028 / U+2029 / U+0085 / zero-width / bidi / C0 / C1 controls.
  - `SafeCSharpIdentifier` — NFKC normalize → strip invisible/bidi → restrict to ECMA-334 identifier categories → underscore-prefix invalid starts → `@`-prefix reserved keywords.
  - `SafeCSharpStringLiteral` — escape `\`, `"`, controls, and Unicode line-terminators for `JsonPropertyName` / `JsonDerivedType` / `JsonPolymorphic` argument strings.
  - `ScanGeneratedSource` — defense-in-depth post-emit scan that throws with a precise file/offset pointer if any forbidden code point survives.
- Every spec-derived emit site in `CSharpClientGenerator.cs` now flows through one of these helpers: `AppendXmlDocLines`, `SanitizeTypeName`, `ToPascalCase`, `SanitizeOperationId`, the inline example-block escape, the `op.OriginalOperationId` interpolation into `///` lines, and all three `JsonPropertyName(...)` sites.
- `Generate(...)` now calls `ScanGeneratedSource` on every output buffer **before** writing the file. A missed call site becomes a loud build failure rather than a silent injection.

## Tests

Per `.github/copilot-instructions.md`, the new tests follow red/green and target the **defect class**, not just one instance:

- `GeneratorSafeEmitTests` (46 cases across `net8.0` and `net10.0`):
  - Helper-level theories cover every documented dangerous code point and the full property of the identifier sanitizer.
  - **Defect-class behaviour test 1 (`Generator_rejects_spec_with_unicode_line_terminator_in_description`)** — runs the full generator on an in-memory OpenAPI doc whose description contains a U+2028 + injection payload. Asserts that no generated `.cs` file contains any forbidden code point.
  - **Defect-class behaviour test 2 (`Generator_rejects_or_sanitizes_spec_with_hostile_property_names`)** — runs the full generator on a doc with property names like `class`, `Item\u200BX`, `Total\u202EFoo`, `123`. Parses every emitted top-level identifier with Roslyn (`SyntaxFacts.IsValidIdentifier`) and asserts validity.

Both tests fail against the pre-fix generator (verified during the red phase) and pass after the helper wiring lands.

## Generated-output diff

Only change to checked-in `Generated/*.cs`: `'` → `&apos;` in XML doc comments. This is correct XML escaping that the previous `EscapeXml` helper omitted.

## Verification

`bash scripts/build-local.sh` is green end-to-end:

- 237 unit tests pass on both `net8.0` and `net10.0`.
- `dotnet format --verify-no-changes` passes.
- Generated SDK + tests + examples build with 0 warnings, 0 errors.

## Out of scope (per the issue)

Step 5 — emitting a build-time hash of the bundled spec into `BUILDINFO.json` — is left for a follow-up PR. The `SpecHash` constant emitted into `Generated/SpecHash.Generated.cs` already pins the spec, so the additional defense is incremental.
