### PR TITLE
ci: change default SPEC_REF fallback to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
         default: 'main'
 
 env:
-  SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'stable/8.9' }}
+  SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'main' }}
 
 jobs:
   commitlint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
         default: 'main'
 
 env:
-  SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'stable/8.9' }}
+  SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'main' }}
 
 concurrency:
   group: orchestration-cluster-api-csharp-release-${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Change the default `SPEC_REF` fallback in both `ci.yml` and `release.yml` from `'stable/8.9'` to `'main'`.

## Why

The fallback only applies when:
- The job is **not** a `workflow_dispatch` (so `inputs.spec_ref` is unset), and
- The repo variable `SPEC_REF_OVERRIDE` is unset.

Today that produces builds against the `stable/8.9` upstream spec by default. Going forward, unconfigured branches should track the upstream development spec (`main`); stable branches continue to pin explicitly via `SPEC_REF_OVERRIDE` (with the existing `SPEC_REF_OVERRIDE_ACK` + `SPEC_REF_OVERRIDE_EXPIRES` guards).

## Changes

- `.github/workflows/ci.yml` — env fallback `'stable/8.9'` → `'main'`.
- `.github/workflows/release.yml` — env fallback `'stable/8.9'` → `'main'`.

The `workflow_dispatch` input default was already `'main'`, so this only aligns the implicit fallback with the explicit one.
