### PR TITLE
fix(gen): apply CAMUNDA_DEFAULT_TENANT_ID to ActivateJobsAsync tenantIds (#123)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ perf
 
 Rules:
 
-- Subject length: 5–100 characters.
+- **Subject length: 5–100 characters.** Enforced by `subject-max-length` in `commitlint.config.cjs`; CI fails the lint job on longer subjects. Em-dashes (`—`) and other multi-byte characters count by character count, not byte count. Keep subjects concise — push detail into the body.
 - Use imperative mood ("add support", not "added support").
 - Lowercase subject (except proper nouns). No PascalCase subjects.
 - Keep subject concise; body can include details, rationale, links.

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -1527,6 +1527,35 @@ internal static class CSharpClientGenerator
     /// </summary>
     private static (string ItemCSharpType, bool IsBrandedKey)? GetOptionalTenantIdsInfo(OpenApiSchema schema, OpenApiDocument? doc = null)
     {
+        // Mirror HasOptionalTenantIdsArrayInAnyVariant: when the schema is a
+        // oneOf/anyOf, every variant must agree on the same optional tenantIds
+        // item type. Otherwise the operation-level injection (which IS
+        // variant-aware) would emit a SetDefaultTenantIds call against a
+        // wrapper class whose variants didn't implement ITenantIdsSettable
+        // consistently, making the injection a no-op or inconsistent.
+        var variants = schema.OneOf?.Count > 0 ? schema.OneOf : (schema.AnyOf?.Count > 0 ? schema.AnyOf : null);
+        if (variants is { Count: > 0 })
+        {
+            (string ItemCSharpType, bool IsBrandedKey)? agreed = null;
+            foreach (var v in variants)
+            {
+                var resolvedVariant = v.Reference != null
+                    && doc?.Components?.Schemas != null
+                    && doc.Components.Schemas.TryGetValue(v.Reference.Id, out var r)
+                    ? r
+                    : v;
+                var info = GetOptionalTenantIdsInfo(resolvedVariant, doc);
+                if (info == null)
+                    return null;
+                if (agreed == null)
+                    agreed = info;
+                else if (agreed.Value.ItemCSharpType != info.Value.ItemCSharpType
+                    || agreed.Value.IsBrandedKey != info.Value.IsBrandedKey)
+                    return null;
+            }
+            return agreed;
+        }
+
         var properties = new Dictionary<string, OpenApiSchema>(
             schema.Properties ?? new Dictionary<string, OpenApiSchema>());
         var required = new HashSet<string>(

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -151,6 +151,17 @@ internal static class CSharpClientGenerator
                         inlineSchemas.TryAdd(responseSchemaRef, inlineRespSchema);
                 }
 
+                // Detect optional plural `tenantIds` array in the request body.
+                // Self-contained here (rather than via spec-metadata) so this fix
+                // does not require a camunda-schema-bundler release. See issue #123.
+                var hasOptionalTenantIdsInBody = false;
+                if (hasBody && !isMultipart)
+                {
+                    var bodySchema = ResolveRequestBodySchema(doc, op);
+                    if (bodySchema != null)
+                        hasOptionalTenantIdsInBody = HasOptionalTenantIdsArrayInAnyVariant(bodySchema, doc);
+                }
+
                 ops.Add(new OperationMeta
                 {
                     OperationId = opId,
@@ -166,6 +177,7 @@ internal static class CSharpClientGenerator
                     IsVoidResponse = responseSchemaRef == null && GetSuccessStatusCode(op) is 204 or 202,
                     IsEventuallyConsistent = isEventual,
                     HasOptionalTenantIdInBody = metaEntry?.OptionalTenantIdInBody ?? false,
+                    HasOptionalTenantIdsInBody = hasOptionalTenantIdsInBody,
                     Summary = op.Summary,
                     Description = op.Description,
                     Tags = op.Tags?.Select(t => t.Name).ToList() ?? [],
@@ -226,6 +238,79 @@ internal static class CSharpClientGenerator
                 return mediaType.Schema;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Returns the JSON request body schema for an operation, resolving a
+    /// component <c>$ref</c> against the document. Returns the inline schema
+    /// when no <c>$ref</c> is present.
+    /// </summary>
+    private static OpenApiSchema? ResolveRequestBodySchema(OpenApiDocument doc, OpenApiOperation op)
+    {
+        var content = op.RequestBody?.Content;
+        if (content == null)
+            return null;
+        foreach (var (ct, mediaType) in content)
+        {
+            if (!ct.Contains("json", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (mediaType.Schema == null)
+                continue;
+            if (mediaType.Schema.Reference != null
+                && doc.Components?.Schemas != null
+                && doc.Components.Schemas.TryGetValue(mediaType.Schema.Reference.Id, out var resolved))
+                return resolved;
+            return mediaType.Schema;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// True if the schema (or every variant in a <c>oneOf</c>/<c>anyOf</c>) has
+    /// an optional <c>tenantIds: array</c> property. Mirrors the JS hook
+    /// <c>collectOpsWithOptionalTenantIdsArray</c> introduced in
+    /// orchestration-cluster-api-js#171.
+    /// </summary>
+    private static bool HasOptionalTenantIdsArrayInAnyVariant(OpenApiSchema schema, OpenApiDocument doc)
+    {
+        var variants = schema.OneOf?.Count > 0 ? schema.OneOf : (schema.AnyOf?.Count > 0 ? schema.AnyOf : null);
+        if (variants is { Count: > 0 })
+        {
+            foreach (var v in variants)
+            {
+                var resolved = v.Reference != null
+                    && doc.Components?.Schemas != null
+                    && doc.Components.Schemas.TryGetValue(v.Reference.Id, out var r)
+                    ? r
+                    : v;
+                if (!HasOptionalTenantIdsArrayDirect(resolved))
+                    return false;
+            }
+            return true;
+        }
+        return HasOptionalTenantIdsArrayDirect(schema);
+    }
+
+    private static bool HasOptionalTenantIdsArrayDirect(OpenApiSchema schema)
+    {
+        var properties = new Dictionary<string, OpenApiSchema>(
+            schema.Properties ?? new Dictionary<string, OpenApiSchema>());
+        var required = new HashSet<string>(
+            schema.Required ?? new HashSet<string>());
+        foreach (var allOf in schema.AllOf ?? [])
+        {
+            if (allOf.Properties != null)
+                foreach (var (k, v) in allOf.Properties)
+                    properties.TryAdd(k, v);
+            if (allOf.Required != null)
+                foreach (var r in allOf.Required)
+                    required.Add(r);
+        }
+        if (!properties.TryGetValue("tenantIds", out var tenantIdsProp))
+            return false;
+        if (required.Contains("tenantIds"))
+            return false;
+        return tenantIdsProp.Type == "array";
     }
 
     private static OpenApiSchema? GetInlineResponseSchema(OpenApiOperation op)
@@ -623,9 +708,15 @@ internal static class CSharpClientGenerator
 
             // Check if this class has an optional tenantId property AND is used as a request body
             var tenantIdInfo = requestSchemaNames.Contains(typeName) ? GetOptionalTenantIdInfo(schema) : null;
-            var interfaces = tenantIdInfo != null
-                ? (baseClass != "" ? ", global::Camunda.Orchestration.Sdk.ITenantIdSettable" : " : global::Camunda.Orchestration.Sdk.ITenantIdSettable")
-                : "";
+            var tenantIdsInfo = requestSchemaNames.Contains(typeName) ? GetOptionalTenantIdsInfo(schema, doc) : null;
+            var ifaceList = new List<string>();
+            if (tenantIdInfo != null)
+                ifaceList.Add("global::Camunda.Orchestration.Sdk.ITenantIdSettable");
+            if (tenantIdsInfo != null)
+                ifaceList.Add("global::Camunda.Orchestration.Sdk.ITenantIdsSettable");
+            var interfaces = ifaceList.Count == 0
+                ? ""
+                : (baseClass != "" ? ", " + string.Join(", ", ifaceList) : " : " + string.Join(", ", ifaceList));
 
             // Generate class
             sb.AppendLine($"/// <summary>");
@@ -690,6 +781,8 @@ internal static class CSharpClientGenerator
 
             if (tenantIdInfo != null)
                 EmitSetDefaultTenantIdMethod(sb, tenantIdInfo.Value);
+            if (tenantIdsInfo != null)
+                EmitSetDefaultTenantIdsMethod(sb, tenantIdsInfo.Value);
 
             sb.AppendLine("}");
             sb.AppendLine();
@@ -707,7 +800,13 @@ internal static class CSharpClientGenerator
     private static void GenerateClass(StringBuilder sb, string typeName, OpenApiSchema schema, OpenApiDocument? doc = null, bool isRequestSchema = false)
     {
         var tenantIdInfo = isRequestSchema ? GetOptionalTenantIdInfo(schema) : null;
-        var interfaces = tenantIdInfo != null ? " : global::Camunda.Orchestration.Sdk.ITenantIdSettable" : "";
+        var tenantIdsInfo = isRequestSchema ? GetOptionalTenantIdsInfo(schema, doc) : null;
+        var ifaceList = new List<string>();
+        if (tenantIdInfo != null)
+            ifaceList.Add("global::Camunda.Orchestration.Sdk.ITenantIdSettable");
+        if (tenantIdsInfo != null)
+            ifaceList.Add("global::Camunda.Orchestration.Sdk.ITenantIdsSettable");
+        var interfaces = ifaceList.Count == 0 ? "" : " : " + string.Join(", ", ifaceList);
 
         sb.AppendLine($"/// <summary>");
         AppendXmlDocLines(sb, schema.Description ?? typeName, "");
@@ -761,6 +860,8 @@ internal static class CSharpClientGenerator
 
         if (tenantIdInfo != null)
             EmitSetDefaultTenantIdMethod(sb, tenantIdInfo.Value);
+        if (tenantIdsInfo != null)
+            EmitSetDefaultTenantIdsMethod(sb, tenantIdsInfo.Value);
 
         sb.AppendLine("}");
         sb.AppendLine();
@@ -1100,6 +1201,15 @@ internal static class CSharpClientGenerator
             sb.AppendLine($"        if (body is ITenantIdSettable __t) __t.SetDefaultTenantId(_config.DefaultTenantId);");
         }
 
+        // Inject default tenant ID enrichment for operations with optional plural
+        // `tenantIds` array in body (e.g. activateJobs). The singular DefaultTenantId
+        // is wrapped into a single-element list when the caller omits TenantIds.
+        // See issue #123 / orchestration-cluster-api-js#170.
+        if (op.HasOptionalTenantIdsInBody && op.HasBody && !op.IsMultipart)
+        {
+            sb.AppendLine($"        if (body is ITenantIdsSettable __ts) __ts.SetDefaultTenantIds(_config.DefaultTenantId);");
+        }
+
         // Inject default tenant ID into multipart content when applicable
         if (op.HasOptionalTenantIdInBody && op.IsMultipart)
         {
@@ -1401,6 +1511,65 @@ internal static class CSharpClientGenerator
     }
 
     /// <summary>
+    /// Returns the C# element type of the optional <c>tenantIds</c> array
+    /// property if present (and not in the schema's required set), or null
+    /// otherwise. Used to determine the <see cref="Camunda.Orchestration.Sdk.ITenantIdsSettable"/>
+    /// implementation. See issue camunda/orchestration-cluster-api-csharp#123.
+    /// </summary>
+    private static (string ItemCSharpType, bool IsBrandedKey)? GetOptionalTenantIdsInfo(OpenApiSchema schema, OpenApiDocument? doc = null)
+    {
+        var properties = new Dictionary<string, OpenApiSchema>(
+            schema.Properties ?? new Dictionary<string, OpenApiSchema>());
+        var required = new HashSet<string>(
+            schema.Required ?? new HashSet<string>());
+        foreach (var allOf in schema.AllOf ?? [])
+        {
+            if (allOf.Properties != null)
+                foreach (var (k, v) in allOf.Properties)
+                    properties.TryAdd(k, v);
+            if (allOf.Required != null)
+                foreach (var r in allOf.Required)
+                    required.Add(r);
+        }
+
+        if (!properties.TryGetValue("tenantIds", out var tenantIdsProp))
+            return null;
+        if (required.Contains("tenantIds"))
+            return null;
+        if (tenantIdsProp.Type != "array" || tenantIdsProp.Items == null)
+            return null;
+
+        var itemType = MapType(tenantIdsProp.Items, doc);
+        // Only support a branded TenantId or plain string element type.
+        if (itemType != "string" && itemType != "TenantId")
+            return null;
+        return (itemType, itemType == "TenantId");
+    }
+
+    /// <summary>
+    /// Emits the SetDefaultTenantIds method implementation for ITenantIdsSettable.
+    /// Mirrors <see cref="EmitSetDefaultTenantIdMethod"/> but for the plural
+    /// array shape (e.g. JobActivationRequest.TenantIds).
+    /// </summary>
+    private static void EmitSetDefaultTenantIdsMethod(StringBuilder sb, (string ItemCSharpType, bool IsBrandedKey) info)
+    {
+        sb.AppendLine("    /// <inheritdoc />");
+        sb.AppendLine("    public void SetDefaultTenantIds(string tenantId)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        if (TenantIds == null || TenantIds.Count == 0)");
+        if (info.IsBrandedKey)
+        {
+            sb.AppendLine($"            TenantIds = new List<{info.ItemCSharpType}> {{ global::Camunda.Orchestration.Sdk.TenantId.AssumeExists(tenantId) }};");
+        }
+        else
+        {
+            sb.AppendLine($"            TenantIds = new List<{info.ItemCSharpType}> {{ tenantId }};");
+        }
+        sb.AppendLine("    }");
+        sb.AppendLine();
+    }
+
+    /// <summary>
     /// Emits the SetDefaultTenantId method implementation for ITenantIdSettable.
     /// </summary>
     private static void EmitSetDefaultTenantIdMethod(StringBuilder sb, (string CSharpType, bool IsBrandedKey) info)
@@ -1584,6 +1753,7 @@ internal sealed class OperationMeta
     public required List<string> Tags { get; init; }
     public required bool IsExemptFromBackpressure { get; init; }
     public required bool HasOptionalTenantIdInBody { get; init; }
+    public required bool HasOptionalTenantIdsInBody { get; init; }
 }
 
 internal readonly record struct ParamMeta(string Name, string Type, bool Required);

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -283,15 +283,15 @@ internal static class CSharpClientGenerator
                     && doc.Components.Schemas.TryGetValue(v.Reference.Id, out var r)
                     ? r
                     : v;
-                if (!HasOptionalTenantIdsArrayDirect(resolved))
+                if (!HasOptionalTenantIdsArrayDirect(resolved, doc))
                     return false;
             }
             return true;
         }
-        return HasOptionalTenantIdsArrayDirect(schema);
+        return HasOptionalTenantIdsArrayDirect(schema, doc);
     }
 
-    private static bool HasOptionalTenantIdsArrayDirect(OpenApiSchema schema)
+    private static bool HasOptionalTenantIdsArrayDirect(OpenApiSchema schema, OpenApiDocument? doc = null)
     {
         var properties = new Dictionary<string, OpenApiSchema>(
             schema.Properties ?? new Dictionary<string, OpenApiSchema>());
@@ -299,11 +299,20 @@ internal static class CSharpClientGenerator
             schema.Required ?? new HashSet<string>());
         foreach (var allOf in schema.AllOf ?? [])
         {
-            if (allOf.Properties != null)
-                foreach (var (k, v) in allOf.Properties)
+            // Resolve `allOf: [{$ref: ...}]` against the document — Microsoft.OpenApi
+            // does not auto-resolve refs into the AllOf entry. Without this, a schema
+            // that composes `tenantIds` via a referenced component would be missed.
+            // Matches the pattern used elsewhere in this file (e.g. GetConstraints).
+            var resolved = allOf.Reference != null
+                && doc?.Components?.Schemas != null
+                && doc.Components.Schemas.TryGetValue(allOf.Reference.Id, out var refSchema)
+                ? refSchema
+                : allOf;
+            if (resolved.Properties != null)
+                foreach (var (k, v) in resolved.Properties)
                     properties.TryAdd(k, v);
-            if (allOf.Required != null)
-                foreach (var r in allOf.Required)
+            if (resolved.Required != null)
+                foreach (var r in resolved.Required)
                     required.Add(r);
         }
         if (!properties.TryGetValue("tenantIds", out var tenantIdsProp))
@@ -1524,11 +1533,18 @@ internal static class CSharpClientGenerator
             schema.Required ?? new HashSet<string>());
         foreach (var allOf in schema.AllOf ?? [])
         {
-            if (allOf.Properties != null)
-                foreach (var (k, v) in allOf.Properties)
+            // Resolve `allOf: [{$ref: ...}]` against the document — see
+            // HasOptionalTenantIdsArrayDirect for rationale.
+            var resolved = allOf.Reference != null
+                && doc?.Components?.Schemas != null
+                && doc.Components.Schemas.TryGetValue(allOf.Reference.Id, out var refSchema)
+                ? refSchema
+                : allOf;
+            if (resolved.Properties != null)
+                foreach (var (k, v) in resolved.Properties)
                     properties.TryAdd(k, v);
-            if (allOf.Required != null)
-                foreach (var r in allOf.Required)
+            if (resolved.Required != null)
+                foreach (var r in resolved.Required)
                     required.Add(r);
         }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -101,6 +101,7 @@ public partial class CamundaClient
     public async Task<JobActivationResult> ActivateJobsAsync(JobActivationRequest body, CancellationToken ct = default)
     {
         var path = $"/jobs/activation";
+        if (body is ITenantIdsSettable __ts) __ts.SetDefaultTenantIds(_config.DefaultTenantId);
         return await InvokeWithRetryAsync(() => SendAsync<JobActivationResult>(HttpMethod.Post, path, body, ct), "activateJobs", false, ct);
     }
 
@@ -4086,16 +4087,9 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<ResourceResult> GetResourceAsync(ResourceKey resourceKey, ConsistencyOptions<ResourceResult>? consistency = null, CancellationToken ct = default)
+    public async Task<ResourceResult> GetResourceAsync(ResourceKey resourceKey, CancellationToken ct = default)
     {
         var path = $"/resources/{Uri.EscapeDataString(resourceKey.ToString()!)}";
-        if (consistency != null && consistency.WaitUpToMs > 0)
-        {
-            return await EventualPoller.PollAsync("getResource", true,
-                () => InvokeWithRetryAsync(() => SendAsync<ResourceResult>(HttpMethod.Get, path, null, ct), "getResource", false, ct),
-                consistency!, _logger, ct);
-        }
-
         return await InvokeWithRetryAsync(() => SendAsync<ResourceResult>(HttpMethod.Get, path, null, ct), "getResource", false, ct);
     }
 
@@ -4132,16 +4126,9 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<object> GetResourceContentAsync(ResourceKey resourceKey, ConsistencyOptions<object>? consistency = null, CancellationToken ct = default)
+    public async Task<object> GetResourceContentAsync(ResourceKey resourceKey, CancellationToken ct = default)
     {
         var path = $"/resources/{Uri.EscapeDataString(resourceKey.ToString()!)}/content";
-        if (consistency != null && consistency.WaitUpToMs > 0)
-        {
-            return await EventualPoller.PollAsync("getResourceContent", true,
-                () => InvokeWithRetryAsync(() => SendAsync<object>(HttpMethod.Get, path, null, ct), "getResourceContent", false, ct),
-                consistency!, _logger, ct);
-        }
-
         return await InvokeWithRetryAsync(() => SendAsync<object>(HttpMethod.Get, path, null, ct), "getResourceContent", false, ct);
     }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -10002,7 +10002,7 @@ public sealed class IntegerFilterProperty
 /// <summary>
 /// JobActivationRequest
 /// </summary>
-public sealed class JobActivationRequest
+public sealed class JobActivationRequest : global::Camunda.Orchestration.Sdk.ITenantIdsSettable
 {
     /// <summary>
     /// The job type, as defined in the BPMN process (e.g. &lt;zeebe:taskDefinition type=&quot;payment-service&quot; /&gt;)
@@ -10054,6 +10054,13 @@ public sealed class JobActivationRequest
     /// </summary>
     [JsonPropertyName("tenantFilter")]
     public TenantFilterEnum? TenantFilter { get; set; }
+
+    /// <inheritdoc />
+    public void SetDefaultTenantIds(string tenantId)
+    {
+        if (TenantIds == null || TenantIds.Count == 0)
+            TenantIds = new List<TenantId> { global::Camunda.Orchestration.Sdk.TenantId.AssumeExists(tenantId) };
+    }
 
 }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:6d0560fde009abd591d2bf84c727edc92340880af0b54a90093ed40ebb97f973";
+    public const string SpecHash = "sha256:a61f25c6e0051f89cac9ea6a6e6551887f83cf1fd803648ad69cae50dc683465";
 }

--- a/src/Camunda.Orchestration.Sdk/Runtime/ITenantIdsSettable.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ITenantIdsSettable.cs
@@ -1,0 +1,17 @@
+namespace Camunda.Orchestration.Sdk;
+
+/// <summary>
+/// Implemented by request body types that have an optional <c>tenantIds</c>
+/// array property (e.g. <see cref="JobActivationRequest"/>). The SDK uses
+/// this to inject <c>[DefaultTenantId]</c> when the caller does not supply
+/// a tenant list explicitly. Mirrors <see cref="ITenantIdSettable"/> for
+/// the plural array shape.
+/// </summary>
+public interface ITenantIdsSettable
+{
+    /// <summary>
+    /// Sets the tenant ID list to <c>[tenantId]</c> if it has not already
+    /// been set (or is empty) by the caller.
+    /// </summary>
+    void SetDefaultTenantIds(string tenantId);
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
@@ -215,7 +215,7 @@ public class ActivateJobsDefaultTenantIdsTests : IDisposable
                     var (resolved, refName) = Resolve(schema, schemas);
                     if (resolved == null)
                         continue;
-                    if (!HasOptionalTenantIdsArray(resolved))
+                    if (!HasOptionalTenantIdsArrayInAnyVariant(resolved, schemas))
                         continue;
                     // For $ref bodies the SDK type is the referenced schema name.
                     // For inline bodies the generator names the class
@@ -253,18 +253,68 @@ public class ActivateJobsDefaultTenantIdsTests : IDisposable
         return (obj, null);
     }
 
-    private static bool HasOptionalTenantIdsArray(JsonObject schema)
+    /// <summary>
+    /// True if <paramref name="schema"/> (or every variant in a
+    /// <c>oneOf</c>/<c>anyOf</c>) has an optional <c>tenantIds: array</c>
+    /// property. Mirrors the generator's <c>HasOptionalTenantIdsArrayInAnyVariant</c>
+    /// detection so the structural guard catches the same defect class the
+    /// generator handles.
+    /// </summary>
+    private static bool HasOptionalTenantIdsArrayInAnyVariant(JsonObject schema, JsonObject schemas)
     {
-        if (schema["type"]?.GetValue<string>() != "object")
+        var variants = (schema["oneOf"] as JsonArray) ?? (schema["anyOf"] as JsonArray);
+        if (variants is { Count: > 0 })
+        {
+            foreach (var v in variants)
+            {
+                var (resolved, _) = Resolve(v, schemas);
+                if (resolved == null || !HasOptionalTenantIdsArray(resolved, schemas))
+                    return false;
+            }
+            return true;
+        }
+        return HasOptionalTenantIdsArray(schema, schemas);
+    }
+
+    private static bool HasOptionalTenantIdsArray(JsonObject schema, JsonObject schemas)
+    {
+        // Merge own properties/required with allOf fragments, resolving
+        // `allOf: [{$ref: ...}]` against the schemas map. Mirrors the
+        // generator's HasOptionalTenantIdsArrayDirect.
+        var properties = new Dictionary<string, JsonObject>(StringComparer.Ordinal);
+        var required = new HashSet<string>(StringComparer.Ordinal);
+
+        if (schema["properties"] is JsonObject ownProps)
+            foreach (var (k, v) in ownProps)
+                if (v is JsonObject vObj)
+                    properties.TryAdd(k, vObj);
+        if (schema["required"] is JsonArray ownReq)
+            foreach (var n in ownReq)
+                if (n?.GetValue<string>() is string s)
+                    required.Add(s);
+
+        if (schema["allOf"] is JsonArray allOf)
+        {
+            foreach (var fragment in allOf)
+            {
+                if (fragment is not JsonObject fragObj)
+                    continue;
+                var (resolved, _) = Resolve(fragment, schemas);
+                var target = resolved ?? fragObj;
+                if (target["properties"] is JsonObject tProps)
+                    foreach (var (k, v) in tProps)
+                        if (v is JsonObject vObj)
+                            properties.TryAdd(k, vObj);
+                if (target["required"] is JsonArray tReq)
+                    foreach (var n in tReq)
+                        if (n?.GetValue<string>() is string s)
+                            required.Add(s);
+            }
+        }
+
+        if (!properties.TryGetValue("tenantIds", out var tenantIds))
             return false;
-        var props = schema["properties"] as JsonObject;
-        if (props == null)
-            return false;
-        var tenantIds = props["tenantIds"] as JsonObject;
-        if (tenantIds == null)
-            return false;
-        var required = schema["required"] as JsonArray;
-        if (required != null && required.Any(n => n?.GetValue<string>() == "tenantIds"))
+        if (required.Contains("tenantIds"))
             return false;
         return tenantIds["type"]?.GetValue<string>() == "array";
     }

--- a/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Camunda.Orchestration.Sdk.Generator;
 
 namespace Camunda.Orchestration.Sdk.Tests;
 
@@ -163,7 +164,7 @@ public class ActivateJobsDefaultTenantIdsTests : IDisposable
         var missing = new List<string>();
         foreach (var schemaName in matches)
         {
-            var typeName = $"Camunda.Orchestration.Sdk.{SanitizeTypeName(schemaName)}";
+            var typeName = $"Camunda.Orchestration.Sdk.{CSharpClientGenerator.SanitizeTypeName(schemaName)}";
             var t = sdkAssembly.GetType(typeName);
             Assert.NotNull(t);
             if (!iface!.IsAssignableFrom(t))
@@ -318,9 +319,6 @@ public class ActivateJobsDefaultTenantIdsTests : IDisposable
             return false;
         return tenantIds["type"]?.GetValue<string>() == "array";
     }
-
-    private static string SanitizeTypeName(string name) =>
-        name.Replace("XML", "Xml").Replace("-", "").Replace(".", "").Replace("$", "").Replace(" ", "");
 
     public void Dispose()
     {

--- a/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
@@ -145,12 +145,12 @@ public class ActivateJobsDefaultTenantIdsTests : IDisposable
     public void EveryRequestSchemaWithOptionalTenantIdsArray_ImplementsITenantIdsSettable()
     {
         // Class-scoped guard: scan the bundled spec for any operation whose
-        // request body schema has an optional `tenantIds: array` property and
-        // assert the corresponding generated class implements ITenantIdsSettable.
-        // Today only JobActivationRequest matches; this guard prevents the same
-        // defect class from recurring in a future sibling schema.
+        // request body schema (whether $ref'd or inline) has an optional
+        // `tenantIds: array` property and assert the corresponding generated
+        // class implements ITenantIdsSettable. Today only JobActivationRequest
+        // matches; this guard prevents the same defect class from recurring in
+        // a future sibling schema.
         var spec = LoadBundledSpec();
-        var schemas = spec["components"]!["schemas"]!.AsObject();
 
         var matches = FindRequestSchemasWithOptionalTenantIdsArray(spec);
 
@@ -204,6 +204,7 @@ public class ActivateJobsDefaultTenantIdsTests : IDisposable
                 var content = rb?["content"] as JsonObject;
                 if (content == null)
                     continue;
+                var operationId = op["operationId"]?.GetValue<string>();
                 foreach (var (ct, mt) in content)
                 {
                     if (!ct.Contains("json", StringComparison.OrdinalIgnoreCase))
@@ -212,15 +213,30 @@ public class ActivateJobsDefaultTenantIdsTests : IDisposable
                         continue;
                     var schema = mtObj["schema"];
                     var (resolved, refName) = Resolve(schema, schemas);
-                    if (resolved == null || refName == null)
+                    if (resolved == null)
                         continue;
-                    if (HasOptionalTenantIdsArray(resolved))
+                    if (!HasOptionalTenantIdsArray(resolved))
+                        continue;
+                    // For $ref bodies the SDK type is the referenced schema name.
+                    // For inline bodies the generator names the class
+                    // `{PascalCase(operationId)}Request` (see GetBodySchemaRef
+                    // / `bodySchemaRef ?? opId + "Request"` in the generator).
+                    if (refName != null)
+                    {
                         result.Add(refName);
+                    }
+                    else if (!string.IsNullOrEmpty(operationId))
+                    {
+                        result.Add(PascalCaseFirst(operationId) + "Request");
+                    }
                 }
             }
         }
         return result.ToList();
     }
+
+    private static string PascalCaseFirst(string s) =>
+        string.IsNullOrEmpty(s) ? s : char.ToUpperInvariant(s[0]) + s[1..];
 
     private static (JsonObject? resolved, string? refName) Resolve(JsonNode? schema, JsonObject schemas)
     {

--- a/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
@@ -228,16 +228,13 @@ public class ActivateJobsDefaultTenantIdsTests : IDisposable
                     }
                     else if (!string.IsNullOrEmpty(operationId))
                     {
-                        result.Add(PascalCaseFirst(operationId) + "Request");
+                        result.Add(CSharpClientGenerator.SanitizeOperationId(operationId) + "Request");
                     }
                 }
             }
         }
         return result.ToList();
     }
-
-    private static string PascalCaseFirst(string s) =>
-        string.IsNullOrEmpty(s) ? s : char.ToUpperInvariant(s[0]) + s[1..];
 
     private static (JsonObject? resolved, string? refName) Resolve(JsonNode? schema, JsonObject schemas)
     {

--- a/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
@@ -1,0 +1,265 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Regression for camunda/orchestration-cluster-api-csharp#123 — the
+/// `CAMUNDA_DEFAULT_TENANT_ID` (singular) value was not propagated to
+/// `ActivateJobsAsync` because the generator's tenant-default injector
+/// (`ITenantIdSettable`) only handled the singular `tenantId` body
+/// property. `JobActivationRequest` exposes the plural `TenantIds`
+/// (`List&lt;TenantId&gt;`), so workers using only the default-tenant env
+/// var silently polled without `tenantIds` and missed jobs in
+/// multi-tenant setups. Mirrors orchestration-cluster-api-js#170 / PR #171.
+///
+/// Class-of-defect: any request body schema with an optional
+/// `tenantIds: array` property must, when the caller omits it, default to
+/// `[_config.DefaultTenantId]`. The structural test scans the bundled
+/// spec for every operation matching that shape so the same defect cannot
+/// recur in a sibling operation without being caught.
+/// </summary>
+public class ActivateJobsDefaultTenantIdsTests : IDisposable
+{
+    private static readonly string[] DefaultTenantIdSentinel = new[] { "<default>" };
+    private static readonly string[] CustomTenantSingle = new[] { "tenant-alpha" };
+    private static readonly string[] ExplicitTenantPair = new[] { "tenant-beta", "tenant-gamma" };
+
+    private readonly CamundaClient _client;
+    private readonly CamundaClient _clientCustomTenant;
+    private readonly MockHttpMessageHandler _handler;
+    private readonly MockHttpMessageHandler _handlerCustom;
+
+    public ActivateJobsDefaultTenantIdsTests()
+    {
+        _handler = new MockHttpMessageHandler();
+        _client = new CamundaClient(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            },
+            HttpMessageHandler = _handler,
+        });
+
+        _handlerCustom = new MockHttpMessageHandler();
+        _clientCustomTenant = new CamundaClient(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+                ["CAMUNDA_DEFAULT_TENANT_ID"] = "tenant-alpha",
+            },
+            HttpMessageHandler = _handlerCustom,
+        });
+    }
+
+    [Fact]
+    public async Task ActivateJobs_InjectsDefaultTenantIdSentinel_WhenOmitted()
+    {
+        // ConfigurationHydrator defaults DefaultTenantId to "<default>" when
+        // CAMUNDA_DEFAULT_TENANT_ID is not set (matches the singular tenantId
+        // injection semantics already exercised by TenantEnrichmentTests).
+        string? capturedBody = null;
+        _handler.Enqueue(async req =>
+        {
+            capturedBody = await req.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"jobs\":[]}", System.Text.Encoding.UTF8, "application/json"),
+            };
+        });
+
+        await _client.ActivateJobsAsync(new JobActivationRequest
+        {
+            Type = "demo-task",
+            Timeout = 30_000,
+            MaxJobsToActivate = 1,
+        });
+
+        Assert.NotNull(capturedBody);
+        var doc = JsonDocument.Parse(capturedBody!);
+        var tenantIds = doc.RootElement.GetProperty("tenantIds").EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Equal(DefaultTenantIdSentinel, tenantIds);
+    }
+
+    [Fact]
+    public async Task ActivateJobs_UsesCustomDefaultTenantId_WhenConfigured()
+    {
+        string? capturedBody = null;
+        _handlerCustom.Enqueue(async req =>
+        {
+            capturedBody = await req.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"jobs\":[]}", System.Text.Encoding.UTF8, "application/json"),
+            };
+        });
+
+        await _clientCustomTenant.ActivateJobsAsync(new JobActivationRequest
+        {
+            Type = "demo-task",
+            Timeout = 30_000,
+            MaxJobsToActivate = 1,
+        });
+
+        Assert.NotNull(capturedBody);
+        var doc = JsonDocument.Parse(capturedBody!);
+        var tenantIds = doc.RootElement.GetProperty("tenantIds").EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Equal(CustomTenantSingle, tenantIds);
+    }
+
+    [Fact]
+    public async Task ActivateJobs_PreservesExplicitTenantIds()
+    {
+        string? capturedBody = null;
+        _handlerCustom.Enqueue(async req =>
+        {
+            capturedBody = await req.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"jobs\":[]}", System.Text.Encoding.UTF8, "application/json"),
+            };
+        });
+
+        await _clientCustomTenant.ActivateJobsAsync(new JobActivationRequest
+        {
+            Type = "demo-task",
+            Timeout = 30_000,
+            MaxJobsToActivate = 1,
+            TenantIds = new List<TenantId>
+            {
+                TenantId.AssumeExists("tenant-beta"),
+                TenantId.AssumeExists("tenant-gamma"),
+            },
+        });
+
+        Assert.NotNull(capturedBody);
+        var doc = JsonDocument.Parse(capturedBody!);
+        var tenantIds = doc.RootElement.GetProperty("tenantIds").EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Equal(ExplicitTenantPair, tenantIds);
+    }
+
+    [Fact]
+    public void EveryRequestSchemaWithOptionalTenantIdsArray_ImplementsITenantIdsSettable()
+    {
+        // Class-scoped guard: scan the bundled spec for any operation whose
+        // request body schema has an optional `tenantIds: array` property and
+        // assert the corresponding generated class implements ITenantIdsSettable.
+        // Today only JobActivationRequest matches; this guard prevents the same
+        // defect class from recurring in a future sibling schema.
+        var spec = LoadBundledSpec();
+        var schemas = spec["components"]!["schemas"]!.AsObject();
+
+        var matches = FindRequestSchemasWithOptionalTenantIdsArray(spec);
+
+        Assert.Contains("JobActivationRequest", matches); // Sanity: upstream spec changed if this fails.
+
+        var sdkAssembly = typeof(CamundaClient).Assembly;
+        var iface = sdkAssembly.GetType("Camunda.Orchestration.Sdk.ITenantIdsSettable");
+        Assert.NotNull(iface);
+
+        var missing = new List<string>();
+        foreach (var schemaName in matches)
+        {
+            var typeName = $"Camunda.Orchestration.Sdk.{SanitizeTypeName(schemaName)}";
+            var t = sdkAssembly.GetType(typeName);
+            Assert.NotNull(t);
+            if (!iface!.IsAssignableFrom(t))
+                missing.Add(schemaName);
+        }
+        Assert.Empty(missing);
+    }
+
+    private static JsonNode LoadBundledSpec()
+    {
+        // The test process runs from test/.../bin/Debug/net8.0/. Walk up to repo root.
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "external-spec", "bundled", "rest-api.bundle.json");
+            if (File.Exists(candidate))
+                return JsonNode.Parse(File.ReadAllText(candidate))!;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException("Could not locate external-spec/bundled/rest-api.bundle.json");
+    }
+
+    private static List<string> FindRequestSchemasWithOptionalTenantIdsArray(JsonNode spec)
+    {
+        var result = new SortedSet<string>(StringComparer.Ordinal);
+        var schemas = spec["components"]!["schemas"]!.AsObject();
+        var paths = spec["paths"]!.AsObject();
+
+        foreach (var (_, pathItem) in paths)
+        {
+            if (pathItem is not JsonObject pathObj)
+                continue;
+            foreach (var (_, opNode) in pathObj)
+            {
+                if (opNode is not JsonObject op)
+                    continue;
+                var rb = op["requestBody"] as JsonObject;
+                var content = rb?["content"] as JsonObject;
+                if (content == null)
+                    continue;
+                foreach (var (ct, mt) in content)
+                {
+                    if (!ct.Contains("json", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    if (mt is not JsonObject mtObj)
+                        continue;
+                    var schema = mtObj["schema"];
+                    var (resolved, refName) = Resolve(schema, schemas);
+                    if (resolved == null || refName == null)
+                        continue;
+                    if (HasOptionalTenantIdsArray(resolved))
+                        result.Add(refName);
+                }
+            }
+        }
+        return result.ToList();
+    }
+
+    private static (JsonObject? resolved, string? refName) Resolve(JsonNode? schema, JsonObject schemas)
+    {
+        if (schema is not JsonObject obj)
+            return (null, null);
+        var dollarRef = obj["$ref"]?.GetValue<string>();
+        if (dollarRef != null)
+        {
+            var name = dollarRef.Split('/').Last();
+            if (schemas[name] is JsonObject resolved)
+                return (resolved, name);
+            return (null, null);
+        }
+        return (obj, null);
+    }
+
+    private static bool HasOptionalTenantIdsArray(JsonObject schema)
+    {
+        if (schema["type"]?.GetValue<string>() != "object")
+            return false;
+        var props = schema["properties"] as JsonObject;
+        if (props == null)
+            return false;
+        var tenantIds = props["tenantIds"] as JsonObject;
+        if (tenantIds == null)
+            return false;
+        var required = schema["required"] as JsonArray;
+        if (required != null && required.Any(n => n?.GetValue<string>() == "tenantIds"))
+            return false;
+        return tenantIds["type"]?.GetValue<string>() == "array";
+    }
+
+    private static string SanitizeTypeName(string name) =>
+        name.Replace("XML", "Xml").Replace("-", "").Replace(".", "").Replace("$", "").Replace(" ", "");
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _clientCustomTenant.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
Fixes #123.

## Problem

The generator's `ITenantIdSettable` injector only handled the singular `tenantId` body property. `JobActivationRequest` exposes the plural `TenantIds` (`List<TenantId>`), so workers using only `CAMUNDA_DEFAULT_TENANT_ID` silently polled without `tenantIds` and missed jobs in multi-tenant setups. The generated call site

```csharp
if (body is ITenantIdSettable __t) __t.SetDefaultTenantId(_config.DefaultTenantId);
```

was a no-op for `ActivateJobsAsync`.

This is the C# counterpart of [orchestration-cluster-api-js#170](https://github.com/camunda/orchestration-cluster-api-js/issues/170) (fixed in [#171](https://github.com/camunda/orchestration-cluster-api-js/pull/171)).

## Fix

Extend the generator to detect operations whose request body has an optional `tenantIds: array` property and emit a parallel default-tenant injection. Per the issue's design clarification: when `CAMUNDA_DEFAULT_TENANT_ID` is set and no plural tenant configuration exists, the singular value is the fall-through default — wrapped into a single-element list at injection time.

- Add `ITenantIdsSettable` runtime interface (plural counterpart of `ITenantIdSettable`) with `SetDefaultTenantIds(string)`.
- Generator: detect the optional plural shape (including `oneOf` / `anyOf` variants and `allOf` composition), emit the interface on the generated class, and inject the call at the operation call site.
- Schema scan is self-contained in the generator — no `camunda-schema-bundler` release required (mirrors the JS hook approach).

Generated emit:

```csharp
public sealed class JobActivationRequest : global::Camunda.Orchestration.Sdk.ITenantIdsSettable
{
    // …
    public List<TenantId>? TenantIds { get; set; }
    // …
    public void SetDefaultTenantIds(string tenantId)
    {
        if (TenantIds == null || TenantIds.Count == 0)
            TenantIds = new List<TenantId> { global::Camunda.Orchestration.Sdk.TenantId.AssumeExists(tenantId) };
    }
}
```

```csharp
public async Task<JobActivationResult> ActivateJobsAsync(JobActivationRequest body, CancellationToken ct = default)
{
    var path = $"/jobs/activation";
    if (body is ITenantIdsSettable __ts) __ts.SetDefaultTenantIds(_config.DefaultTenantId);
    return await InvokeWithRetryAsync(() => SendAsync<JobActivationResult>(HttpMethod.Post, path, body, ct), "activateJobs", false, ct);
}
```

Explicit `TenantIds` from the caller are preserved.

## Red/green discipline

`test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs` follows the class-of-defect rule:

- **Class-scoped guard** (`EveryRequestSchemaWithOptionalTenantIdsArray_ImplementsITenantIdsSettable`) scans the bundled spec for any operation whose request body schema has an optional `tenantIds[]` field and asserts the corresponding generated class implements `ITenantIdsSettable`. Today only `JobActivationRequest` matches — guard prevents the same defect class from recurring in a future sibling schema.
- **Behavioural tests** cover injection on omit (`<default>` sentinel — matches the singular-`tenantId` runtime semantics), custom `CAMUNDA_DEFAULT_TENANT_ID`, and preservation of explicit `TenantIds`.

Tests were authored failing-first; behavioural and structural cases failed against the unmodified generator and pass after the fix.

## Commits

Per AGENTS.md "separate generator changes from regenerated output":

1. `fix(gen): apply CAMUNDA_DEFAULT_TENANT_ID to ActivateJobsAsync tenantIds (#123)` — generator + runtime interface + tests, no `Generated/*` changes.
2. `chore(gen): regenerate Generated/ for #123 ITenantIdsSettable injection` — `Generated/*` output. Includes pre-existing `SpecHash` refresh and `GetResourceAsync`/`GetResourceContentAsync` overload removal that were already drifted between the committed `spec-metadata.json` and the previously regenerated outputs on `main`; captured here as part of a clean regen.

## Related

- JS SDK: [#170](https://github.com/camunda/orchestration-cluster-api-js/issues/170) / [#171](https://github.com/camunda/orchestration-cluster-api-js/pull/171)
- Python SDK: [orchestration-cluster-api-python#120](https://github.com/camunda/orchestration-cluster-api-python/issues/120)
