### PR TITLE
docs: add searchResources example

### DIFF
--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -973,6 +973,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.SearchResourcesAsync(Camunda.Orchestration.Sdk.ResourceSearchQuery,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.ResourceSearchQueryResult},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Admin.cs#SearchResources)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.GetRoleAsync(System.String,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.RoleResult},System.Threading.CancellationToken)
 example:
 - *content

--- a/examples/Admin.cs
+++ b/examples/Admin.cs
@@ -364,6 +364,22 @@ public static class AdminExamples
     // </GetResourceContent>
     #endregion GetResourceContent
 
+    #region SearchResources
+
+    // <SearchResources>
+    public static async Task SearchResourcesExample()
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.SearchResourcesAsync(new ResourceSearchQuery());
+        foreach (var resource in result.Items!)
+        {
+            Console.WriteLine($"Resource: {resource.ResourceName}");
+        }
+    }
+    // </SearchResources>
+    #endregion SearchResources
+
     #region GetUsageMetrics
 
     // <GetUsageMetrics>

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -179,6 +179,13 @@
       "label": "Get resource content"
     }
   ],
+  "searchResources": [
+    {
+      "file": "Admin.cs",
+      "region": "SearchResources",
+      "label": "Search resources"
+    }
+  ],
   "evaluateDecision": [
     {
       "file": "Decision.cs",


### PR DESCRIPTION
## Summary

Adds the missing `searchResources` example to fix the `check-example-coverage` CI gate.

The upstream spec added `POST /resources/search` (`searchResources` operationId). CI regenerates the SDK from the latest upstream spec before running coverage checks, so the generated types (`ResourceSearchQuery`, `SearchResourcesAsync`) will exist when the check runs.

### Changes

- Added `SearchResources` example region in `examples/Admin.cs`
- Added `searchResources` entry in `examples/operation-map.json`