### PR TITLE
feat(worker): backport TenantIds/TenantId on JobWorkerConfig to stable/9

### DIFF
--- a/src/Camunda.Orchestration.Sdk/CamundaClient.Workers.cs
+++ b/src/Camunda.Orchestration.Sdk/CamundaClient.Workers.cs
@@ -37,6 +37,8 @@ public partial class CamundaClient : IAsyncDisposable
             StartupJitterMaxSeconds = config.StartupJitterMaxSeconds > 0
                 ? config.StartupJitterMaxSeconds
                 : defaults?.StartupJitterMaxSeconds ?? 0,
+            TenantIds = config.TenantIds,
+            TenantId = config.TenantId,
         };
         var worker = new JobWorker(this, merged, handler, _loggerFactory, _jsonOptions);
         _workers.Add(worker);

--- a/src/Camunda.Orchestration.Sdk/Runtime/JobWorker.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/JobWorker.cs
@@ -86,6 +86,26 @@ public sealed class JobWorkerConfig
     /// <c>0</c> (the default) means no delay.
     /// </summary>
     public double StartupJitterMaxSeconds { get; init; }
+
+    /// <summary>
+    /// Restrict job activation to the given tenant IDs (multi-tenant setups).
+    /// Cannot be combined with <see cref="TenantId"/> — setting both is
+    /// rejected with <see cref="ArgumentException"/>.
+    ///
+    /// <para>If neither <see cref="TenantIds"/> nor <see cref="TenantId"/> is set
+    /// (or <see cref="TenantIds"/> is empty), the activation request falls back
+    /// to <c>[CamundaConfig.DefaultTenantId]</c> (which itself defaults to
+    /// <c>"&lt;default&gt;"</c> and can be overridden via the
+    /// <c>CAMUNDA_DEFAULT_TENANT_ID</c> environment variable).</para>
+    /// </summary>
+    public IReadOnlyList<string>? TenantIds { get; init; }
+
+    /// <summary>
+    /// Convenience for the common single-tenant case. Equivalent to setting
+    /// <see cref="TenantIds"/> to <c>[TenantId]</c>. Cannot be combined with
+    /// <see cref="TenantIds"/>.
+    /// </summary>
+    public string? TenantId { get; init; }
 }
 
 /// <summary>
@@ -195,6 +215,7 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly long _jobTimeoutMs;
     private readonly int _maxConcurrentJobs;
+    private readonly List<TenantId>? _resolvedTenantIds;
 
     private CancellationTokenSource? _cts;
     private Task? _pollTask;
@@ -220,6 +241,18 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
             throw new ArgumentException(
                 "MaxConcurrentJobs is required: set it on JobWorkerConfig, via CAMUNDA_WORKER_MAX_CONCURRENT_JOBS environment variable, or accept the default (10).",
                 nameof(config));
+
+        if (config.TenantIds is not null && !string.IsNullOrEmpty(config.TenantId))
+            throw new ArgumentException(
+                "JobWorkerConfig.TenantIds and JobWorkerConfig.TenantId are mutually exclusive — set one, not both.",
+                nameof(config));
+
+        if (config.TenantId is not null && string.IsNullOrWhiteSpace(config.TenantId))
+            throw new ArgumentException(
+                "JobWorkerConfig.TenantId must not be empty or whitespace — omit it (null) to use the default tenant.",
+                nameof(config));
+
+        _resolvedTenantIds = ResolveTenantIds(config);
 
         _jobTimeoutMs = config.JobTimeoutMs.Value;
         _maxConcurrentJobs = config.MaxConcurrentJobs.Value;
@@ -339,6 +372,7 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
                         MaxJobsToActivate = capacity,
                         FetchVariable = _config.FetchVariables,
                         RequestTimeout = _config.PollTimeoutMs ?? 0,
+                        TenantIds = _resolvedTenantIds,
                     }, ct: ct).ConfigureAwait(false);
 
                     if (response?.Jobs == null || response.Jobs.Count == 0)
@@ -463,6 +497,24 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
             _logger.LogError(ex, "JobWorker '{Name}': failed to throw BPMN error for {JobKey}",
                 _name, job.JobKey);
         }
+    }
+
+    private static List<TenantId>? ResolveTenantIds(JobWorkerConfig config)
+    {
+        if (config.TenantIds is { Count: > 0 } list)
+        {
+            var resolved = new List<TenantId>(list.Count);
+            foreach (var id in list)
+                resolved.Add(global::Camunda.Orchestration.Sdk.TenantId.AssumeExists(id));
+            return resolved;
+        }
+
+        if (config.TenantId is not null)
+            return new List<TenantId> { global::Camunda.Orchestration.Sdk.TenantId.AssumeExists(config.TenantId) };
+
+        // Leave null so the generated ActivateJobsAsync injects [DefaultTenantId]
+        // via ITenantIdsSettable.SetDefaultTenantIds.
+        return null;
     }
 
     private ActivatedJobResult? DeserializeJob(object rawJob)

--- a/test/Camunda.Orchestration.Sdk.Tests/JobWorkerTenantTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/JobWorkerTenantTests.cs
@@ -1,0 +1,278 @@
+using System.Net;
+using System.Text.Json;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Regression for camunda/orchestration-cluster-api-csharp#120 — workers
+/// created via <c>CamundaClient.CreateJobWorker</c> must support
+/// per-worker <c>TenantIds</c> / <c>TenantId</c> on
+/// <see cref="JobWorkerConfig"/>, and must fall back to the configured
+/// <c>DefaultTenantId</c> when neither is set explicitly.
+///
+/// <para>Class-of-defect scope: every public <c>CreateJobWorker</c>
+/// overload routes through the same merged config and the same activation
+/// poll body, so each tenant-resolution path (default, singular, plural,
+/// explicit-overrides-default) is exercised end-to-end against the
+/// activation HTTP request body.</para>
+/// </summary>
+public class JobWorkerTenantTests
+{
+    private static readonly string[] DefaultSentinel = new[] { "<default>" };
+    private static readonly string[] AcmeOnly = new[] { "acme" };
+    private static readonly string[] AlphaOnly = new[] { "alpha" };
+    private static readonly string[] BetaGamma = new[] { "beta", "gamma" };
+    private static readonly string[] Explicit12 = new[] { "explicit-1", "explicit-2" };
+    private static readonly string[] BetaOnly = new[] { "beta" };
+    private static readonly string[] FuncTenantOnly = new[] { "func-tenant" };
+
+    private static async Task<List<string>> RunOnePollAndCaptureTenantIdsAsync(
+        Dictionary<string, string> config,
+        string? tenantId = null,
+        IReadOnlyList<string>? tenantIds = null)
+    {
+        var handler = new MockHttpMessageHandler();
+        var firstRequestBody = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        handler.Enqueue(async req =>
+        {
+            var body = await req.Content!.ReadAsStringAsync();
+            firstRequestBody.TrySetResult(body);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"jobs\":[]}", System.Text.Encoding.UTF8, "application/json"),
+            };
+        });
+        // Subsequent polls (if the loop spins faster than we tear it down) get an empty response.
+        for (var i = 0; i < 8; i++)
+            handler.Enqueue(HttpStatusCode.OK, "{\"jobs\":[]}");
+
+        using var client = new CamundaClient(new CamundaOptions
+        {
+            Config = config,
+            HttpMessageHandler = handler,
+        });
+
+        var workerConfig = new JobWorkerConfig
+        {
+            JobType = "tenant-test",
+            JobTimeoutMs = 30_000,
+            MaxConcurrentJobs = 1,
+            AutoStart = false,
+            TenantId = tenantId,
+            TenantIds = tenantIds,
+        };
+
+        var worker = client.CreateJobWorker(workerConfig, (_, _) => Task.FromResult<object?>(null));
+        worker.Start();
+
+        var capturedJson = await firstRequestBody.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(TimeSpan.FromSeconds(1));
+
+        using var doc = JsonDocument.Parse(capturedJson);
+        if (!doc.RootElement.TryGetProperty("tenantIds", out var arr))
+            return new List<string>();
+        return arr.EnumerateArray().Select(e => e.GetString() ?? "").ToList();
+    }
+
+    [Fact]
+    public async Task PollLoop_FallsBackTo_DefaultTenantIdSentinel_WhenNothingConfigured()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+        });
+
+        Assert.Equal(DefaultSentinel, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_UsesEnvDefaultTenantId_WhenWorkerOmitsTenantConfig()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_DEFAULT_TENANT_ID"] = "acme",
+        });
+
+        Assert.Equal(AcmeOnly, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_UsesSingularTenantId_FromWorkerConfig()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+        }, tenantId: "alpha");
+
+        Assert.Equal(AlphaOnly, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_UsesPluralTenantIds_FromWorkerConfig()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+        }, tenantIds: BetaGamma);
+
+        Assert.Equal(BetaGamma, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_ExplicitTenantOverrides_EnvDefault()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_DEFAULT_TENANT_ID"] = "ignored-default",
+        }, tenantIds: Explicit12);
+
+        Assert.Equal(Explicit12, tenantIds);
+    }
+
+    [Fact]
+    public void CreateJobWorker_RejectsBoth_TenantId_And_TenantIds()
+    {
+        using var client = new CamundaClient(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            },
+            HttpMessageHandler = new MockHttpMessageHandler(),
+        });
+
+        var config = new JobWorkerConfig
+        {
+            JobType = "conflict",
+            JobTimeoutMs = 30_000,
+            AutoStart = false,
+            TenantId = "alpha",
+            TenantIds = BetaOnly,
+        };
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => client.CreateJobWorker(config, (_, _) => Task.FromResult<object?>(null)));
+        Assert.Contains("mutually exclusive", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PollLoop_EmptyTenantIds_FallsBackToDefault()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+        }, tenantIds: Array.Empty<string>());
+
+        Assert.Equal(DefaultSentinel, tenantIds);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void CreateJobWorker_RejectsEmptyOrWhitespace_TenantId(string badTenantId)
+    {
+        using var client = new CamundaClient(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            },
+            HttpMessageHandler = new MockHttpMessageHandler(),
+        });
+
+        var config = new JobWorkerConfig
+        {
+            JobType = "empty-tenant",
+            JobTimeoutMs = 30_000,
+            AutoStart = false,
+            TenantId = badTenantId,
+        };
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => client.CreateJobWorker(config, (_, _) => Task.FromResult<object?>(null)));
+        Assert.Contains("must not be empty or whitespace", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData("bad tenant!")]
+    public void CreateJobWorker_RejectsMalformedEntries_InTenantIds(string badEntry)
+    {
+        using var client = new CamundaClient(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            },
+            HttpMessageHandler = new MockHttpMessageHandler(),
+        });
+
+        var config = new JobWorkerConfig
+        {
+            JobType = "malformed-tenants",
+            JobTimeoutMs = 30_000,
+            AutoStart = false,
+            TenantIds = new[] { "valid-tenant", badEntry },
+        };
+
+        Assert.ThrowsAny<ArgumentException>(
+            () => client.CreateJobWorker(config, (_, _) => Task.FromResult<object?>(null)));
+    }
+
+    /// <summary>
+    /// The <c>Func&lt;ActivatedJob, CancellationToken, Task&gt;</c> overload delegates
+    /// to the primary overload — verify tenant resolution works end-to-end through it.
+    /// </summary>
+    [Fact]
+    public async Task FuncOverload_UsesSingularTenantId()
+    {
+        var handler = new MockHttpMessageHandler();
+        var firstRequestBody = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        handler.Enqueue(async req =>
+        {
+            var body = await req.Content!.ReadAsStringAsync();
+            firstRequestBody.TrySetResult(body);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"jobs\":[]}", System.Text.Encoding.UTF8, "application/json"),
+            };
+        });
+        for (var i = 0; i < 8; i++)
+            handler.Enqueue(HttpStatusCode.OK, "{\"jobs\":[]}");
+
+        using var client = new CamundaClient(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            },
+            HttpMessageHandler = handler,
+        });
+
+        var workerConfig = new JobWorkerConfig
+        {
+            JobType = "func-overload-test",
+            JobTimeoutMs = 30_000,
+            MaxConcurrentJobs = 1,
+            AutoStart = false,
+            TenantId = "func-tenant",
+        };
+
+        // Use the Func<ActivatedJob, CancellationToken, Task> overload
+        var worker = client.CreateJobWorker(workerConfig, (_, _) => Task.CompletedTask);
+        worker.Start();
+
+        var capturedJson = await firstRequestBody.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(TimeSpan.FromSeconds(1));
+
+        using var doc = JsonDocument.Parse(capturedJson);
+        Assert.True(doc.RootElement.TryGetProperty("tenantIds", out var arr));
+        var tenantIds = arr.EnumerateArray().Select(e => e.GetString() ?? "").ToList();
+        Assert.Equal(FuncTenantOnly, tenantIds);
+    }
+}


### PR DESCRIPTION
Backport of #157 to `stable/9`.

Cherry-picked the merge commit from `main`. The only conflict was `PublicApi.shipped.txt` which doesn't exist on `stable/9` — resolved by removing it.

Build and all 13 tenant tests pass on `net10.0`.