### PR TITLE
feat: v10 migration — bundler 2.4.1, spec ref main, branded types, examples

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,140 @@
+# Migration Guide: v9 → v10
+
+This guide covers breaking changes and new features when upgrading from `Camunda.Orchestration.Sdk` v9 (Camunda 8.9) to v10 (Camunda 8.10).
+
+> **Note:** v10 is currently in alpha (`10.0.0-alpha.N` on NuGet). The changes listed here may evolve before the stable v10.0.0 release.
+
+## Package update
+
+```xml
+<!-- Before -->
+<PackageReference Include="Camunda.Orchestration.Sdk" Version="9.*" />
+
+<!-- After -->
+<PackageReference Include="Camunda.Orchestration.Sdk" Version="10.*" />
+```
+
+Or via the CLI:
+
+```bash
+dotnet add package Camunda.Orchestration.Sdk --version "10.*-*"
+```
+
+## Breaking changes
+
+### Type renames (bundler dedup)
+
+The v10 generator uses an upgraded spec bundler that correctly preserves upstream schema names instead of inventing inline names. Several types that were previously generated as standalone classes are now replaced by their canonical upstream equivalents.
+
+If your code references any of the old type names, update them to the new names:
+
+| Removed type (v9) | Replacement (v10) |
+|---|---|
+| `CreateMappingRuleResponse` | `MappingRuleCreateResult` |
+| `GetUserResponse` | `UserResult` |
+| `SearchClientsForGroupRequest` | `GroupClientSearchQueryRequest` |
+| `SearchClientsForGroupResponse` | `GroupClientSearchResult` |
+| `SearchClientsForRoleRequest` | `RoleClientSearchQueryRequest` |
+| `SearchClientsForRoleResponse` | `RoleClientSearchResult` |
+| `SearchClientsForTenantRequest` | `TenantClientSearchQueryRequest` |
+| `SearchClientsForTenantResponse` | `TenantClientSearchResult` |
+| `SearchMappingRuleResponse` | `MappingRuleSearchQueryResult` |
+| `SearchMappingRulesForGroupResponse` | `GroupMappingRuleSearchResult` |
+| `SearchMappingRulesForRoleResponse` | `RoleMappingRuleSearchResult` |
+| `SearchMappingRulesForTenantResponse` | `TenantMappingRuleSearchResult` |
+| `SearchRolesForGroupResponse` | `GroupRoleSearchResult` |
+| `SearchRolesForTenantResponse` | `TenantRoleSearchResult` |
+| `SearchUsersForGroupRequest` | `GroupUserSearchQueryRequest` |
+| `SearchUsersForGroupResponse` | `GroupUserSearchResult` |
+| `SearchUsersForRoleRequest` | `RoleUserSearchQueryRequest` |
+| `SearchUsersForRoleResponse` | `RoleUserSearchResult` |
+| `SearchUsersForTenantRequest` | `TenantUserSearchQueryRequest` |
+| `SearchUsersForTenantResponse` | `TenantUserSearchResult` |
+| `SearchUsersResponse` | `UserSearchResult` |
+| `SearchUserTaskEffectiveVariablesRequest` | `UserTaskEffectiveVariableSearchQueryRequest` |
+| `SearchUserTaskVariablesRequest` | `UserTaskVariableSearchQueryRequest` |
+| `SearchVariablesRequest` | `VariableSearchQuery` |
+| `UpdateMappingRuleResponse` | `MappingRuleUpdateResult` |
+| `UpdateUserResponse` | `UserUpdateResult` |
+
+The replacement types are structurally identical — only the names change. A find-and-replace across your codebase is sufficient.
+
+### Method signature changes
+
+The following methods have updated parameter and/or return types to match the type renames above:
+
+| Method | Changed parameter / return type |
+|---|---|
+| `CreateMappingRuleAsync` | Returns `MappingRuleCreateResult` (was `CreateMappingRuleResponse`) |
+| `UpdateMappingRuleAsync` | Returns `MappingRuleUpdateResult` (was `UpdateMappingRuleResponse`) |
+| `SearchMappingRuleAsync` | Returns `MappingRuleSearchQueryResult` (was `SearchMappingRuleResponse`) |
+| `SearchClientsForGroupAsync` | Takes `GroupClientSearchQueryRequest`, returns `GroupClientSearchResult` |
+| `SearchClientsForRoleAsync` | Takes `RoleClientSearchQueryRequest`, returns `RoleClientSearchResult` |
+| `SearchClientsForTenantAsync` | Takes `TenantClientSearchQueryRequest`, returns `TenantClientSearchResult` |
+| `SearchMappingRulesForGroupAsync` | Returns `GroupMappingRuleSearchResult` |
+| `SearchMappingRulesForRoleAsync` | Returns `RoleMappingRuleSearchResult` |
+| `SearchMappingRulesForTenantAsync` | Returns `TenantMappingRuleSearchResult` |
+| `SearchRolesForGroupAsync` | Returns `GroupRoleSearchResult` |
+| `SearchRolesForTenantAsync` | Returns `TenantRoleSearchResult` |
+| `SearchUsersForGroupAsync` | Takes `GroupUserSearchQueryRequest`, returns `GroupUserSearchResult` |
+| `SearchUsersForRoleAsync` | Takes `RoleUserSearchQueryRequest`, returns `RoleUserSearchResult` |
+| `SearchUsersForTenantAsync` | Takes `TenantUserSearchQueryRequest`, returns `TenantUserSearchResult` |
+| `SearchUserTaskEffectiveVariablesAsync` | Takes `UserTaskEffectiveVariableSearchQueryRequest` (was `SearchUserTaskEffectiveVariablesRequest`) |
+| `SearchUserTaskVariablesAsync` | Takes `UserTaskVariableSearchQueryRequest` (was `SearchUserTaskVariablesRequest`) |
+| `SearchVariablesAsync` | Takes `VariableSearchQuery` (was `SearchVariablesRequest`) |
+| `GetUserAsync` | Returns `UserResult` (was `GetUserResponse`) |
+| `SearchUsersAsync` | Returns `UserSearchResult` (was `SearchUsersResponse`) |
+| `UpdateUserAsync` | Returns `UserUpdateResult` (was `UpdateUserResponse`) |
+
+### Eventual consistency parameter types
+
+`GetResourceAsync` and `GetResourceContentAsync` now accept an optional `ConsistencyOptions` parameter, matching the pattern used by all other eventually-consistent endpoints. If you pass these methods by reference or use them in delegates, you may need to update the signature:
+
+```csharp
+// Before (v9)
+var resource = await client.GetResourceAsync(resourceKey);
+
+// After (v10) — the call is unchanged, but the optional parameter exists
+var resource = await client.GetResourceAsync(resourceKey);
+// Or, with eventual consistency:
+var resource = await client.GetResourceAsync(resourceKey,
+    new ConsistencyOptions<ResourceResult> { WaitUpToMs = 5000 });
+```
+
+## New features
+
+### Resource search
+
+v10 adds a `SearchResourcesAsync` method with full search, filter, and sort support:
+
+```csharp
+var result = await client.SearchResourcesAsync(new ResourceSearchQuery
+{
+    Filter = new ResourceFilter { /* ... */ },
+    Sort = [new ResourceSearchQuerySortRequest { Field = "..." }],
+});
+```
+
+Supporting types: `ResourceSearchQuery`, `ResourceFilter`, `ResourceSearchQueryResult`, `ResourceSearchQuerySortRequest`.
+
+### New filter properties
+
+The following filter properties are now available on existing search filters:
+
+- **`ElementIdFilterProperty`** — filter by element ID on flow node instance searches (`AdvancedElementIdFilter`, `ElementIdExactMatch`).
+- **`ProcessDefinitionIdFilterProperty`** — filter by process definition ID (`AdvancedProcessDefinitionIdFilter`, `ProcessDefinitionIdExactMatch`).
+- **`MessageSubscriptionTypeFilterProperty`** — filter message subscriptions by type (`AdvancedMessageSubscriptionTypeFilter`, `MessageSubscriptionTypeExactMatch`).
+
+### New enum
+
+- **`MessageSubscriptionTypeEnum`** — discriminates message subscription types.
+
+## No changes
+
+The following areas are **unchanged** between v9 and v10:
+
+- **Target framework**: .NET 8.0+
+- **Runtime behavior**: Auth, retry, backpressure, job workers, eventual consistency polling
+- **Configuration**: All `CAMUNDA_*` environment variables and `CamundaOptions` properties
+- **Branded types**: All existing `ICamundaKey` types (`ProcessDefinitionKey`, `UserTaskKey`, etc.) retain the same API. v10 adds new branded types: `GroupId`, `RoleId`, `ClientId`, `MappingRuleId`, `AgentInstanceKey`, `ClusterVariableName`
+- **Enum handling**: `TolerantEnumConverter` continues to handle unknown enum values gracefully

--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -613,6 +613,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.GetAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceKey,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.AgentInstanceResult},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/AgentInstance.cs#GetAgentInstance)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.GetAuditLogAsync(Camunda.Orchestration.Sdk.AuditLogKey,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.AuditLogResult},System.Threading.CancellationToken)
 example:
 - *content
@@ -1240,6 +1250,16 @@ example:
 
 
 [!code-csharp[](../../examples/Admin.cs#SearchAuditLogs)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.SearchAgentInstancesAsync(Camunda.Orchestration.Sdk.AgentInstanceSearchQuery,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.AgentInstanceSearchQueryResult},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/AgentInstance.cs#SearchAgentInstances)]
 
 
 ---

--- a/examples/Admin.cs
+++ b/examples/Admin.cs
@@ -6,11 +6,11 @@ public static class AdminExamples
 {
     #region GetGlobalClusterVariable
     // <GetGlobalClusterVariable>
-    public static async Task GetGlobalClusterVariableExample()
+    public static async Task GetGlobalClusterVariableExample(ClusterVariableName name)
     {
         using var client = CamundaClient.Create();
 
-        var result = await client.GetGlobalClusterVariableAsync("my-variable");
+        var result = await client.GetGlobalClusterVariableAsync(name);
         Console.WriteLine($"Variable: {result.Name} = {result.Value}");
     }
     // </GetGlobalClusterVariable>
@@ -19,14 +19,14 @@ public static class AdminExamples
     #region CreateGlobalClusterVariable
 
     // <CreateGlobalClusterVariable>
-    public static async Task CreateGlobalClusterVariableExample()
+    public static async Task CreateGlobalClusterVariableExample(ClusterVariableName name)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.CreateGlobalClusterVariableAsync(
             new CreateClusterVariableRequest
             {
-                Name = "my-variable",
+                Name = name,
                 Value = "my-value",
             });
 
@@ -38,12 +38,12 @@ public static class AdminExamples
     #region UpdateGlobalClusterVariable
 
     // <UpdateGlobalClusterVariable>
-    public static async Task UpdateGlobalClusterVariableExample()
+    public static async Task UpdateGlobalClusterVariableExample(ClusterVariableName name)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.UpdateGlobalClusterVariableAsync(
-            "my-variable",
+            name,
             new UpdateClusterVariableRequest
             {
                 Value = "updated-value",
@@ -57,11 +57,11 @@ public static class AdminExamples
     #region DeleteGlobalClusterVariable
 
     // <DeleteGlobalClusterVariable>
-    public static async Task DeleteGlobalClusterVariableExample()
+    public static async Task DeleteGlobalClusterVariableExample(ClusterVariableName name)
     {
         using var client = CamundaClient.Create();
 
-        await client.DeleteGlobalClusterVariableAsync("my-variable");
+        await client.DeleteGlobalClusterVariableAsync(name);
     }
     // </DeleteGlobalClusterVariable>
     #endregion DeleteGlobalClusterVariable
@@ -69,13 +69,13 @@ public static class AdminExamples
     #region GetTenantClusterVariable
 
     // <GetTenantClusterVariable>
-    public static async Task GetTenantClusterVariableExample(TenantId tenantId)
+    public static async Task GetTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.GetTenantClusterVariableAsync(
             tenantId,
-            "my-variable");
+            name);
 
         Console.WriteLine($"Variable: {result.Name} = {result.Value}");
     }
@@ -85,7 +85,7 @@ public static class AdminExamples
     #region CreateTenantClusterVariable
 
     // <CreateTenantClusterVariable>
-    public static async Task CreateTenantClusterVariableExample(TenantId tenantId)
+    public static async Task CreateTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     {
         using var client = CamundaClient.Create();
 
@@ -93,7 +93,7 @@ public static class AdminExamples
             tenantId,
             new CreateClusterVariableRequest
             {
-                Name = "my-variable",
+                Name = name,
                 Value = "tenant-value",
             });
 
@@ -105,13 +105,13 @@ public static class AdminExamples
     #region UpdateTenantClusterVariable
 
     // <UpdateTenantClusterVariable>
-    public static async Task UpdateTenantClusterVariableExample(TenantId tenantId)
+    public static async Task UpdateTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.UpdateTenantClusterVariableAsync(
             tenantId,
-            "my-variable",
+            name,
             new UpdateClusterVariableRequest
             {
                 Value = "updated-tenant-value",
@@ -125,13 +125,13 @@ public static class AdminExamples
     #region DeleteTenantClusterVariable
 
     // <DeleteTenantClusterVariable>
-    public static async Task DeleteTenantClusterVariableExample(TenantId tenantId)
+    public static async Task DeleteTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     {
         using var client = CamundaClient.Create();
 
         await client.DeleteTenantClusterVariableAsync(
             tenantId,
-            "my-variable");
+            name);
     }
     // </DeleteTenantClusterVariable>
     #endregion DeleteTenantClusterVariable

--- a/examples/AgentInstance.cs
+++ b/examples/AgentInstance.cs
@@ -1,0 +1,35 @@
+// Compilable usage examples for agent instance operations.
+// These examples are type-checked during build to guard against API regressions.
+using Camunda.Orchestration.Sdk;
+
+public static class AgentInstanceExamples
+{
+    #region GetAgentInstance
+    // <GetAgentInstance>
+    public static async Task GetAgentInstanceExample(AgentInstanceKey agentInstanceKey)
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.GetAgentInstanceAsync(agentInstanceKey);
+        Console.WriteLine($"Agent instance: {result.AgentInstanceKey}, status: {result.Status}");
+    }
+    // </GetAgentInstance>
+    #endregion GetAgentInstance
+
+    #region SearchAgentInstances
+
+    // <SearchAgentInstances>
+    public static async Task SearchAgentInstancesExample()
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.SearchAgentInstancesAsync(new AgentInstanceSearchQuery());
+
+        foreach (var instance in result.Items)
+        {
+            Console.WriteLine($"Agent instance: {instance.AgentInstanceKey}, status: {instance.Status}");
+        }
+    }
+    // </SearchAgentInstances>
+    #endregion SearchAgentInstances
+}

--- a/examples/Group.cs
+++ b/examples/Group.cs
@@ -6,13 +6,13 @@ public static class GroupExamples
 {
     #region CreateGroup
     // <CreateGroup>
-    public static async Task CreateGroupExample()
+    public static async Task CreateGroupExample(GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.CreateGroupAsync(new GroupCreateRequest
         {
-            GroupId = "engineering",
+            GroupId = groupId,
             Name = "Engineering",
         });
 
@@ -24,11 +24,11 @@ public static class GroupExamples
     #region GetGroup
 
     // <GetGroup>
-    public static async Task GetGroupExample()
+    public static async Task GetGroupExample(GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
-        var result = await client.GetGroupAsync("engineering");
+        var result = await client.GetGroupAsync(groupId);
         Console.WriteLine($"Group: {result.Name}");
     }
     // </GetGroup>
@@ -54,11 +54,11 @@ public static class GroupExamples
     #region UpdateGroup
 
     // <UpdateGroup>
-    public static async Task UpdateGroupExample()
+    public static async Task UpdateGroupExample(GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
-        await client.UpdateGroupAsync("engineering", new GroupUpdateRequest
+        await client.UpdateGroupAsync(groupId, new GroupUpdateRequest
         {
             Name = "engineering-team",
         });
@@ -69,11 +69,11 @@ public static class GroupExamples
     #region DeleteGroup
 
     // <DeleteGroup>
-    public static async Task DeleteGroupExample()
+    public static async Task DeleteGroupExample(GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
-        await client.DeleteGroupAsync("engineering");
+        await client.DeleteGroupAsync(groupId);
     }
     // </DeleteGroup>
     #endregion DeleteGroup
@@ -81,11 +81,11 @@ public static class GroupExamples
     #region AssignUserToGroup
 
     // <AssignUserToGroup>
-    public static async Task AssignUserToGroupExample(Username username)
+    public static async Task AssignUserToGroupExample(GroupId groupId, Username username)
     {
         using var client = CamundaClient.Create();
 
-        await client.AssignUserToGroupAsync("engineering", username);
+        await client.AssignUserToGroupAsync(groupId, username);
     }
     // </AssignUserToGroup>
     #endregion AssignUserToGroup
@@ -93,11 +93,11 @@ public static class GroupExamples
     #region UnassignUserFromGroup
 
     // <UnassignUserFromGroup>
-    public static async Task UnassignUserFromGroupExample(Username username)
+    public static async Task UnassignUserFromGroupExample(GroupId groupId, Username username)
     {
         using var client = CamundaClient.Create();
 
-        await client.UnassignUserFromGroupAsync("engineering", username);
+        await client.UnassignUserFromGroupAsync(groupId, username);
     }
     // </UnassignUserFromGroup>
     #endregion UnassignUserFromGroup
@@ -105,11 +105,11 @@ public static class GroupExamples
     #region AssignClientToGroup
 
     // <AssignClientToGroup>
-    public static async Task AssignClientToGroupExample()
+    public static async Task AssignClientToGroupExample(GroupId groupId, ClientId clientId)
     {
         using var client = CamundaClient.Create();
 
-        await client.AssignClientToGroupAsync("engineering", "my-service-account");
+        await client.AssignClientToGroupAsync(groupId, clientId);
     }
     // </AssignClientToGroup>
     #endregion AssignClientToGroup
@@ -117,11 +117,11 @@ public static class GroupExamples
     #region UnassignClientFromGroup
 
     // <UnassignClientFromGroup>
-    public static async Task UnassignClientFromGroupExample()
+    public static async Task UnassignClientFromGroupExample(GroupId groupId, ClientId clientId)
     {
         using var client = CamundaClient.Create();
 
-        await client.UnassignClientFromGroupAsync("engineering", "my-service-account");
+        await client.UnassignClientFromGroupAsync(groupId, clientId);
     }
     // </UnassignClientFromGroup>
     #endregion UnassignClientFromGroup
@@ -129,11 +129,11 @@ public static class GroupExamples
     #region AssignMappingRuleToGroup
 
     // <AssignMappingRuleToGroup>
-    public static async Task AssignMappingRuleToGroupExample()
+    public static async Task AssignMappingRuleToGroupExample(GroupId groupId, MappingRuleId mappingRuleId)
     {
         using var client = CamundaClient.Create();
 
-        await client.AssignMappingRuleToGroupAsync("engineering", "rule-123");
+        await client.AssignMappingRuleToGroupAsync(groupId, mappingRuleId);
     }
     // </AssignMappingRuleToGroup>
     #endregion AssignMappingRuleToGroup
@@ -141,11 +141,11 @@ public static class GroupExamples
     #region UnassignMappingRuleFromGroup
 
     // <UnassignMappingRuleFromGroup>
-    public static async Task UnassignMappingRuleFromGroupExample()
+    public static async Task UnassignMappingRuleFromGroupExample(GroupId groupId, MappingRuleId mappingRuleId)
     {
         using var client = CamundaClient.Create();
 
-        await client.UnassignMappingRuleFromGroupAsync("engineering", "rule-123");
+        await client.UnassignMappingRuleFromGroupAsync(groupId, mappingRuleId);
     }
     // </UnassignMappingRuleFromGroup>
     #endregion UnassignMappingRuleFromGroup
@@ -153,12 +153,12 @@ public static class GroupExamples
     #region SearchUsersForGroup
 
     // <SearchUsersForGroup>
-    public static async Task SearchUsersForGroupExample()
+    public static async Task SearchUsersForGroupExample(GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.SearchUsersForGroupAsync(
-            "engineering",
+            groupId,
             new SearchUsersForGroupRequest());
 
         foreach (var user in result.Items)
@@ -172,12 +172,12 @@ public static class GroupExamples
     #region SearchClientsForGroup
 
     // <SearchClientsForGroup>
-    public static async Task SearchClientsForGroupExample()
+    public static async Task SearchClientsForGroupExample(GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.SearchClientsForGroupAsync(
-            "engineering",
+            groupId,
             new SearchClientsForGroupRequest());
 
         foreach (var c in result.Items)
@@ -191,12 +191,12 @@ public static class GroupExamples
     #region SearchRolesForGroup
 
     // <SearchRolesForGroup>
-    public static async Task SearchRolesForGroupExample()
+    public static async Task SearchRolesForGroupExample(GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.SearchRolesForGroupAsync(
-            "engineering",
+            groupId,
             new RoleSearchQueryRequest());
 
         foreach (var role in result.Items)
@@ -210,12 +210,12 @@ public static class GroupExamples
     #region SearchMappingRulesForGroup
 
     // <SearchMappingRulesForGroup>
-    public static async Task SearchMappingRulesForGroupExample()
+    public static async Task SearchMappingRulesForGroupExample(GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.SearchMappingRulesForGroupAsync(
-            "engineering",
+            groupId,
             new MappingRuleSearchQueryRequest());
 
         foreach (var rule in result.Items)

--- a/examples/Group.cs
+++ b/examples/Group.cs
@@ -159,7 +159,7 @@ public static class GroupExamples
 
         var result = await client.SearchUsersForGroupAsync(
             groupId,
-            new SearchUsersForGroupRequest());
+            new GroupUserSearchQueryRequest());
 
         foreach (var user in result.Items)
         {
@@ -178,7 +178,7 @@ public static class GroupExamples
 
         var result = await client.SearchClientsForGroupAsync(
             groupId,
-            new SearchClientsForGroupRequest());
+            new GroupClientSearchQueryRequest());
 
         foreach (var c in result.Items)
         {

--- a/examples/MappingRule.cs
+++ b/examples/MappingRule.cs
@@ -25,11 +25,11 @@ public static class MappingRuleExamples
     #region GetMappingRule
 
     // <GetMappingRule>
-    public static async Task GetMappingRuleExample()
+    public static async Task GetMappingRuleExample(MappingRuleId mappingRuleId)
     {
         using var client = CamundaClient.Create();
 
-        var result = await client.GetMappingRuleAsync("rule-123");
+        var result = await client.GetMappingRuleAsync(mappingRuleId);
         Console.WriteLine($"Mapping rule: {result.Name}");
     }
     // </GetMappingRule>
@@ -56,11 +56,11 @@ public static class MappingRuleExamples
     #region UpdateMappingRule
 
     // <UpdateMappingRule>
-    public static async Task UpdateMappingRuleExample()
+    public static async Task UpdateMappingRuleExample(MappingRuleId mappingRuleId)
     {
         using var client = CamundaClient.Create();
 
-        await client.UpdateMappingRuleAsync("rule-123", new MappingRuleUpdateRequest
+        await client.UpdateMappingRuleAsync(mappingRuleId, new MappingRuleUpdateRequest
         {
             ClaimName = "groups",
             ClaimValue = "senior-engineering",
@@ -73,11 +73,11 @@ public static class MappingRuleExamples
     #region DeleteMappingRule
 
     // <DeleteMappingRule>
-    public static async Task DeleteMappingRuleExample()
+    public static async Task DeleteMappingRuleExample(MappingRuleId mappingRuleId)
     {
         using var client = CamundaClient.Create();
 
-        await client.DeleteMappingRuleAsync("rule-123");
+        await client.DeleteMappingRuleAsync(mappingRuleId);
     }
     // </DeleteMappingRule>
     #endregion DeleteMappingRule

--- a/examples/Role.cs
+++ b/examples/Role.cs
@@ -23,11 +23,11 @@ public static class RoleExamples
     #region GetRole
 
     // <GetRole>
-    public static async Task GetRoleExample()
+    public static async Task GetRoleExample(RoleId roleId)
     {
         using var client = CamundaClient.Create();
 
-        var result = await client.GetRoleAsync("developer");
+        var result = await client.GetRoleAsync(roleId);
         Console.WriteLine($"Role: {result.Name}");
     }
     // </GetRole>
@@ -53,11 +53,11 @@ public static class RoleExamples
     #region UpdateRole
 
     // <UpdateRole>
-    public static async Task UpdateRoleExample()
+    public static async Task UpdateRoleExample(RoleId roleId)
     {
         using var client = CamundaClient.Create();
 
-        await client.UpdateRoleAsync("developer", new RoleUpdateRequest
+        await client.UpdateRoleAsync(roleId, new RoleUpdateRequest
         {
             Name = "senior-developer",
         });
@@ -68,11 +68,11 @@ public static class RoleExamples
     #region DeleteRole
 
     // <DeleteRole>
-    public static async Task DeleteRoleExample()
+    public static async Task DeleteRoleExample(RoleId roleId)
     {
         using var client = CamundaClient.Create();
 
-        await client.DeleteRoleAsync("developer");
+        await client.DeleteRoleAsync(roleId);
     }
     // </DeleteRole>
     #endregion DeleteRole
@@ -80,11 +80,11 @@ public static class RoleExamples
     #region AssignRoleToUser
 
     // <AssignRoleToUser>
-    public static async Task AssignRoleToUserExample(Username username)
+    public static async Task AssignRoleToUserExample(RoleId roleId, Username username)
     {
         using var client = CamundaClient.Create();
 
-        await client.AssignRoleToUserAsync("developer", username);
+        await client.AssignRoleToUserAsync(roleId, username);
     }
     // </AssignRoleToUser>
     #endregion AssignRoleToUser
@@ -92,11 +92,11 @@ public static class RoleExamples
     #region UnassignRoleFromUser
 
     // <UnassignRoleFromUser>
-    public static async Task UnassignRoleFromUserExample(Username username)
+    public static async Task UnassignRoleFromUserExample(RoleId roleId, Username username)
     {
         using var client = CamundaClient.Create();
 
-        await client.UnassignRoleFromUserAsync("developer", username);
+        await client.UnassignRoleFromUserAsync(roleId, username);
     }
     // </UnassignRoleFromUser>
     #endregion UnassignRoleFromUser
@@ -104,11 +104,11 @@ public static class RoleExamples
     #region AssignRoleToGroup
 
     // <AssignRoleToGroup>
-    public static async Task AssignRoleToGroupExample()
+    public static async Task AssignRoleToGroupExample(RoleId roleId, GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
-        await client.AssignRoleToGroupAsync("developer", "engineering");
+        await client.AssignRoleToGroupAsync(roleId, groupId);
     }
     // </AssignRoleToGroup>
     #endregion AssignRoleToGroup
@@ -116,11 +116,11 @@ public static class RoleExamples
     #region UnassignRoleFromGroup
 
     // <UnassignRoleFromGroup>
-    public static async Task UnassignRoleFromGroupExample()
+    public static async Task UnassignRoleFromGroupExample(RoleId roleId, GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
-        await client.UnassignRoleFromGroupAsync("developer", "engineering");
+        await client.UnassignRoleFromGroupAsync(roleId, groupId);
     }
     // </UnassignRoleFromGroup>
     #endregion UnassignRoleFromGroup
@@ -128,11 +128,11 @@ public static class RoleExamples
     #region AssignRoleToClient
 
     // <AssignRoleToClient>
-    public static async Task AssignRoleToClientExample()
+    public static async Task AssignRoleToClientExample(RoleId roleId, ClientId clientId)
     {
         using var client = CamundaClient.Create();
 
-        await client.AssignRoleToClientAsync("developer", "my-service-account");
+        await client.AssignRoleToClientAsync(roleId, clientId);
     }
     // </AssignRoleToClient>
     #endregion AssignRoleToClient
@@ -140,11 +140,11 @@ public static class RoleExamples
     #region UnassignRoleFromClient
 
     // <UnassignRoleFromClient>
-    public static async Task UnassignRoleFromClientExample()
+    public static async Task UnassignRoleFromClientExample(RoleId roleId, ClientId clientId)
     {
         using var client = CamundaClient.Create();
 
-        await client.UnassignRoleFromClientAsync("developer", "my-service-account");
+        await client.UnassignRoleFromClientAsync(roleId, clientId);
     }
     // </UnassignRoleFromClient>
     #endregion UnassignRoleFromClient
@@ -152,11 +152,11 @@ public static class RoleExamples
     #region AssignRoleToMappingRule
 
     // <AssignRoleToMappingRule>
-    public static async Task AssignRoleToMappingRuleExample()
+    public static async Task AssignRoleToMappingRuleExample(RoleId roleId, MappingRuleId mappingRuleId)
     {
         using var client = CamundaClient.Create();
 
-        await client.AssignRoleToMappingRuleAsync("developer", "rule-123");
+        await client.AssignRoleToMappingRuleAsync(roleId, mappingRuleId);
     }
     // </AssignRoleToMappingRule>
     #endregion AssignRoleToMappingRule
@@ -164,11 +164,11 @@ public static class RoleExamples
     #region UnassignRoleFromMappingRule
 
     // <UnassignRoleFromMappingRule>
-    public static async Task UnassignRoleFromMappingRuleExample()
+    public static async Task UnassignRoleFromMappingRuleExample(RoleId roleId, MappingRuleId mappingRuleId)
     {
         using var client = CamundaClient.Create();
 
-        await client.UnassignRoleFromMappingRuleAsync("developer", "rule-123");
+        await client.UnassignRoleFromMappingRuleAsync(roleId, mappingRuleId);
     }
     // </UnassignRoleFromMappingRule>
     #endregion UnassignRoleFromMappingRule
@@ -176,12 +176,12 @@ public static class RoleExamples
     #region SearchUsersForRole
 
     // <SearchUsersForRole>
-    public static async Task SearchUsersForRoleExample()
+    public static async Task SearchUsersForRoleExample(RoleId roleId)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.SearchUsersForRoleAsync(
-            "developer",
+            roleId,
             new SearchUsersForRoleRequest());
 
         foreach (var user in result.Items)
@@ -195,12 +195,12 @@ public static class RoleExamples
     #region SearchGroupsForRole
 
     // <SearchGroupsForRole>
-    public static async Task SearchGroupsForRoleExample()
+    public static async Task SearchGroupsForRoleExample(RoleId roleId)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.SearchGroupsForRoleAsync(
-            "developer",
+            roleId,
             new RoleGroupSearchQueryRequest());
 
         foreach (var group in result.Items)
@@ -214,12 +214,12 @@ public static class RoleExamples
     #region SearchClientsForRole
 
     // <SearchClientsForRole>
-    public static async Task SearchClientsForRoleExample()
+    public static async Task SearchClientsForRoleExample(RoleId roleId)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.SearchClientsForRoleAsync(
-            "developer",
+            roleId,
             new SearchClientsForRoleRequest());
 
         foreach (var c in result.Items)
@@ -233,12 +233,12 @@ public static class RoleExamples
     #region SearchMappingRulesForRole
 
     // <SearchMappingRulesForRole>
-    public static async Task SearchMappingRulesForRoleExample()
+    public static async Task SearchMappingRulesForRoleExample(RoleId roleId)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.SearchMappingRulesForRoleAsync(
-            "developer",
+            roleId,
             new MappingRuleSearchQueryRequest());
 
         foreach (var rule in result.Items)

--- a/examples/Role.cs
+++ b/examples/Role.cs
@@ -182,7 +182,7 @@ public static class RoleExamples
 
         var result = await client.SearchUsersForRoleAsync(
             roleId,
-            new SearchUsersForRoleRequest());
+            new RoleUserSearchQueryRequest());
 
         foreach (var user in result.Items)
         {
@@ -220,7 +220,7 @@ public static class RoleExamples
 
         var result = await client.SearchClientsForRoleAsync(
             roleId,
-            new SearchClientsForRoleRequest());
+            new RoleClientSearchQueryRequest());
 
         foreach (var c in result.Items)
         {

--- a/examples/Tenant.cs
+++ b/examples/Tenant.cs
@@ -6,13 +6,13 @@ public static class TenantExamples
 {
     #region CreateTenant
     // <CreateTenant>
-    public static async Task CreateTenantExample()
+    public static async Task CreateTenantExample(TenantId tenantId)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.CreateTenantAsync(new TenantCreateRequest
         {
-            TenantId = "acme-corp",
+            TenantId = tenantId,
             Name = "Acme Corporation",
         });
 
@@ -111,13 +111,13 @@ public static class TenantExamples
     #region AssignGroupToTenant
 
     // <AssignGroupToTenant>
-    public static async Task AssignGroupToTenantExample(TenantId tenantId)
+    public static async Task AssignGroupToTenantExample(TenantId tenantId, GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
         await client.AssignGroupToTenantAsync(
             tenantId,
-            "engineering");
+            groupId);
     }
     // </AssignGroupToTenant>
     #endregion AssignGroupToTenant
@@ -125,13 +125,13 @@ public static class TenantExamples
     #region UnassignGroupFromTenant
 
     // <UnassignGroupFromTenant>
-    public static async Task UnassignGroupFromTenantExample(TenantId tenantId)
+    public static async Task UnassignGroupFromTenantExample(TenantId tenantId, GroupId groupId)
     {
         using var client = CamundaClient.Create();
 
         await client.UnassignGroupFromTenantAsync(
             tenantId,
-            "engineering");
+            groupId);
     }
     // </UnassignGroupFromTenant>
     #endregion UnassignGroupFromTenant
@@ -139,13 +139,13 @@ public static class TenantExamples
     #region AssignRoleToTenant
 
     // <AssignRoleToTenant>
-    public static async Task AssignRoleToTenantExample(TenantId tenantId)
+    public static async Task AssignRoleToTenantExample(TenantId tenantId, RoleId roleId)
     {
         using var client = CamundaClient.Create();
 
         await client.AssignRoleToTenantAsync(
             tenantId,
-            "developer");
+            roleId);
     }
     // </AssignRoleToTenant>
     #endregion AssignRoleToTenant
@@ -153,13 +153,13 @@ public static class TenantExamples
     #region UnassignRoleFromTenant
 
     // <UnassignRoleFromTenant>
-    public static async Task UnassignRoleFromTenantExample(TenantId tenantId)
+    public static async Task UnassignRoleFromTenantExample(TenantId tenantId, RoleId roleId)
     {
         using var client = CamundaClient.Create();
 
         await client.UnassignRoleFromTenantAsync(
             tenantId,
-            "developer");
+            roleId);
     }
     // </UnassignRoleFromTenant>
     #endregion UnassignRoleFromTenant
@@ -167,13 +167,13 @@ public static class TenantExamples
     #region AssignClientToTenant
 
     // <AssignClientToTenant>
-    public static async Task AssignClientToTenantExample(TenantId tenantId)
+    public static async Task AssignClientToTenantExample(TenantId tenantId, ClientId clientId)
     {
         using var client = CamundaClient.Create();
 
         await client.AssignClientToTenantAsync(
             tenantId,
-            "my-service-account");
+            clientId);
     }
     // </AssignClientToTenant>
     #endregion AssignClientToTenant
@@ -181,13 +181,13 @@ public static class TenantExamples
     #region UnassignClientFromTenant
 
     // <UnassignClientFromTenant>
-    public static async Task UnassignClientFromTenantExample(TenantId tenantId)
+    public static async Task UnassignClientFromTenantExample(TenantId tenantId, ClientId clientId)
     {
         using var client = CamundaClient.Create();
 
         await client.UnassignClientFromTenantAsync(
             tenantId,
-            "my-service-account");
+            clientId);
     }
     // </UnassignClientFromTenant>
     #endregion UnassignClientFromTenant
@@ -195,13 +195,13 @@ public static class TenantExamples
     #region AssignMappingRuleToTenant
 
     // <AssignMappingRuleToTenant>
-    public static async Task AssignMappingRuleToTenantExample(TenantId tenantId)
+    public static async Task AssignMappingRuleToTenantExample(TenantId tenantId, MappingRuleId mappingRuleId)
     {
         using var client = CamundaClient.Create();
 
         await client.AssignMappingRuleToTenantAsync(
             tenantId,
-            "rule-123");
+            mappingRuleId);
     }
     // </AssignMappingRuleToTenant>
     #endregion AssignMappingRuleToTenant
@@ -209,13 +209,13 @@ public static class TenantExamples
     #region UnassignMappingRuleFromTenant
 
     // <UnassignMappingRuleFromTenant>
-    public static async Task UnassignMappingRuleFromTenantExample(TenantId tenantId)
+    public static async Task UnassignMappingRuleFromTenantExample(TenantId tenantId, MappingRuleId mappingRuleId)
     {
         using var client = CamundaClient.Create();
 
         await client.UnassignMappingRuleFromTenantAsync(
             tenantId,
-            "rule-123");
+            mappingRuleId);
     }
     // </UnassignMappingRuleFromTenant>
     #endregion UnassignMappingRuleFromTenant

--- a/examples/Tenant.cs
+++ b/examples/Tenant.cs
@@ -229,7 +229,7 @@ public static class TenantExamples
 
         var result = await client.SearchUsersForTenantAsync(
             tenantId,
-            new SearchUsersForTenantRequest());
+            new TenantUserSearchQueryRequest());
 
         foreach (var user in result.Items)
         {
@@ -248,7 +248,7 @@ public static class TenantExamples
 
         var result = await client.SearchClientsForTenantAsync(
             tenantId,
-            new SearchClientsForTenantRequest());
+            new TenantClientSearchQueryRequest());
 
         foreach (var c in result.Items)
         {

--- a/examples/User.cs
+++ b/examples/User.cs
@@ -6,13 +6,13 @@ public static class UserExamples
 {
     #region CreateUser
     // <CreateUser>
-    public static async Task CreateUserExample()
+    public static async Task CreateUserExample(Username username)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.CreateUserAsync(new UserRequest
         {
-            Username = "jdoe",
+            Username = username,
             Name = "Jane Doe",
             Email = "jdoe@example.com",
             Password = "secure-password",
@@ -26,13 +26,13 @@ public static class UserExamples
     #region CreateAdminUser
 
     // <CreateAdminUser>
-    public static async Task CreateAdminUserExample()
+    public static async Task CreateAdminUserExample(Username username)
     {
         using var client = CamundaClient.Create();
 
         var result = await client.CreateAdminUserAsync(new UserRequest
         {
-            Username = "admin",
+            Username = username,
             Name = "Admin User",
             Email = "admin@example.com",
             Password = "admin-password",

--- a/examples/UserTask.cs
+++ b/examples/UserTask.cs
@@ -112,7 +112,7 @@ public static class UserTaskExamples
 
         var result = await client.SearchUserTaskVariablesAsync(
             userTaskKey,
-            new SearchUserTaskVariablesRequest());
+            new UserTaskVariableSearchQueryRequest());
 
         foreach (var variable in result.Items)
         {
@@ -150,7 +150,7 @@ public static class UserTaskExamples
 
         var result = await client.SearchUserTaskEffectiveVariablesAsync(
             userTaskKey,
-            new SearchUserTaskEffectiveVariablesRequest());
+            new UserTaskEffectiveVariableSearchQueryRequest());
 
         foreach (var variable in result.Items)
         {

--- a/examples/VariableElement.cs
+++ b/examples/VariableElement.cs
@@ -23,7 +23,7 @@ public static class VariableElementExamples
     {
         using var client = CamundaClient.Create();
 
-        var result = await client.SearchVariablesAsync(new SearchVariablesRequest());
+        var result = await client.SearchVariablesAsync(new VariableSearchQuery());
 
         foreach (var variable in result.Items)
         {

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -1,4 +1,18 @@
 {
+  "getAgentInstance": [
+    {
+      "file": "AgentInstance.cs",
+      "region": "GetAgentInstance",
+      "label": "Get an agent instance"
+    }
+  ],
+  "searchAgentInstances": [
+    {
+      "file": "AgentInstance.cs",
+      "region": "SearchAgentInstances",
+      "label": "Search agent instances"
+    }
+  ],
   "getTopology": [
     {
       "file": "Client.cs",

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -41,6 +41,9 @@
       "name": "Ad-hoc sub-process"
     },
     {
+      "name": "Agent instance"
+    },
+    {
       "name": "Audit Log"
     },
     {
@@ -144,6 +147,109 @@
     }
   ],
   "paths": {
+    "/agent-instances/{agentInstanceKey}": {
+      "get": {
+        "x-eventually-consistent": true,
+        "tags": [
+          "Agent instance"
+        ],
+        "operationId": "getAgentInstance",
+        "summary": "Get agent instance",
+        "description": "Returns agent instance as JSON.",
+        "parameters": [
+          {
+            "name": "agentInstanceKey",
+            "in": "path",
+            "required": true,
+            "description": "The key of the agent instance to retrieve.",
+            "schema": {
+              "$ref": "#/components/schemas/AgentInstanceKey"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The agent instance is successfully returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstanceResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/paths/~1clock/put/responses/400"
+          },
+          "401": {
+            "$ref": "#/paths/~1roles/post/responses/401"
+          },
+          "403": {
+            "$ref": "#/paths/~1roles/post/responses/403"
+          },
+          "404": {
+            "description": "The agent instance with the given key was not found.\nMore details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/paths/~1clock/put/responses/500"
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
+    "/agent-instances/search": {
+      "post": {
+        "x-eventually-consistent": true,
+        "tags": [
+          "Agent instance"
+        ],
+        "operationId": "searchAgentInstances",
+        "summary": "Search agent instances",
+        "description": "Search for agent instances based on given criteria.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstanceSearchQuery"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The agent instance search result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstanceSearchQueryResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/paths/~1clock/put/responses/400"
+          },
+          "401": {
+            "$ref": "#/paths/~1roles/post/responses/401"
+          },
+          "403": {
+            "$ref": "#/paths/~1roles/post/responses/403"
+          },
+          "500": {
+            "$ref": "#/paths/~1clock/put/responses/500"
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/audit-logs/search": {
       "post": {
         "x-eventually-consistent": true,
@@ -175,41 +281,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
             "description": "An internal error occurred while processing the request."
@@ -250,31 +328,10 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The audit log with the given key was not found.",
@@ -287,14 +344,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -326,41 +376,13 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -397,41 +419,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The owner was not found.",
@@ -444,24 +438,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -497,51 +477,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -582,21 +527,7 @@
             "description": "The authorization was updated successfully."
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "404": {
             "description": "The authorization with the authorizationKey was not found.",
@@ -609,24 +540,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -662,31 +579,10 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The authorization with the given key was not found.",
@@ -699,14 +595,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -735,21 +624,7 @@
             "description": "The authorization was deleted successfully."
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "404": {
             "description": "The authorization with the authorizationKey was not found.",
@@ -762,24 +637,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -826,14 +687,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -880,14 +734,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -945,14 +792,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -990,24 +830,10 @@
             "content": {}
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The batch operation was not found.",
@@ -1020,14 +846,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -1065,24 +884,10 @@
             "content": {}
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The batch operation was not found.",
@@ -1095,24 +900,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -1150,24 +941,10 @@
             "content": {}
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The batch operation was not found.",
@@ -1180,24 +957,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -1274,24 +1037,10 @@
             "description": "The clock was successfully reset to the system time."
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -1306,6 +1055,16 @@
         ],
         "summary": "Create a global-scoped cluster variable",
         "description": "Create a global-scoped cluster variable.",
+        "x-semantic-establishes": {
+          "kind": "GlobalClusterVariable",
+          "identifiedBy": [
+            {
+              "in": "body",
+              "name": "name",
+              "semanticType": "ClusterVariableName"
+            }
+          ]
+        },
         "requestBody": {
           "required": true,
           "content": {
@@ -1328,51 +1087,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -1387,13 +1111,22 @@
         ],
         "summary": "Get a global-scoped cluster variable",
         "description": "Get a global-scoped cluster variable.",
+        "x-semantic-requires": {
+          "kind": "GlobalClusterVariable",
+          "bind": {
+            "name": {
+              "from": "path",
+              "name": "name"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "name",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClusterVariableName"
             },
             "description": "The name of the cluster variable"
           }
@@ -1410,41 +1143,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Cluster variable not found",
@@ -1457,14 +1162,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -1477,13 +1175,22 @@
         ],
         "summary": "Update a global-scoped cluster variable",
         "description": "Updates the value of an existing global cluster variable.\nThe variable must exist, otherwise a 404 error is returned.\n",
+        "x-semantic-requires": {
+          "kind": "GlobalClusterVariable",
+          "bind": {
+            "name": {
+              "from": "path",
+              "name": "name"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "name",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClusterVariableName"
             },
             "description": "The name of the cluster variable"
           }
@@ -1510,41 +1217,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Cluster variable not found",
@@ -1557,14 +1236,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -1577,13 +1249,22 @@
         ],
         "summary": "Delete a global-scoped cluster variable",
         "description": "Delete a global-scoped cluster variable.",
+        "x-semantic-requires": {
+          "kind": "GlobalClusterVariable",
+          "bind": {
+            "name": {
+              "from": "path",
+              "name": "name"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "name",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClusterVariableName"
             },
             "description": "The name of the cluster variable"
           }
@@ -1593,41 +1274,13 @@
             "description": "Cluster variable deleted successfully"
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Cluster variable not found",
@@ -1640,14 +1293,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -1694,51 +1340,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -1753,6 +1364,30 @@
         ],
         "summary": "Create a tenant-scoped cluster variable",
         "description": "Create a new cluster variable for the given tenant.",
+        "x-semantic-establishes": {
+          "kind": "TenantClusterVariable",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "tenantId",
+              "semanticType": "TenantId"
+            },
+            {
+              "in": "body",
+              "name": "name",
+              "semanticType": "ClusterVariableName"
+            }
+          ]
+        },
+        "x-semantic-requires": {
+          "kind": "Tenant",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -1786,41 +1421,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The tenant with the given ID was not found.",
@@ -1833,14 +1440,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -1855,6 +1455,19 @@
         ],
         "summary": "Get a tenant-scoped cluster variable",
         "description": "Get a tenant-scoped cluster variable.",
+        "x-semantic-requires": {
+          "kind": "TenantClusterVariable",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            },
+            "name": {
+              "from": "path",
+              "name": "name"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -1870,7 +1483,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClusterVariableName"
             },
             "description": "The name of the cluster variable"
           }
@@ -1887,41 +1500,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Cluster variable not found",
@@ -1934,14 +1519,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -1954,6 +1532,19 @@
         ],
         "summary": "Update a tenant-scoped cluster variable",
         "description": "Updates the value of an existing tenant-scoped cluster variable.\nThe variable must exist, otherwise a 404 error is returned.\n",
+        "x-semantic-requires": {
+          "kind": "TenantClusterVariable",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            },
+            "name": {
+              "from": "path",
+              "name": "name"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -1969,7 +1560,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClusterVariableName"
             },
             "description": "The name of the cluster variable"
           }
@@ -1996,41 +1587,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Cluster variable not found",
@@ -2043,14 +1606,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -2063,6 +1619,19 @@
         ],
         "summary": "Delete a tenant-scoped cluster variable",
         "description": "Delete a tenant-scoped cluster variable.",
+        "x-semantic-requires": {
+          "kind": "TenantClusterVariable",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            },
+            "name": {
+              "from": "path",
+              "name": "name"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -2078,7 +1647,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClusterVariableName"
             },
             "description": "The name of the cluster variable"
           }
@@ -2088,41 +1657,13 @@
             "description": "Cluster variable deleted successfully"
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Cluster variable not found",
@@ -2135,14 +1676,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -2208,14 +1742,7 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
             "description": "The client is not authorized to start process instances for the specified process definition.\nIf a processDefinitionKey is not provided, this indicates that the client is not authorized\nto start process instances for at least one of the matched process definitions.\n",
@@ -2238,24 +1765,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.9"
@@ -2292,51 +1805,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -2389,14 +1867,7 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The decision is not found.",
@@ -2409,24 +1880,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -2463,51 +1920,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -2545,41 +1967,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The decision definition with the given key was not found. More details are provided in the response body.\n",
@@ -2592,14 +1986,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -2637,41 +2024,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The decision definition with the given key was not found. More details are provided in the response body.\n",
@@ -2684,14 +2043,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -2728,51 +2080,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -2810,41 +2127,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The decision instance with the given key was not found. More details are provided in the response body.\n",
@@ -2857,14 +2146,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -2912,31 +2194,10 @@
             "description": "The decision instance is marked for deletion."
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The decision instance is not found.",
@@ -2949,24 +2210,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.9"
@@ -3013,41 +2260,13 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -3084,51 +2303,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -3166,41 +2350,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The decision requirements with the given key was not found. More details are provided in the response body.\n",
@@ -3213,14 +2369,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -3258,41 +2407,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The decision requirements with the given key was not found. More details are provided in the response body.\n",
@@ -3305,14 +2426,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -3366,24 +2480,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -3458,14 +2558,7 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "415": {
             "description": "The server cannot process the request because the media type (Content-Type) of the request payload is not supported\nby the server for the requested resource and method.\n",
@@ -3567,24 +2660,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "415": {
-            "description": "The server cannot process the request because the media type (Content-Type) of the request payload is not supported\nby the server for the requested resource and method.\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1documents/post/responses/415"
           }
         },
         "x-added-in-version": "8.7"
@@ -3651,14 +2730,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -3706,14 +2778,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -3779,14 +2844,7 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           }
         },
         "x-added-in-version": "8.7"
@@ -3827,41 +2885,13 @@
             "description": "The ad-hoc sub-process instance is modified."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The ad-hoc sub-process instance is not found or the provided key does not identify an ad-hoc sub-process.",
@@ -3874,24 +2904,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -3928,51 +2944,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -4010,41 +2991,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The element instance with the given key was not found.\nMore details are provided in the response body.\n",
@@ -4057,14 +3010,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -4112,41 +3058,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The element instance with the given key was not found.",
@@ -4159,14 +3077,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -4207,55 +3118,16 @@
             "description": "The variables were updated."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           },
           "504": {
-            "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                },
-                "examples": {
-                  "taskListenerTimeout": {
-                    "value": {
-                      "type": "about:blank",
-                      "title": "DEADLINE_EXCEEDED",
-                      "status": 504,
-                      "detail": "Expected to handle request, but request timed out between gateway and broker",
-                      "instance": "/v2/user-tasks/123/completion"
-                    }
-                  }
-                }
-              }
-            }
+            "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
           }
         },
         "x-added-in-version": "8.6"
@@ -4292,51 +3164,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -4351,6 +3188,16 @@
         "operationId": "createGlobalTaskListener",
         "summary": "Create global user task listener",
         "description": "Create a new global user task listener.",
+        "x-semantic-establishes": {
+          "kind": "GlobalTaskListener",
+          "identifiedBy": [
+            {
+              "in": "body",
+              "name": "id",
+              "semanticType": "GlobalListenerId"
+            }
+          ]
+        },
         "requestBody": {
           "content": {
             "application/json": {
@@ -4373,41 +3220,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "409": {
             "description": "A global listener with this id already exists.",
@@ -4420,24 +3239,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.9"
@@ -4452,6 +3257,15 @@
         "operationId": "getGlobalTaskListener",
         "summary": "Get global user task listener",
         "description": "Get a global user task listener by its id.",
+        "x-semantic-requires": {
+          "kind": "GlobalTaskListener",
+          "bind": {
+            "id": {
+              "from": "path",
+              "name": "id"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "id",
@@ -4475,31 +3289,10 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The global user task listener with the given id was not found.",
@@ -4512,14 +3305,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -4532,6 +3318,15 @@
         "operationId": "updateGlobalTaskListener",
         "summary": "Update global user task listener",
         "description": "Updates a global user task listener.",
+        "x-semantic-requires": {
+          "kind": "GlobalTaskListener",
+          "bind": {
+            "id": {
+              "from": "path",
+              "name": "id"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "id",
@@ -4565,41 +3360,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The global user task listener was not found.",
@@ -4612,24 +3379,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.9"
@@ -4642,6 +3395,15 @@
         "operationId": "deleteGlobalTaskListener",
         "summary": "Delete global user task listener",
         "description": "Deletes a global user task listener.",
+        "x-semantic-requires": {
+          "kind": "GlobalTaskListener",
+          "bind": {
+            "id": {
+              "from": "path",
+              "name": "id"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "id",
@@ -4658,41 +3420,13 @@
             "description": "The global listener was deleted successfully."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The global user task listener was not found.",
@@ -4705,24 +3439,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.9"
@@ -4758,51 +3478,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -4816,7 +3501,17 @@
         ],
         "operationId": "createGroup",
         "summary": "Create group",
-        "description": "Create a new group.",
+        "description": "Create a new group.\n\nThe supplied `groupId` is validated against `^[a-zA-Z0-9_~@.+-]+$`\n(max 256 characters) by `IdentifierValidator.validateId` in the\nruntime. This strict validation applies wherever the Groups API\nis available: in OIDC deployments that set\n`camunda.security.authentication.oidc.groupsClaim` the Groups\nAPI (including this endpoint) is disabled entirely, so group\nCRUD never sees externally-minted IdP IDs. The BYOG relaxation\nonly loosens validation when a group is referenced *as a member*\nof a role or tenant (`assignRoleToGroup`,\n`assignGroupToTenant`); group CRUD itself always uses the strict\ndefault-id regex. The constraint is not advertised on the\n`GroupId` schema so that the same schema can be reused at\nmember-reference sites without falsely rejecting\nexternally-minted IdP group IDs there.\n",
+        "x-semantic-establishes": {
+          "kind": "Group",
+          "identifiedBy": [
+            {
+              "in": "body",
+              "name": "groupId",
+              "semanticType": "GroupId"
+            }
+          ]
+        },
         "requestBody": {
           "content": {
             "application/json": {
@@ -4838,61 +3533,19 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -4929,51 +3582,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -4988,6 +3606,15 @@
         "operationId": "getGroup",
         "summary": "Get group",
         "description": "Get a group by its ID.",
+        "x-semantic-requires": {
+          "kind": "Group",
+          "bind": {
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -4995,7 +3622,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -5011,31 +3638,10 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -5048,14 +3654,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -5068,6 +3667,15 @@
         "operationId": "updateGroup",
         "summary": "Update group",
         "description": "Update a group with the given ID.",
+        "x-semantic-requires": {
+          "kind": "Group",
+          "bind": {
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -5075,7 +3683,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -5101,31 +3709,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -5138,24 +3725,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -5168,6 +3741,15 @@
         "operationId": "deleteGroup",
         "summary": "Delete group",
         "description": "Deletes the group with the given ID.",
+        "x-semantic-requires": {
+          "kind": "Group",
+          "bind": {
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -5175,7 +3757,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -5184,21 +3766,7 @@
             "description": "The group was deleted successfully."
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -5211,24 +3779,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -5243,6 +3797,15 @@
         "operationId": "searchClientsForGroup",
         "summary": "Search group clients",
         "description": "Search clients assigned to a group.",
+        "x-semantic-requires": {
+          "kind": "Group",
+          "bind": {
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -5250,7 +3813,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -5317,7 +3880,11 @@
                         "properties": {
                           "clientId": {
                             "description": "The ID of the client.",
-                            "type": "string"
+                            "allOf": [
+                              {
+                                "$ref": "#/components/schemas/ClientId"
+                              }
+                            ]
                           }
                         },
                         "required": [
@@ -5331,41 +3898,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -5378,14 +3917,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -5400,6 +3932,22 @@
         "operationId": "assignClientToGroup",
         "summary": "Assign a client to a group",
         "description": "Assigns a client to a group, making it a member of the group.\nMembers of the group inherit the group authorizations, roles, and tenant assignments.\n",
+        "x-semantic-establishes": {
+          "kind": "GroupClientMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "groupId",
+              "semanticType": "GroupId"
+            },
+            {
+              "in": "path",
+              "name": "clientId",
+              "semanticType": "ClientId"
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -5407,7 +3955,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           },
           {
@@ -5416,7 +3964,7 @@
             "required": true,
             "description": "The client ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClientId"
             }
           }
         ],
@@ -5425,24 +3973,10 @@
             "description": "The client was assigned successfully to the group."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -5465,24 +3999,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -5495,6 +4015,19 @@
         "operationId": "unassignClientFromGroup",
         "summary": "Unassign a client from a group",
         "description": "Unassigns a client from a group.\nThe client is removed as a group member, with associated authorizations, roles, and tenant assignments no longer applied.\n",
+        "x-semantic-requires": {
+          "kind": "GroupClientMembership",
+          "bind": {
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            },
+            "clientId": {
+              "from": "path",
+              "name": "clientId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -5502,7 +4035,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           },
           {
@@ -5511,7 +4044,7 @@
             "required": true,
             "description": "The client ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClientId"
             }
           }
         ],
@@ -5520,24 +4053,10 @@
             "description": "The client was unassigned successfully from the group."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group with the given ID was not found, or the client is not assigned to this group.",
@@ -5550,24 +4069,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -5582,6 +4087,15 @@
         "operationId": "searchMappingRulesForGroup",
         "summary": "Search group mapping rules",
         "description": "Search mapping rules assigned to a group.",
+        "x-semantic-requires": {
+          "kind": "Group",
+          "bind": {
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -5589,7 +4103,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -5632,41 +4146,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -5679,14 +4165,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -5701,6 +4180,22 @@
         "operationId": "assignMappingRuleToGroup",
         "summary": "Assign a mapping rule to a group",
         "description": "Assigns a mapping rule to a group.",
+        "x-semantic-establishes": {
+          "kind": "GroupMappingRuleMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "groupId",
+              "semanticType": "GroupId"
+            },
+            {
+              "in": "path",
+              "name": "mappingRuleId",
+              "semanticType": "MappingRuleId"
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -5708,7 +4203,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           },
           {
@@ -5717,7 +4212,7 @@
             "required": true,
             "description": "The mapping rule ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/MappingRuleId"
             }
           }
         ],
@@ -5726,24 +4221,10 @@
             "description": "The mapping rule was assigned successfully to the group."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group or mapping rule with the given ID was not found.",
@@ -5766,24 +4247,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -5796,6 +4263,19 @@
         "operationId": "unassignMappingRuleFromGroup",
         "summary": "Unassign a mapping rule from a group",
         "description": "Unassigns a mapping rule from a group.",
+        "x-semantic-requires": {
+          "kind": "GroupMappingRuleMembership",
+          "bind": {
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            },
+            "mappingRuleId": {
+              "from": "path",
+              "name": "mappingRuleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -5803,7 +4283,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           },
           {
@@ -5812,7 +4292,7 @@
             "required": true,
             "description": "The mapping rule ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/MappingRuleId"
             }
           }
         ],
@@ -5821,24 +4301,10 @@
             "description": "The mapping rule was unassigned successfully from the group."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group or mapping rule with the given ID was not found, or the mapping rule is not assigned to this group.",
@@ -5851,24 +4317,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -5883,6 +4335,15 @@
         "operationId": "searchRolesForGroup",
         "summary": "Search group roles",
         "description": "Search roles assigned to a group.",
+        "x-semantic-requires": {
+          "kind": "Group",
+          "bind": {
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -5890,7 +4351,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -5933,41 +4394,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -5980,14 +4413,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -6002,6 +4428,15 @@
         "operationId": "searchUsersForGroup",
         "summary": "Search group users",
         "description": "Search users assigned to a group.",
+        "x-semantic-requires": {
+          "kind": "Group",
+          "bind": {
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -6009,7 +4444,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -6089,41 +4524,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -6136,14 +4543,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -6158,6 +4558,22 @@
         "operationId": "assignUserToGroup",
         "summary": "Assign a user to a group",
         "description": "Assigns a user to a group, making the user a member of the group.\nGroup members inherit the group authorizations, roles, and tenant assignments.\n",
+        "x-semantic-establishes": {
+          "kind": "GroupUserMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "groupId",
+              "semanticType": "GroupId"
+            },
+            {
+              "in": "path",
+              "name": "username",
+              "semanticType": "Username"
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -6165,7 +4581,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           },
           {
@@ -6183,24 +4599,10 @@
             "description": "The user was assigned successfully to the group."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group or user with the given ID or username was not found.",
@@ -6223,24 +4625,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -6253,6 +4641,19 @@
         "operationId": "unassignUserFromGroup",
         "summary": "Unassign a user from a group",
         "description": "Unassigns a user from a group.\nThe user is removed as a group member, with associated authorizations, roles, and tenant assignments no longer applied.\n",
+        "x-semantic-requires": {
+          "kind": "GroupUserMembership",
+          "bind": {
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            },
+            "username": {
+              "from": "path",
+              "name": "username"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "groupId",
@@ -6260,7 +4661,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           },
           {
@@ -6278,24 +4679,10 @@
             "description": "The user was unassigned successfully from the group."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The group or user with the given ID was not found, or the user is not assigned to this group.",
@@ -6308,24 +4695,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -6362,51 +4735,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -6444,41 +4782,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The incident with the given key was not found.",
@@ -6491,14 +4801,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -6539,14 +4842,7 @@
             "description": "The incident is marked as resolved."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The incident with the incidentKey is not found.",
@@ -6569,24 +4865,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -6623,51 +4905,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -6704,51 +4951,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -6785,51 +4997,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -6866,51 +5043,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -6951,14 +5093,7 @@
             "description": "The job was updated successfully."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The job with the jobKey is not found.",
@@ -6981,24 +5116,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -7039,14 +5160,7 @@
             "description": "The job was completed successfully."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The job with the given key was not found.",
@@ -7069,24 +5183,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -7127,14 +5227,7 @@
             "description": "An error is thrown for the job."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The job with the given key was not found or is not activated.\n",
@@ -7157,24 +5250,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -7215,14 +5294,7 @@
             "description": "The job is failed."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The job with the given jobKey is not found. It was completed by another worker, or the process instance itself was canceled.\n",
@@ -7245,24 +5317,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -7323,51 +5381,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -7404,51 +5427,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -7485,51 +5473,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -7566,51 +5519,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -7647,51 +5565,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -7718,14 +5601,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -7740,6 +5616,16 @@
         "operationId": "createMappingRule",
         "summary": "Create mapping rule",
         "description": "Create a new mapping rule\n",
+        "x-semantic-establishes": {
+          "kind": "MappingRule",
+          "identifiedBy": [
+            {
+              "in": "body",
+              "name": "mappingRuleId",
+              "semanticType": "MappingRuleId"
+            }
+          ]
+        },
         "requestBody": {
           "content": {
             "application/json": {
@@ -7766,14 +5652,7 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
             "description": "The request to create a mapping rule was denied.\nMore details are provided in the response body.\n",
@@ -7796,14 +5675,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -7856,51 +5728,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -7915,6 +5752,15 @@
         "operationId": "updateMappingRule",
         "summary": "Update mapping rule",
         "description": "Update a mapping rule.\n",
+        "x-semantic-requires": {
+          "kind": "MappingRule",
+          "bind": {
+            "mappingRuleId": {
+              "from": "path",
+              "name": "mappingRuleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "mappingRuleId",
@@ -7922,7 +5768,7 @@
             "required": true,
             "description": "The ID of the mapping rule to update.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/MappingRuleId"
             }
           }
         ],
@@ -7952,14 +5798,7 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
             "description": "The request to update a mapping rule was denied.\nMore details are provided in the response body.\n",
@@ -7982,24 +5821,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -8012,6 +5837,15 @@
         "operationId": "deleteMappingRule",
         "summary": "Delete a mapping rule",
         "description": "Deletes the mapping rule with the given ID.\n",
+        "x-semantic-requires": {
+          "kind": "MappingRule",
+          "bind": {
+            "mappingRuleId": {
+              "from": "path",
+              "name": "mappingRuleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "mappingRuleId",
@@ -8019,7 +5853,7 @@
             "required": true,
             "description": "The ID of the mapping rule to delete.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/MappingRuleId"
             }
           }
         ],
@@ -8028,21 +5862,7 @@
             "description": "The mapping rule was deleted successfully."
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "404": {
             "description": "The mapping rule with the mappingRuleId was not found.",
@@ -8055,24 +5875,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -8085,6 +5891,15 @@
         "operationId": "getMappingRule",
         "summary": "Get a mapping rule",
         "description": "Gets the mapping rule with the given ID.\n",
+        "x-semantic-requires": {
+          "kind": "MappingRule",
+          "bind": {
+            "mappingRuleId": {
+              "from": "path",
+              "name": "mappingRuleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "mappingRuleId",
@@ -8092,7 +5907,7 @@
             "required": true,
             "description": "The ID of the mapping rule to get.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/MappingRuleId"
             }
           }
         ],
@@ -8108,21 +5923,7 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "404": {
             "description": "The mapping rule with the mappingRuleId was not found.",
@@ -8135,14 +5936,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -8179,51 +5973,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -8260,24 +6019,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found",
@@ -8290,24 +6035,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -8344,34 +6075,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -8408,51 +6118,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -8489,51 +6164,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -8570,51 +6210,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -8652,41 +6257,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The process definition with the given key was not found. More details are provided in the response body.\n",
@@ -8699,14 +6276,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -8747,41 +6317,13 @@
             "description": "The process was found, but no form is associated with it."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found",
@@ -8794,14 +6336,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -8849,51 +6384,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -8941,41 +6441,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The process definition with the given key was not found.\nMore details are provided in the response body.\n",
@@ -8988,14 +6460,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -9032,51 +6497,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -9130,14 +6560,7 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "409": {
             "description": "The process instance creation was rejected due to a business ID uniqueness conflict.\nThis can happen only when Business ID Uniqueness Control is enabled and an\nactive root process instance with the provided business ID already exists\nfor the same process definition and tenant.\n",
@@ -9150,24 +6573,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           },
           "504": {
             "description": "The process instance creation request timed out in the gateway.\nThis can happen if the `awaitCompletion` request parameter is set to `true`\nand the created process instance did not complete within the defined request timeout.\nThis often happens when the created instance is not fully automated or contains wait states.\n",
@@ -9224,41 +6633,13 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -9305,41 +6686,13 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -9386,41 +6739,13 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -9467,41 +6792,13 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -9548,41 +6845,13 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -9619,51 +6888,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -9701,41 +6935,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The process instance with the given key was not found.",
@@ -9748,14 +6954,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -9796,41 +6995,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The process instance is not found.",
@@ -9843,14 +7014,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -9898,14 +7062,7 @@
             "description": "The process instance is canceled."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The process instance is not found.",
@@ -9918,45 +7075,13 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           },
           "504": {
-            "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                },
-                "examples": {
-                  "taskListenerTimeout": {
-                    "value": {
-                      "type": "about:blank",
-                      "title": "DEADLINE_EXCEEDED",
-                      "status": 504,
-                      "detail": "Expected to handle request, but request timed out between gateway and broker",
-                      "instance": "/v2/user-tasks/123/completion"
-                    }
-                  }
-                }
-              }
-            }
+            "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
           }
         },
         "x-added-in-version": "8.6"
@@ -10004,31 +7129,10 @@
             "description": "The process instance is marked for deletion."
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The process instance is not found.",
@@ -10051,24 +7155,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.9"
@@ -10106,31 +7196,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "404": {
             "description": "The process instance is not found.",
@@ -10143,24 +7212,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.9"
@@ -10208,41 +7263,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The process instance with the given key was not found.",
@@ -10255,14 +7282,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -10303,14 +7323,7 @@
             "description": "The process instance is migrated."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The process instance is not found.",
@@ -10333,24 +7346,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -10391,14 +7390,7 @@
             "description": "The process instance is modified."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The process instance is not found.",
@@ -10411,24 +7403,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -10466,51 +7444,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -10548,51 +7491,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -10629,51 +7537,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.10"
@@ -10721,14 +7594,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.7"
@@ -10777,14 +7643,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.7"
@@ -10832,14 +7691,7 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The resource is not found.",
@@ -10852,24 +7704,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -10884,6 +7722,16 @@
         "operationId": "createRole",
         "summary": "Create role",
         "description": "Create a new role.",
+        "x-semantic-establishes": {
+          "kind": "Role",
+          "identifiedBy": [
+            {
+              "in": "body",
+              "name": "roleId",
+              "semanticType": "RoleId"
+            }
+          ]
+        },
         "requestBody": {
           "content": {
             "application/json": {
@@ -10905,14 +7753,7 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
             "description": "The request lacks valid authentication credentials.",
@@ -10942,24 +7783,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -10996,51 +7823,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -11055,6 +7847,15 @@
         "operationId": "getRole",
         "summary": "Get role",
         "description": "Get a role by its ID.",
+        "x-semantic-requires": {
+          "kind": "Role",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -11062,7 +7863,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           }
         ],
@@ -11078,31 +7879,10 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -11115,14 +7895,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -11135,6 +7908,15 @@
         "operationId": "updateRole",
         "summary": "Update role",
         "description": "Update a role with the given ID.",
+        "x-semantic-requires": {
+          "kind": "Role",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -11142,7 +7924,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           }
         ],
@@ -11168,31 +7950,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "404": {
             "description": "The role with the ID is not found.",
@@ -11205,24 +7966,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -11235,6 +7982,15 @@
         "operationId": "deleteRole",
         "summary": "Delete role",
         "description": "Deletes the role with the given ID.",
+        "x-semantic-requires": {
+          "kind": "Role",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -11242,7 +7998,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           }
         ],
@@ -11251,21 +8007,7 @@
             "description": "The role was deleted successfully."
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "404": {
             "description": "The role with the ID was not found.",
@@ -11278,24 +8020,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -11310,6 +8038,15 @@
         "operationId": "searchClientsForRole",
         "summary": "Search role clients",
         "description": "Search clients with assigned role.",
+        "x-semantic-requires": {
+          "kind": "Role",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -11317,7 +8054,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           }
         ],
@@ -11384,7 +8121,11 @@
                         "properties": {
                           "clientId": {
                             "description": "The ID of the client.",
-                            "type": "string"
+                            "allOf": [
+                              {
+                                "$ref": "#/components/schemas/ClientId"
+                              }
+                            ]
                           }
                         },
                         "required": [
@@ -11398,41 +8139,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -11445,14 +8158,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -11467,6 +8173,22 @@
         "operationId": "assignRoleToClient",
         "summary": "Assign a role to a client",
         "description": "Assigns the specified role to the client. The client will inherit the authorizations associated with this role.",
+        "x-semantic-establishes": {
+          "kind": "RoleClientMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "roleId",
+              "semanticType": "RoleId"
+            },
+            {
+              "in": "path",
+              "name": "clientId",
+              "semanticType": "ClientId"
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -11474,7 +8196,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           },
           {
@@ -11483,7 +8205,7 @@
             "required": true,
             "description": "The client ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClientId"
             }
           }
         ],
@@ -11492,24 +8214,10 @@
             "description": "The role was assigned successfully to the client."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -11532,24 +8240,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -11562,6 +8256,19 @@
         "operationId": "unassignRoleFromClient",
         "summary": "Unassign a role from a client",
         "description": "Unassigns the specified role from the client. The client will no longer inherit the authorizations associated with this role.",
+        "x-semantic-requires": {
+          "kind": "RoleClientMembership",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            },
+            "clientId": {
+              "from": "path",
+              "name": "clientId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -11569,7 +8276,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           },
           {
@@ -11578,7 +8285,7 @@
             "required": true,
             "description": "The client ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClientId"
             }
           }
         ],
@@ -11587,24 +8294,10 @@
             "description": "The role was unassigned successfully from the client."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role or client with the given ID or username was not found.",
@@ -11617,24 +8310,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -11649,6 +8328,15 @@
         "operationId": "searchGroupsForRole",
         "summary": "Search role groups",
         "description": "Search groups with assigned role.",
+        "x-semantic-requires": {
+          "kind": "Role",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -11656,7 +8344,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           }
         ],
@@ -11682,41 +8370,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -11729,14 +8389,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -11751,6 +8404,23 @@
         "operationId": "assignRoleToGroup",
         "summary": "Assign a role to a group",
         "description": "Assigns the specified role to the group. Every member of the group (user or client) will inherit the authorizations associated with this role.",
+        "x-semantic-establishes": {
+          "kind": "RoleGroupMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "roleId",
+              "semanticType": "RoleId"
+            },
+            {
+              "in": "path",
+              "name": "groupId",
+              "semanticType": "GroupId",
+              "acceptsExternal": true
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -11758,7 +8428,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           },
           {
@@ -11767,7 +8437,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -11776,24 +8446,10 @@
             "description": "The role was assigned successfully to the group."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role or group with the given ID was not found.",
@@ -11816,24 +8472,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -11846,6 +8488,19 @@
         "operationId": "unassignRoleFromGroup",
         "summary": "Unassign a role from a group",
         "description": "Unassigns the specified role from the group. All group members (user or client) no longer inherit the authorizations associated with this role.",
+        "x-semantic-requires": {
+          "kind": "RoleGroupMembership",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            },
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -11853,7 +8508,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           },
           {
@@ -11862,7 +8517,7 @@
             "required": true,
             "description": "The group ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -11871,24 +8526,10 @@
             "description": "The role was unassigned successfully from the group."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role or group with the given ID was not found.",
@@ -11901,24 +8542,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -11933,6 +8560,15 @@
         "operationId": "searchMappingRulesForRole",
         "summary": "Search role mapping rules",
         "description": "Search mapping rules with assigned role.",
+        "x-semantic-requires": {
+          "kind": "Role",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -11940,7 +8576,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           }
         ],
@@ -11983,41 +8619,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -12030,14 +8638,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -12052,6 +8653,22 @@
         "operationId": "assignRoleToMappingRule",
         "summary": "Assign a role to a mapping rule",
         "description": "Assigns a role to a mapping rule.",
+        "x-semantic-establishes": {
+          "kind": "RoleMappingRuleMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "roleId",
+              "semanticType": "RoleId"
+            },
+            {
+              "in": "path",
+              "name": "mappingRuleId",
+              "semanticType": "MappingRuleId"
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -12059,7 +8676,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           },
           {
@@ -12068,7 +8685,7 @@
             "required": true,
             "description": "The mapping rule ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/MappingRuleId"
             }
           }
         ],
@@ -12077,24 +8694,10 @@
             "description": "The role was assigned successfully to the mapping rule."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role or mapping rule with the given ID was not found.",
@@ -12117,24 +8720,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -12147,6 +8736,19 @@
         "operationId": "unassignRoleFromMappingRule",
         "summary": "Unassign a role from a mapping rule",
         "description": "Unassigns a role from a mapping rule.",
+        "x-semantic-requires": {
+          "kind": "RoleMappingRuleMembership",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            },
+            "mappingRuleId": {
+              "from": "path",
+              "name": "mappingRuleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -12154,7 +8756,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           },
           {
@@ -12163,7 +8765,7 @@
             "required": true,
             "description": "The mapping rule ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/MappingRuleId"
             }
           }
         ],
@@ -12172,24 +8774,10 @@
             "description": "The role was unassigned successfully from the mapping rule."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role or mapping rule with the given ID was not found.",
@@ -12202,24 +8790,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -12234,6 +8808,15 @@
         "operationId": "searchUsersForRole",
         "summary": "Search role users",
         "description": "Search users with assigned role.",
+        "x-semantic-requires": {
+          "kind": "Role",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -12241,7 +8824,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           }
         ],
@@ -12321,41 +8904,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -12368,14 +8923,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -12390,6 +8938,22 @@
         "operationId": "assignRoleToUser",
         "summary": "Assign a role to a user",
         "description": "Assigns the specified role to the user. The user will inherit the authorizations associated with this role.",
+        "x-semantic-establishes": {
+          "kind": "RoleUserMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "roleId",
+              "semanticType": "RoleId"
+            },
+            {
+              "in": "path",
+              "name": "username",
+              "semanticType": "Username"
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -12397,7 +8961,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           },
           {
@@ -12415,24 +8979,10 @@
             "description": "The role was assigned successfully to the user."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role or user with the given ID or username was not found.",
@@ -12455,24 +9005,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -12485,6 +9021,19 @@
         "operationId": "unassignRoleFromUser",
         "summary": "Unassign a role from a user",
         "description": "Unassigns a role from a user. The user will no longer inherit the authorizations associated with this role.",
+        "x-semantic-requires": {
+          "kind": "RoleUserMembership",
+          "bind": {
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            },
+            "username": {
+              "from": "path",
+              "name": "username"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "roleId",
@@ -12492,7 +9041,7 @@
             "required": true,
             "description": "The role ID.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           },
           {
@@ -12510,24 +9059,10 @@
             "description": "The role was unassigned successfully from the user."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The role or user with the given ID or username was not found.",
@@ -12540,24 +9075,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -12594,44 +9115,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -12668,14 +9161,7 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The signal is not found.",
@@ -12688,24 +9174,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.6"
@@ -12826,51 +9298,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -12911,31 +9348,10 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -12950,6 +9366,16 @@
         "operationId": "createTenant",
         "summary": "Create tenant",
         "description": "Creates a new tenant.",
+        "x-semantic-establishes": {
+          "kind": "Tenant",
+          "identifiedBy": [
+            {
+              "in": "body",
+              "name": "tenantId",
+              "semanticType": "TenantId"
+            }
+          ]
+        },
         "requestBody": {
           "content": {
             "application/json": {
@@ -12972,24 +9398,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The resource was not found.",
@@ -13005,24 +9417,10 @@
             "description": "Tenant with this id already exists."
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -13059,41 +9457,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found",
@@ -13106,14 +9476,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -13128,6 +9491,15 @@
         "operationId": "getTenant",
         "summary": "Get tenant",
         "description": "Retrieves a single tenant by tenant ID.",
+        "x-semantic-requires": {
+          "kind": "Tenant",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13151,41 +9523,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Tenant not found.",
@@ -13198,14 +9542,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -13218,6 +9555,15 @@
         "operationId": "updateTenant",
         "summary": "Update tenant",
         "description": "Updates an existing tenant.",
+        "x-semantic-requires": {
+          "kind": "Tenant",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13251,24 +9597,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The tenant was not found.",
@@ -13281,24 +9613,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -13311,6 +9629,15 @@
         "operationId": "deleteTenant",
         "summary": "Delete tenant",
         "description": "Deletes an existing tenant.",
+        "x-semantic-requires": {
+          "kind": "Tenant",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13327,24 +9654,10 @@
             "description": "The tenant was deleted successfully."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The tenant was not found.",
@@ -13357,24 +9670,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -13389,6 +9688,15 @@
         "operationId": "searchClientsForTenant",
         "summary": "Search clients for tenant",
         "description": "Retrieves a filtered and sorted list of clients for a specified tenant.",
+        "x-semantic-requires": {
+          "kind": "Tenant",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13464,7 +9772,11 @@
                         "properties": {
                           "clientId": {
                             "description": "The ID of the client.",
-                            "type": "string"
+                            "allOf": [
+                              {
+                                "$ref": "#/components/schemas/ClientId"
+                              }
+                            ]
                           }
                         },
                         "required": [
@@ -13490,6 +9802,22 @@
         "operationId": "assignClientToTenant",
         "summary": "Assign a client to a tenant",
         "description": "Assign the client to the specified tenant.\nThe client can then access tenant data and perform authorized actions.\n",
+        "x-semantic-establishes": {
+          "kind": "TenantClientMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "tenantId",
+              "semanticType": "TenantId"
+            },
+            {
+              "in": "path",
+              "name": "clientId",
+              "semanticType": "ClientId"
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13506,7 +9834,7 @@
             "required": true,
             "description": "The unique identifier of the application.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClientId"
             }
           }
         ],
@@ -13515,24 +9843,10 @@
             "description": "The client was successfully assigned to the tenant."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The tenant was not found.",
@@ -13545,24 +9859,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -13575,6 +9875,19 @@
         "operationId": "unassignClientFromTenant",
         "summary": "Unassign a client from a tenant",
         "description": "Unassigns the client from the specified tenant.\nThe client can no longer access tenant data.\n",
+        "x-semantic-requires": {
+          "kind": "TenantClientMembership",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            },
+            "clientId": {
+              "from": "path",
+              "name": "clientId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13591,7 +9904,7 @@
             "required": true,
             "description": "The unique identifier of the application.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ClientId"
             }
           }
         ],
@@ -13600,24 +9913,10 @@
             "description": "The client was successfully unassigned from the tenant."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The tenant does not exist or the client was not assigned to it.",
@@ -13630,24 +9929,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -13662,6 +9947,15 @@
         "operationId": "searchGroupIdsForTenant",
         "summary": "Search groups for tenant",
         "description": "Retrieves a filtered and sorted list of groups for a specified tenant.",
+        "x-semantic-requires": {
+          "kind": "Tenant",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13707,6 +10001,23 @@
         "operationId": "assignGroupToTenant",
         "summary": "Assign a group to a tenant",
         "description": "Assigns a group to a specified tenant.\nGroup members (users, clients) can then access tenant data and perform authorized actions.\n",
+        "x-semantic-establishes": {
+          "kind": "TenantGroupMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "tenantId",
+              "semanticType": "TenantId"
+            },
+            {
+              "in": "path",
+              "name": "groupId",
+              "semanticType": "GroupId",
+              "acceptsExternal": true
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13723,7 +10034,7 @@
             "required": true,
             "description": "The unique identifier of the group.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -13732,24 +10043,10 @@
             "description": "The group was successfully assigned to the tenant."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The tenant or group was not found.",
@@ -13762,24 +10059,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -13792,6 +10075,19 @@
         "operationId": "unassignGroupFromTenant",
         "summary": "Unassign a group from a tenant",
         "description": "Unassigns a group from a specified tenant.\nMembers of the group (users, clients) will no longer have access to the tenant's data - except they are assigned directly to the tenant.\n",
+        "x-semantic-requires": {
+          "kind": "TenantGroupMembership",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            },
+            "groupId": {
+              "from": "path",
+              "name": "groupId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13808,7 +10104,7 @@
             "required": true,
             "description": "The unique identifier of the group.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/GroupId"
             }
           }
         ],
@@ -13817,24 +10113,10 @@
             "description": "The group was successfully unassigned from the tenant."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The tenant or group was not found.",
@@ -13847,24 +10129,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -13879,6 +10147,15 @@
         "operationId": "searchMappingRulesForTenant",
         "summary": "Search mapping rules for tenant",
         "description": "Retrieves a filtered and sorted list of MappingRules for a specified tenant.",
+        "x-semantic-requires": {
+          "kind": "Tenant",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13941,6 +10218,22 @@
         "operationId": "assignMappingRuleToTenant",
         "summary": "Assign a mapping rule to a tenant",
         "description": "Assign a single mapping rule to a specified tenant.",
+        "x-semantic-establishes": {
+          "kind": "TenantMappingRuleMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "tenantId",
+              "semanticType": "TenantId"
+            },
+            {
+              "in": "path",
+              "name": "mappingRuleId",
+              "semanticType": "MappingRuleId"
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -13957,7 +10250,7 @@
             "required": true,
             "description": "The unique identifier of the mapping rule.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/MappingRuleId"
             }
           }
         ],
@@ -13966,24 +10259,10 @@
             "description": "The mapping rule was successfully assigned to the tenant."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The tenant or mapping rule was not found.",
@@ -13996,24 +10275,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -14026,6 +10291,19 @@
         "operationId": "unassignMappingRuleFromTenant",
         "summary": "Unassign a mapping rule from a tenant",
         "description": "Unassigns a single mapping rule from a specified tenant without deleting the rule.",
+        "x-semantic-requires": {
+          "kind": "TenantMappingRuleMembership",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            },
+            "mappingRuleId": {
+              "from": "path",
+              "name": "mappingRuleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -14042,7 +10320,7 @@
             "required": true,
             "description": "The unique identifier of the mapping rule.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/MappingRuleId"
             }
           }
         ],
@@ -14051,24 +10329,10 @@
             "description": "The mapping rule was successfully unassigned from the tenant."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The tenant or mapping rule was not found.",
@@ -14081,24 +10345,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -14113,6 +10363,15 @@
         "operationId": "searchRolesForTenant",
         "summary": "Search roles for tenant",
         "description": "Retrieves a filtered and sorted list of roles for a specified tenant.",
+        "x-semantic-requires": {
+          "kind": "Tenant",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -14175,6 +10434,22 @@
         "operationId": "assignRoleToTenant",
         "summary": "Assign a role to a tenant",
         "description": "Assigns a role to a specified tenant.\nUsers, Clients or Groups, that have the role assigned, will get access to the tenant's data and can perform actions according to their authorizations.\n",
+        "x-semantic-establishes": {
+          "kind": "TenantRoleMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "tenantId",
+              "semanticType": "TenantId"
+            },
+            {
+              "in": "path",
+              "name": "roleId",
+              "semanticType": "RoleId"
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -14191,7 +10466,7 @@
             "required": true,
             "description": "The unique identifier of the role.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           }
         ],
@@ -14200,24 +10475,10 @@
             "description": "The role was successfully assigned to the tenant."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The tenant or role was not found.",
@@ -14230,24 +10491,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -14260,6 +10507,19 @@
         "operationId": "unassignRoleFromTenant",
         "summary": "Unassign a role from a tenant",
         "description": "Unassigns a role from a specified tenant.\nUsers, Clients or Groups, that have the role assigned, will no longer have access to the\ntenant's data - unless they are assigned directly to the tenant.\n",
+        "x-semantic-requires": {
+          "kind": "TenantRoleMembership",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            },
+            "roleId": {
+              "from": "path",
+              "name": "roleId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -14276,7 +10536,7 @@
             "required": true,
             "description": "The unique identifier of the role.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleId"
             }
           }
         ],
@@ -14285,24 +10545,10 @@
             "description": "The role was successfully unassigned from the tenant."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The tenant or role was not found.",
@@ -14315,24 +10561,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -14347,6 +10579,15 @@
         "operationId": "searchUsersForTenant",
         "summary": "Search users for tenant",
         "description": "Retrieves a filtered and sorted list of users for a specified tenant.",
+        "x-semantic-requires": {
+          "kind": "Tenant",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -14447,6 +10688,22 @@
         "operationId": "assignUserToTenant",
         "summary": "Assign a user to a tenant",
         "description": "Assign a single user to a specified tenant. The user can then access tenant data and perform authorized actions.",
+        "x-semantic-establishes": {
+          "kind": "TenantUserMembership",
+          "shape": "edge",
+          "identifiedBy": [
+            {
+              "in": "path",
+              "name": "tenantId",
+              "semanticType": "TenantId"
+            },
+            {
+              "in": "path",
+              "name": "username",
+              "semanticType": "Username"
+            }
+          ]
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -14472,24 +10729,10 @@
             "description": "The user was successfully assigned to the tenant."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The tenant or user was not found.",
@@ -14502,24 +10745,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -14532,6 +10761,19 @@
         "operationId": "unassignUserFromTenant",
         "summary": "Unassign a user from a tenant",
         "description": "Unassigns the user from the specified tenant.\nThe user can no longer access tenant data.\n",
+        "x-semantic-requires": {
+          "kind": "TenantUserMembership",
+          "bind": {
+            "tenantId": {
+              "from": "path",
+              "name": "tenantId"
+            },
+            "username": {
+              "from": "path",
+              "name": "username"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "tenantId",
@@ -14557,24 +10799,10 @@
             "description": "The user was successfully unassigned from the tenant."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found. The tenant or user was not found.",
@@ -14587,24 +10815,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -14631,31 +10845,10 @@
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.5"
@@ -14670,6 +10863,16 @@
         "operationId": "createUser",
         "summary": "Create user",
         "description": "Create a new user.",
+        "x-semantic-establishes": {
+          "kind": "User",
+          "identifiedBy": [
+            {
+              "in": "body",
+              "name": "username",
+              "semanticType": "Username"
+            }
+          ]
+        },
         "requestBody": {
           "content": {
             "application/json": {
@@ -14692,41 +10895,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "409": {
             "description": "A user with this username already exists.",
@@ -14739,24 +10914,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -14786,94 +10947,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "required": [
-                    "items"
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching users.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "username": {
-                            "$ref": "#/components/schemas/Username"
-                          },
-                          "name": {
-                            "description": "The name of the user.",
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "email": {
-                            "description": "The email of the user.",
-                            "nullable": true,
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "username",
-                          "name",
-                          "email"
-                        ]
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/UserSearchResult"
                 }
               }
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -14888,6 +10977,15 @@
         "operationId": "getUser",
         "summary": "Get user",
         "description": "Get a user by its username.",
+        "x-semantic-requires": {
+          "kind": "User",
+          "bind": {
+            "username": {
+              "from": "path",
+              "name": "username"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "username",
@@ -14905,57 +11003,16 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "username": {
-                      "$ref": "#/components/schemas/Username"
-                    },
-                    "name": {
-                      "description": "The name of the user.",
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "email": {
-                      "description": "The email of the user.",
-                      "nullable": true,
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "username",
-                    "name",
-                    "email"
-                  ]
+                  "$ref": "#/components/schemas/UserResult"
                 }
               }
             }
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The user with the given username was not found.",
@@ -14968,14 +11025,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -14988,6 +11038,15 @@
         "operationId": "updateUser",
         "summary": "Update user",
         "description": "Updates a user.",
+        "x-semantic-requires": {
+          "kind": "User",
+          "bind": {
+            "username": {
+              "from": "path",
+              "name": "username"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "username",
@@ -15015,50 +11074,16 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "username": {
-                      "$ref": "#/components/schemas/Username"
-                    },
-                    "name": {
-                      "description": "The name of the user.",
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "email": {
-                      "description": "The email of the user.",
-                      "nullable": true,
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "username",
-                    "name",
-                    "email"
-                  ]
+                  "$ref": "#/components/schemas/UserUpdateResult"
                 }
               }
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The user was not found.",
@@ -15071,24 +11096,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -15101,6 +11112,15 @@
         "operationId": "deleteUser",
         "summary": "Delete user",
         "description": "Deletes a user.",
+        "x-semantic-requires": {
+          "kind": "User",
+          "bind": {
+            "username": {
+              "from": "path",
+              "name": "username"
+            }
+          }
+        },
         "parameters": [
           {
             "name": "username",
@@ -15117,14 +11137,7 @@
             "description": "The user was deleted successfully."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The user is not found.",
@@ -15137,24 +11150,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           }
         },
         "x-added-in-version": "8.8"
@@ -15191,51 +11190,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.6"
@@ -15273,41 +11237,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "The user task with the given key was not found.",
@@ -15320,14 +11256,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -15366,14 +11295,7 @@
             "description": "The user task was updated successfully."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The user task with the given key was not found.",
@@ -15396,24 +11318,10 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           },
           "504": {
             "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
@@ -15465,14 +11373,7 @@
             "description": "The user task was unassigned successfully."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The user task with the given key was not found.",
@@ -15495,45 +11396,13 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           },
           "504": {
-            "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                },
-                "examples": {
-                  "taskListenerTimeout": {
-                    "value": {
-                      "type": "about:blank",
-                      "title": "DEADLINE_EXCEEDED",
-                      "status": 504,
-                      "detail": "Expected to handle request, but request timed out between gateway and broker",
-                      "instance": "/v2/user-tasks/123/completion"
-                    }
-                  }
-                }
-              }
-            }
+            "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
           }
         },
         "x-added-in-version": "8.5"
@@ -15574,14 +11443,7 @@
             "description": "The user task's assignment was adjusted."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The user task with the given key was not found.",
@@ -15604,45 +11466,13 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           },
           "504": {
-            "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                },
-                "examples": {
-                  "taskListenerTimeout": {
-                    "value": {
-                      "type": "about:blank",
-                      "title": "DEADLINE_EXCEEDED",
-                      "status": 504,
-                      "detail": "Expected to handle request, but request timed out between gateway and broker",
-                      "instance": "/v2/user-tasks/123/completion"
-                    }
-                  }
-                }
-              }
-            }
+            "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
           }
         },
         "x-added-in-version": "8.5"
@@ -15690,24 +11520,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.9"
@@ -15748,14 +11564,7 @@
             "description": "The user task was completed successfully."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "404": {
             "description": "The user task with the given key was not found.",
@@ -15778,45 +11587,13 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           },
           "503": {
-            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/503"
           },
           "504": {
-            "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                },
-                "examples": {
-                  "taskListenerTimeout": {
-                    "value": {
-                      "type": "about:blank",
-                      "title": "DEADLINE_EXCEEDED",
-                      "status": 504,
-                      "detail": "Expected to handle request, but request timed out between gateway and broker",
-                      "instance": "/v2/user-tasks/123/completion"
-                    }
-                  }
-                }
-              }
-            }
+            "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
           }
         },
         "x-added-in-version": "8.5"
@@ -15872,27 +11649,7 @@
                     "description": "Sort field criteria.",
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "description": "The field to sort by.",
-                          "type": "string",
-                          "enum": [
-                            "value",
-                            "name",
-                            "tenantId",
-                            "variableKey",
-                            "scopeKey",
-                            "processInstanceKey"
-                          ]
-                        },
-                        "order": {
-                          "$ref": "#/components/schemas/SortOrderEnum"
-                        }
-                      },
-                      "required": [
-                        "field"
-                      ]
+                      "$ref": "#/paths/~1user-tasks~1{userTaskKey}~1variables~1search/post/requestBody/content/application~1json/schema/properties/sort/items"
                     }
                   },
                   "filter": {
@@ -15920,24 +11677,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -15978,41 +11721,13 @@
             "description": "The user task was found, but no form is associated with it."
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found",
@@ -16025,14 +11740,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -16133,24 +11841,10 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -16242,51 +11936,16 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -16324,41 +11983,13 @@
             }
           },
           "400": {
-            "description": "The provided data is not valid.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/400"
           },
           "401": {
-            "description": "The request lacks valid authentication credentials.",
-            "headers": {
-              "WWW-Authenticate": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/401"
           },
           "403": {
-            "description": "Forbidden. The request is not allowed.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1roles/post/responses/403"
           },
           "404": {
             "description": "Not found",
@@ -16371,14 +12002,7 @@
             }
           },
           "500": {
-            "description": "An internal error occurred while processing the request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
+            "$ref": "#/paths/~1clock/put/responses/500"
           }
         },
         "x-added-in-version": "8.8"
@@ -16398,6 +12022,396 @@
       }
     },
     "schemas": {
+      "AgentInstanceSearchQuerySortRequest": {
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "description": "The field to sort by.",
+            "type": "string",
+            "enum": [
+              "creationDate",
+              "lastUpdatedDate",
+              "completionDate",
+              "status"
+            ]
+          },
+          "order": {
+            "$ref": "#/components/schemas/SortOrderEnum"
+          }
+        }
+      },
+      "AgentInstanceSearchQuery": {
+        "description": "Agent instance search request.",
+        "type": "object",
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SearchQueryRequest"
+          }
+        ],
+        "properties": {
+          "sort": {
+            "description": "Sort field criteria.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceSearchQuerySortRequest"
+            }
+          },
+          "filter": {
+            "description": "The agent instance search filters.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceFilter"
+              }
+            ]
+          }
+        }
+      },
+      "AgentInstanceFilter": {
+        "description": "Agent instance search filter.",
+        "type": "object",
+        "properties": {
+          "agentInstanceKey": {
+            "description": "The unique key of the agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceKeyFilterProperty"
+              }
+            ]
+          },
+          "status": {
+            "description": "The current status of the agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceStatusFilterProperty"
+              }
+            ]
+          },
+          "elementId": {
+            "description": "The BPMN element ID of the agent task.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementIdFilterProperty"
+              }
+            ]
+          },
+          "processInstanceKey": {
+            "description": "The key of the process instance that owns this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessInstanceKeyFilterProperty"
+              }
+            ]
+          },
+          "processDefinitionKey": {
+            "description": "The key of the process definition associated with this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessDefinitionKeyFilterProperty"
+              }
+            ]
+          },
+          "tenantId": {
+            "description": "The tenant ID of the agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ]
+          },
+          "creationDate": {
+            "description": "The creation date of the agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTimeFilterProperty"
+              }
+            ]
+          },
+          "lastUpdatedDate": {
+            "description": "The date the agent instance was last updated.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTimeFilterProperty"
+              }
+            ]
+          },
+          "completionDate": {
+            "description": "The completion date of the agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTimeFilterProperty"
+              }
+            ]
+          }
+        }
+      },
+      "AgentInstanceSearchQueryResult": {
+        "description": "Agent instance search response.",
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SearchQueryResponse"
+          }
+        ],
+        "properties": {
+          "items": {
+            "description": "The matching agent instances.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceResult"
+            }
+          }
+        }
+      },
+      "AgentInstanceResult": {
+        "type": "object",
+        "required": [
+          "agentInstanceKey",
+          "status",
+          "definition",
+          "metrics",
+          "limits",
+          "elementId",
+          "processInstanceKey",
+          "processDefinitionKey",
+          "tenantId",
+          "creationDate",
+          "lastUpdatedDate",
+          "completionDate"
+        ],
+        "properties": {
+          "agentInstanceKey": {
+            "description": "The unique key for this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceKey"
+              }
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgentInstanceStatusEnum"
+          },
+          "definition": {
+            "description": "The static definition of the agent, including model, provider, and system prompt.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceDefinition"
+              }
+            ]
+          },
+          "metrics": {
+            "description": "Aggregated metrics across all iterations of this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceMetrics"
+              }
+            ]
+          },
+          "limits": {
+            "description": "The configured limits for this agent instance, set once at creation.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceLimits"
+              }
+            ]
+          },
+          "elementId": {
+            "description": "The BPMN element ID of the ad-hoc sub-process or AI agent task that owns this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementId"
+              }
+            ]
+          },
+          "processInstanceKey": {
+            "description": "The key of the process instance that owns this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessInstanceKey"
+              }
+            ]
+          },
+          "processDefinitionKey": {
+            "description": "The key of the process definition associated with this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessDefinitionKey"
+              }
+            ]
+          },
+          "tenantId": {
+            "description": "The tenant ID of this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantId"
+              }
+            ]
+          },
+          "creationDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date when this agent instance was created."
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date when this agent instance was last updated."
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "The date when this agent instance completed. Null while the agent is still running."
+          }
+        }
+      },
+      "AgentInstanceDefinition": {
+        "description": "The static definition of an agent instance, set once at creation.",
+        "type": "object",
+        "required": [
+          "model",
+          "provider",
+          "systemPrompt"
+        ],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "The LLM model identifier (for example, gpt-4o)."
+          },
+          "provider": {
+            "type": "string",
+            "description": "The LLM provider (for example, openai or anthropic)."
+          },
+          "systemPrompt": {
+            "type": "string",
+            "description": "The system prompt configured for this agent instance."
+          }
+        }
+      },
+      "AgentInstanceMetrics": {
+        "description": "Aggregated metrics for an agent instance across all model calls.",
+        "type": "object",
+        "required": [
+          "inputTokens",
+          "outputTokens",
+          "modelCalls",
+          "toolCalls"
+        ],
+        "properties": {
+          "inputTokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total input tokens consumed across all model calls."
+          },
+          "outputTokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total output tokens produced across all model calls."
+          },
+          "modelCalls": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total number of LLM calls made."
+          },
+          "toolCalls": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total number of tool calls made."
+          }
+        }
+      },
+      "AgentInstanceLimits": {
+        "description": "The configured limits for an agent instance, set once at creation.",
+        "type": "object",
+        "required": [
+          "maxModelCalls",
+          "maxTokens",
+          "maxToolCalls"
+        ],
+        "properties": {
+          "maxModelCalls": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum LLM calls allowed. -1 if no limit is configured."
+          },
+          "maxToolCalls": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum tool calls allowed. -1 if no limit is configured."
+          },
+          "maxTokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum total tokens allowed. -1 if no limit is configured."
+          }
+        }
+      },
+      "AgentInstanceStatusEnum": {
+        "description": "The current status of an agent instance.",
+        "type": "string",
+        "enum": [
+          "COMPLETED",
+          "IDLE",
+          "INITIALIZING",
+          "THINKING",
+          "TOOL_CALLING",
+          "TOOL_DISCOVERY"
+        ]
+      },
+      "AgentInstanceStatusFilterProperty": {
+        "description": "AgentInstanceStatusEnum property with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AgentInstanceStatusExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedAgentInstanceStatusFilter"
+          }
+        ]
+      },
+      "AdvancedAgentInstanceStatusFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced AgentInstanceStatusEnum filter.",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceStatusEnum"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceStatusEnum"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceStatusEnum"
+            }
+          },
+          "$like": {
+            "$ref": "#/components/schemas/LikeFilter"
+          }
+        }
+      },
       "AuditLogResult": {
         "description": "Audit log item.",
         "type": "object",
@@ -18664,8 +14678,12 @@
         ],
         "properties": {
           "name": {
-            "type": "string",
-            "description": "The name of the cluster variable. Must be unique within its scope (global or tenant-specific)."
+            "description": "The name of the cluster variable. Must be unique within its scope (global or tenant-specific).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterVariableName"
+              }
+            ]
           },
           "value": {
             "type": "object",
@@ -18735,8 +14753,12 @@
         ],
         "properties": {
           "name": {
-            "type": "string",
-            "description": "The name of the cluster variable. Unique within its scope (global or tenant-specific)."
+            "description": "The name of the cluster variable. Unique within its scope (global or tenant-specific).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterVariableName"
+              }
+            ]
           },
           "scope": {
             "$ref": "#/components/schemas/ClusterVariableScopeEnum"
@@ -22385,7 +18407,11 @@
         "additionalProperties": false,
         "properties": {
           "groupId": {
-            "type": "string",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GroupId"
+              }
+            ],
             "description": "The ID of the new group."
           },
           "name": {
@@ -22406,8 +18432,12 @@
         "type": "object",
         "properties": {
           "groupId": {
-            "description": "The ID of the created group.",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GroupId"
+              }
+            ],
+            "description": "The ID of the created group."
           },
           "name": {
             "description": "The display name of the created group.",
@@ -22445,8 +18475,12 @@
         "type": "object",
         "properties": {
           "groupId": {
-            "type": "string",
-            "description": "The unique external group ID."
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GroupId"
+              }
+            ],
+            "description": "The unique group ID."
           },
           "name": {
             "type": "string",
@@ -22473,7 +18507,11 @@
             "description": "The group name."
           },
           "groupId": {
-            "type": "string",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GroupId"
+              }
+            ],
             "description": "The group ID."
           },
           "description": {
@@ -22645,7 +18683,11 @@
         "properties": {
           "clientId": {
             "description": "The ID of the client.",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClientId"
+              }
+            ]
           }
         },
         "required": [
@@ -22784,6 +18826,10 @@
         "type": "string",
         "format": "GlobalListenerId",
         "x-semantic-type": "GlobalListenerId",
+        "x-semantic-client-minted": true,
+        "minLength": 1,
+        "maxLength": 256,
+        "pattern": "^[a-zA-Z0-9_~@.+\\-]+$",
         "example": "GlobalListener_1"
       },
       "TenantId": {
@@ -22792,19 +18838,74 @@
         "format": "TenantId",
         "type": "string",
         "x-semantic-type": "TenantId",
+        "x-semantic-client-minted": true,
         "minLength": 1,
-        "maxLength": 256,
-        "pattern": "^(<default>|[A-Za-z0-9_@.+-]+)$"
+        "maxLength": 31,
+        "pattern": "^(<default>|[\\w\\.\\-]{1,31})$"
       },
       "Username": {
         "example": "swillis",
         "format": "Username",
         "description": "The unique name of a user.",
         "x-semantic-type": "Username",
+        "x-semantic-client-minted": true,
         "type": "string",
         "minLength": 1,
         "maxLength": 256,
-        "pattern": "^(<default>|[A-Za-z0-9_@.+-]+)$"
+        "pattern": "^[a-zA-Z0-9_~@.+-]+$"
+      },
+      "RoleId": {
+        "example": "admin",
+        "description": "The unique identifier of a role.",
+        "format": "RoleId",
+        "type": "string",
+        "x-semantic-type": "RoleId",
+        "x-semantic-client-minted": true,
+        "minLength": 1,
+        "maxLength": 256,
+        "pattern": "^[a-zA-Z0-9_~@.+-]+$"
+      },
+      "GroupId": {
+        "example": "engineering",
+        "description": "The unique identifier of a group.",
+        "format": "GroupId",
+        "type": "string",
+        "x-semantic-type": "GroupId",
+        "x-semantic-client-minted": true,
+        "minLength": 1,
+        "maxLength": 256
+      },
+      "MappingRuleId": {
+        "example": "my-mapping-rule",
+        "description": "The unique identifier of a mapping rule.",
+        "format": "MappingRuleId",
+        "type": "string",
+        "x-semantic-type": "MappingRuleId",
+        "x-semantic-client-minted": true,
+        "minLength": 1,
+        "maxLength": 256,
+        "pattern": "^[a-zA-Z0-9_~@.+-]+$"
+      },
+      "ClientId": {
+        "example": "my-application",
+        "description": "The unique identifier of an OAuth client.\nMinted outside the Camunda REST API: in SaaS by Console, in Self-Managed\nwith OIDC by the external identity provider (e.g. EntraID, Keycloak,\nOkta). In Self-Managed with Basic authentication, machine-to-machine\napplications are modelled as users instead — see the user identifier.\n",
+        "format": "ClientId",
+        "type": "string",
+        "x-semantic-type": "ClientId",
+        "minLength": 1,
+        "maxLength": 256,
+        "pattern": "^[a-zA-Z0-9_~@.+-]+$"
+      },
+      "ClusterVariableName": {
+        "example": "feature-flag-checkout",
+        "description": "The name of a cluster variable. Unique within its scope (global or tenant-specific).",
+        "format": "ClusterVariableName",
+        "type": "string",
+        "x-semantic-type": "ClusterVariableName",
+        "x-semantic-client-minted": true,
+        "minLength": 1,
+        "maxLength": 256,
+        "pattern": "^[a-zA-Z0-9_~@.+-]+$"
       },
       "Tag": {
         "description": "A tag. Needs to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
@@ -25434,6 +21535,18 @@
         "format": "int64",
         "minimum": 1
       },
+      "AgentInstanceKey": {
+        "description": "System-generated key for an agent instance.",
+        "format": "AgentInstanceKey",
+        "x-semantic-type": "AgentInstanceKey",
+        "example": "4503599627370496",
+        "type": "string",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LongKey"
+          }
+        ]
+      },
       "AuditLogKey": {
         "allOf": [
           {
@@ -25862,6 +21975,58 @@
           }
         }
       },
+      "AgentInstanceKeyFilterProperty": {
+        "description": "AgentInstanceKey property with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AgentInstanceKeyExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedAgentInstanceKeyFilter"
+          }
+        ]
+      },
+      "AdvancedAgentInstanceKeyFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced AgentInstanceKey filter.",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceKey"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceKey"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceKey"
+            }
+          },
+          "$notIn": {
+            "description": "Checks if the property matches none of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceKey"
+            }
+          }
+        }
+      },
       "AuditLogKeyFilterProperty": {
         "description": "AuditLogKey property with full advanced search capabilities.",
         "oneOf": [
@@ -26134,7 +22299,11 @@
         ],
         "properties": {
           "mappingRuleId": {
-            "type": "string",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MappingRuleId"
+              }
+            ],
             "description": "The unique ID of the mapping rule."
           }
         },
@@ -26166,7 +22335,11 @@
             "description": "The name of the mapping rule."
           },
           "mappingRuleId": {
-            "type": "string",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MappingRuleId"
+              }
+            ],
             "description": "The unique ID of the mapping rule."
           }
         },
@@ -26229,7 +22402,11 @@
             "description": "The name of the mapping rule."
           },
           "mappingRuleId": {
-            "type": "string",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MappingRuleId"
+              }
+            ],
             "description": "The ID of the mapping rule."
           }
         },
@@ -26304,7 +22481,11 @@
             "description": "The name of the mapping rule."
           },
           "mappingRuleId": {
-            "type": "string",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MappingRuleId"
+              }
+            ],
             "description": "The ID of the mapping rule."
           }
         }
@@ -29211,8 +25392,12 @@
         "type": "object",
         "properties": {
           "roleId": {
-            "type": "string",
-            "description": "The ID of the new role."
+            "description": "The ID of the new role.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoleId"
+              }
+            ]
           },
           "name": {
             "type": "string",
@@ -29233,7 +25418,11 @@
         "properties": {
           "roleId": {
             "description": "The ID of the created role.",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoleId"
+              }
+            ]
           },
           "name": {
             "description": "The display name of the created role.",
@@ -29280,8 +25469,12 @@
             "description": "The description of the updated role."
           },
           "roleId": {
-            "type": "string",
-            "description": "The ID of the updated role."
+            "description": "The ID of the updated role.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoleId"
+              }
+            ]
           }
         },
         "required": [
@@ -29299,8 +25492,12 @@
             "description": "The role name."
           },
           "roleId": {
-            "type": "string",
-            "description": "The role id."
+            "description": "The role id.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoleId"
+              }
+            ]
           },
           "description": {
             "type": "string",
@@ -29366,7 +25563,11 @@
         "properties": {
           "roleId": {
             "description": "The role ID search filters.",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoleId"
+              }
+            ]
           },
           "name": {
             "description": "The role name search filters.",
@@ -29466,7 +25667,11 @@
         "properties": {
           "clientId": {
             "description": "The ID of the client.",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClientId"
+              }
+            ]
           }
         },
         "required": [
@@ -29533,7 +25738,11 @@
         "properties": {
           "groupId": {
             "description": "The id of the group.",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GroupId"
+              }
+            ]
           }
         },
         "required": [
@@ -29981,11 +26190,12 @@
         "additionalProperties": false,
         "properties": {
           "tenantId": {
-            "type": "string",
-            "description": "The unique ID for the tenant. Must be 255 characters or less. Can contain letters, numbers, [`_`, `-`, `+`, `.`, `@`].",
-            "minLength": 1,
-            "maxLength": 256,
-            "pattern": "^[A-Za-z0-9_@.+-]+$"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantId"
+              }
+            ],
+            "description": "The unique ID for the tenant. Must be 31 characters or less and match\n`^[\\w.-]{1,31}$` (word characters, `.`, `-`). The literal\n`<default>` is also accepted as the default-tenant alias.\n"
           },
           "name": {
             "type": "string",
@@ -30008,7 +26218,12 @@
         ],
         "properties": {
           "tenantId": {
-            "$ref": "#/components/schemas/TenantId"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantId"
+              }
+            ],
+            "description": "The unique identifier of the created tenant."
           },
           "name": {
             "type": "string",
@@ -30049,7 +26264,12 @@
         "type": "object",
         "properties": {
           "tenantId": {
-            "$ref": "#/components/schemas/TenantId"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantId"
+              }
+            ],
+            "description": "The unique identifier of the updated tenant."
           },
           "name": {
             "type": "string",
@@ -30077,7 +26297,12 @@
             "example": "Customer Service department"
           },
           "tenantId": {
-            "$ref": "#/components/schemas/TenantId"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantId"
+              }
+            ],
+            "description": "The unique identifier of the tenant."
           },
           "description": {
             "type": "string",
@@ -30144,7 +26369,12 @@
         "type": "object",
         "properties": {
           "tenantId": {
-            "$ref": "#/components/schemas/TenantId"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantId"
+              }
+            ],
+            "description": "The unique identifier of the tenant."
           },
           "name": {
             "type": "string",
@@ -30245,7 +26475,11 @@
         "properties": {
           "clientId": {
             "description": "The ID of the client.",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClientId"
+              }
+            ]
           }
         },
         "required": [
@@ -30312,8 +26546,12 @@
         "type": "object",
         "properties": {
           "groupId": {
-            "description": "The groupId of the group.",
-            "type": "string"
+            "description": "The group ID.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GroupId"
+              }
+            ]
           }
         },
         "required": [
@@ -31160,8 +27398,12 @@
             "type": "string"
           },
           "username": {
-            "description": "The username of the user.",
-            "type": "string"
+            "description": "The username of the new user.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Username"
+              }
+            ]
           },
           "name": {
             "description": "The name of the user.",
@@ -31184,7 +27426,12 @@
         ],
         "properties": {
           "username": {
-            "$ref": "#/components/schemas/Username"
+            "description": "The username of the created user.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Username"
+              }
+            ]
           },
           "name": {
             "description": "The name of the user.",
@@ -31224,7 +27471,12 @@
         "type": "object",
         "properties": {
           "username": {
-            "$ref": "#/components/schemas/Username"
+            "description": "The username of the updated user.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Username"
+              }
+            ]
           },
           "name": {
             "description": "The name of the user.",
@@ -31247,7 +27499,12 @@
         "type": "object",
         "properties": {
           "username": {
-            "$ref": "#/components/schemas/Username"
+            "description": "The username of the user.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Username"
+              }
+            ]
           },
           "name": {
             "description": "The name of the user.",
@@ -31634,6 +27891,16 @@
           "variables"
         ]
       },
+      "AgentInstanceStatusExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentInstanceStatusEnum"
+          }
+        ]
+      },
       "AuditLogEntityKeyExactMatch": {
         "type": "string",
         "title": "Exact match",
@@ -31942,6 +28209,16 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/DecisionEvaluationInstanceKey"
+          }
+        ]
+      },
+      "AgentInstanceKeyExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentInstanceKey"
           }
         ]
       },

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -179,13 +179,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The agent instance with the given key was not found.\nMore details are provided in the response body.\n",
@@ -198,7 +226,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.10"
@@ -235,16 +270,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.10"
@@ -281,13 +351,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
             "description": "An internal error occurred while processing the request."
@@ -328,10 +426,31 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The audit log with the given key was not found.",
@@ -344,7 +463,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -376,13 +502,41 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -419,13 +573,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The owner was not found.",
@@ -438,10 +620,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -477,16 +673,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -527,7 +758,21 @@
             "description": "The authorization was updated successfully."
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The authorization with the authorizationKey was not found.",
@@ -540,10 +785,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -579,10 +838,31 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The authorization with the given key was not found.",
@@ -595,7 +875,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -624,7 +911,21 @@
             "description": "The authorization was deleted successfully."
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The authorization with the authorizationKey was not found.",
@@ -637,10 +938,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -687,7 +1002,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -734,7 +1056,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -792,7 +1121,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -830,10 +1166,24 @@
             "content": {}
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The batch operation was not found.",
@@ -846,7 +1196,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -884,10 +1241,24 @@
             "content": {}
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The batch operation was not found.",
@@ -900,10 +1271,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -941,10 +1326,24 @@
             "content": {}
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The batch operation was not found.",
@@ -957,10 +1356,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -1037,10 +1450,24 @@
             "description": "The clock was successfully reset to the system time."
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -1087,16 +1514,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -1143,13 +1605,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Cluster variable not found",
@@ -1162,7 +1652,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -1217,13 +1714,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Cluster variable not found",
@@ -1236,7 +1761,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -1274,13 +1806,41 @@
             "description": "Cluster variable deleted successfully"
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Cluster variable not found",
@@ -1293,7 +1853,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -1340,16 +1907,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -1421,13 +2023,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The tenant with the given ID was not found.",
@@ -1440,7 +2070,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -1500,13 +2137,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Cluster variable not found",
@@ -1519,7 +2184,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -1587,13 +2259,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Cluster variable not found",
@@ -1606,7 +2306,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -1657,13 +2364,41 @@
             "description": "Cluster variable deleted successfully"
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Cluster variable not found",
@@ -1676,7 +2411,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -1742,7 +2484,14 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
             "description": "The client is not authorized to start process instances for the specified process definition.\nIf a processDefinitionKey is not provided, this indicates that the client is not authorized\nto start process instances for at least one of the matched process definitions.\n",
@@ -1765,10 +2514,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -1805,16 +2568,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -1867,7 +2665,14 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The decision is not found.",
@@ -1880,10 +2685,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -1920,16 +2739,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -1967,13 +2821,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The decision definition with the given key was not found. More details are provided in the response body.\n",
@@ -1986,7 +2868,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -2024,13 +2913,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The decision definition with the given key was not found. More details are provided in the response body.\n",
@@ -2043,7 +2960,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -2080,16 +3004,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -2127,13 +3086,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The decision instance with the given key was not found. More details are provided in the response body.\n",
@@ -2146,7 +3133,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -2177,14 +3171,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "nullable": true,
-                "additionalProperties": false,
-                "properties": {
-                  "operationReference": {
-                    "$ref": "#/components/schemas/OperationReference"
-                  }
-                }
+                "$ref": "#/components/schemas/DeleteDecisionInstanceRequest"
               }
             }
           }
@@ -2194,10 +3181,31 @@
             "description": "The decision instance is marked for deletion."
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The decision instance is not found.",
@@ -2210,10 +3218,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -2260,13 +3282,41 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -2303,16 +3353,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -2350,13 +3435,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The decision requirements with the given key was not found. More details are provided in the response body.\n",
@@ -2369,7 +3482,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -2407,13 +3527,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The decision requirements with the given key was not found. More details are provided in the response body.\n",
@@ -2426,7 +3574,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -2480,10 +3635,24 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -2558,7 +3727,14 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "415": {
             "description": "The server cannot process the request because the media type (Content-Type) of the request payload is not supported\nby the server for the requested resource and method.\n",
@@ -2660,10 +3836,24 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "415": {
-            "$ref": "#/paths/~1documents/post/responses/415"
+            "description": "The server cannot process the request because the media type (Content-Type) of the request payload is not supported\nby the server for the requested resource and method.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.7"
@@ -2730,7 +3920,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -2778,7 +3975,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -2844,7 +4048,14 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.7"
@@ -2885,13 +4096,41 @@
             "description": "The ad-hoc sub-process instance is modified."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The ad-hoc sub-process instance is not found or the provided key does not identify an ad-hoc sub-process.",
@@ -2904,10 +4143,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -2944,16 +4197,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -2991,13 +4279,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The element instance with the given key was not found.\nMore details are provided in the response body.\n",
@@ -3010,7 +4326,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -3058,13 +4381,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The element instance with the given key was not found.",
@@ -3077,7 +4428,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -3118,16 +4476,55 @@
             "description": "The variables were updated."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "504": {
-            "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
+            "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                },
+                "examples": {
+                  "taskListenerTimeout": {
+                    "value": {
+                      "type": "about:blank",
+                      "title": "DEADLINE_EXCEEDED",
+                      "status": 504,
+                      "detail": "Expected to handle request, but request timed out between gateway and broker",
+                      "instance": "/v2/user-tasks/123/completion"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -3164,16 +4561,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -3220,13 +4652,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "409": {
             "description": "A global listener with this id already exists.",
@@ -3239,10 +4699,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -3289,10 +4763,31 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The global user task listener with the given id was not found.",
@@ -3305,7 +4800,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -3360,13 +4862,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The global user task listener was not found.",
@@ -3379,10 +4909,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -3420,13 +4964,41 @@
             "description": "The global listener was deleted successfully."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The global user task listener was not found.",
@@ -3439,10 +5011,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -3478,16 +5064,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -3533,19 +5154,61 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -3582,16 +5245,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -3638,10 +5336,31 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -3654,7 +5373,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -3709,10 +5435,31 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -3725,10 +5472,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -3766,7 +5527,21 @@
             "description": "The group was deleted successfully."
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -3779,10 +5554,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -3822,36 +5611,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SearchQueryRequest"
-                  }
-                ],
-                "type": "object",
-                "properties": {
-                  "sort": {
-                    "description": "Sort field criteria.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "description": "The field to sort by.",
-                          "type": "string",
-                          "enum": [
-                            "clientId"
-                          ]
-                        },
-                        "order": {
-                          "$ref": "#/components/schemas/SortOrderEnum"
-                        }
-                      },
-                      "required": [
-                        "field"
-                      ]
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/GroupClientSearchQueryRequest"
               }
             }
           }
@@ -3862,49 +5622,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "items"
-                  ],
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching client IDs.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "clientId": {
-                            "description": "The ID of the client.",
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/ClientId"
-                              }
-                            ]
-                          }
-                        },
-                        "required": [
-                          "clientId"
-                        ]
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/GroupClientSearchResult"
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -3917,7 +5675,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -3973,10 +5738,24 @@
             "description": "The client was assigned successfully to the group."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -3999,10 +5778,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -4053,10 +5846,24 @@
             "description": "The client was unassigned successfully from the group."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group with the given ID was not found, or the client is not assigned to this group.",
@@ -4069,10 +5876,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -4123,36 +5944,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "items"
-                  ],
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching mapping rules.",
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/MappingRuleResult"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/GroupMappingRuleSearchResult"
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -4165,7 +5997,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -4221,10 +6060,24 @@
             "description": "The mapping rule was assigned successfully to the group."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group or mapping rule with the given ID was not found.",
@@ -4247,10 +6100,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -4301,10 +6168,24 @@
             "description": "The mapping rule was unassigned successfully from the group."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group or mapping rule with the given ID was not found, or the mapping rule is not assigned to this group.",
@@ -4317,10 +6198,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -4371,36 +6266,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "items"
-                  ],
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching roles.",
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/RoleResult"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/GroupRoleSearchResult"
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -4413,7 +6319,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -4453,36 +6366,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SearchQueryRequest"
-                  }
-                ],
-                "type": "object",
-                "properties": {
-                  "sort": {
-                    "description": "Sort field criteria.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "description": "The field to sort by.",
-                          "type": "string",
-                          "enum": [
-                            "username"
-                          ]
-                        },
-                        "order": {
-                          "$ref": "#/components/schemas/SortOrderEnum"
-                        }
-                      },
-                      "required": [
-                        "field"
-                      ]
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/GroupUserSearchQueryRequest"
               }
             }
           }
@@ -4493,44 +6377,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "items"
-                  ],
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching members.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "username": {
-                            "$ref": "#/components/schemas/Username"
-                          }
-                        },
-                        "required": [
-                          "username"
-                        ]
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/GroupUserSearchResult"
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group with the given ID was not found.",
@@ -4543,7 +6430,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -4599,10 +6493,24 @@
             "description": "The user was assigned successfully to the group."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group or user with the given ID or username was not found.",
@@ -4625,10 +6533,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -4679,10 +6601,24 @@
             "description": "The user was unassigned successfully from the group."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The group or user with the given ID was not found, or the user is not assigned to this group.",
@@ -4695,10 +6631,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -4735,16 +6685,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -4782,13 +6767,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The incident with the given key was not found.",
@@ -4801,7 +6814,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -4842,7 +6862,14 @@
             "description": "The incident is marked as resolved."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The incident with the incidentKey is not found.",
@@ -4865,10 +6892,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -4905,16 +6946,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -4951,16 +7027,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -4997,16 +7108,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -5043,16 +7189,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -5093,7 +7274,14 @@
             "description": "The job was updated successfully."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The job with the jobKey is not found.",
@@ -5116,10 +7304,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -5160,7 +7362,14 @@
             "description": "The job was completed successfully."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The job with the given key was not found.",
@@ -5183,10 +7392,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -5227,7 +7450,14 @@
             "description": "An error is thrown for the job."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The job with the given key was not found or is not activated.\n",
@@ -5250,10 +7480,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -5294,7 +7538,14 @@
             "description": "The job is failed."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The job with the given jobKey is not found. It was completed by another worker, or the process instance itself was canceled.\n",
@@ -5317,10 +7568,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -5381,16 +7646,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -5427,16 +7727,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -5473,16 +7808,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -5519,16 +7889,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -5565,16 +7970,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -5601,7 +8041,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -5641,18 +8088,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/MappingRuleCreateUpdateResult"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/MappingRuleCreateResult"
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
             "description": "The request to create a mapping rule was denied.\nMore details are provided in the response body.\n",
@@ -5675,7 +8124,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -5705,39 +8161,57 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "items"
-                  ],
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching mapping rules.",
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/MappingRuleResult"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/MappingRuleSearchQueryResult"
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -5787,18 +8261,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/MappingRuleCreateUpdateResult"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/MappingRuleUpdateResult"
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
             "description": "The request to update a mapping rule was denied.\nMore details are provided in the response body.\n",
@@ -5821,10 +8297,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -5862,7 +8352,21 @@
             "description": "The mapping rule was deleted successfully."
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The mapping rule with the mappingRuleId was not found.",
@@ -5875,10 +8379,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -5923,7 +8441,21 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The mapping rule with the mappingRuleId was not found.",
@@ -5936,7 +8468,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -5973,16 +8512,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6019,10 +8593,24 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found",
@@ -6035,10 +8623,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -6075,13 +8677,34 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -6118,16 +8741,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6164,16 +8822,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -6210,16 +8903,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -6257,13 +8985,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The process definition with the given key was not found. More details are provided in the response body.\n",
@@ -6276,7 +9032,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6317,13 +9080,41 @@
             "description": "The process was found, but no form is associated with it."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found",
@@ -6336,7 +9127,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6384,16 +9182,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6441,13 +9274,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The process definition with the given key was not found.\nMore details are provided in the response body.\n",
@@ -6460,7 +9321,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6497,16 +9365,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -6560,7 +9463,14 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "409": {
             "description": "The process instance creation was rejected due to a business ID uniqueness conflict.\nThis can happen only when Business ID Uniqueness Control is enabled and an\nactive root process instance with the provided business ID already exists\nfor the same process definition and tenant.\n",
@@ -6573,10 +9483,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "504": {
             "description": "The process instance creation request timed out in the gateway.\nThis can happen if the `awaitCompletion` request parameter is set to `true`\nand the created process instance did not complete within the defined request timeout.\nThis often happens when the created instance is not fully automated or contains wait states.\n",
@@ -6633,13 +9557,41 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6686,13 +9638,41 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -6739,13 +9719,41 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6792,13 +9800,41 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6845,13 +9881,41 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6888,16 +9952,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -6935,13 +10034,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The process instance with the given key was not found.",
@@ -6954,7 +10081,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -6995,13 +10129,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The process instance is not found.",
@@ -7014,7 +10176,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -7045,14 +10214,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "nullable": true,
-                "additionalProperties": false,
-                "properties": {
-                  "operationReference": {
-                    "$ref": "#/components/schemas/OperationReference"
-                  }
-                }
+                "$ref": "#/components/schemas/CancelProcessInstanceRequest"
               }
             }
           }
@@ -7062,7 +10224,14 @@
             "description": "The process instance is canceled."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The process instance is not found.",
@@ -7075,13 +10244,45 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "504": {
-            "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
+            "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                },
+                "examples": {
+                  "taskListenerTimeout": {
+                    "value": {
+                      "type": "about:blank",
+                      "title": "DEADLINE_EXCEEDED",
+                      "status": 504,
+                      "detail": "Expected to handle request, but request timed out between gateway and broker",
+                      "instance": "/v2/user-tasks/123/completion"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -7112,14 +10313,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "nullable": true,
-                "additionalProperties": false,
-                "properties": {
-                  "operationReference": {
-                    "$ref": "#/components/schemas/OperationReference"
-                  }
-                }
+                "$ref": "#/components/schemas/DeleteProcessInstanceRequest"
               }
             }
           }
@@ -7129,10 +10323,31 @@
             "description": "The process instance is marked for deletion."
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The process instance is not found.",
@@ -7155,10 +10370,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -7196,10 +10425,31 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The process instance is not found.",
@@ -7212,10 +10462,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -7263,13 +10527,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The process instance with the given key was not found.",
@@ -7282,7 +10574,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -7323,7 +10622,14 @@
             "description": "The process instance is migrated."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The process instance is not found.",
@@ -7346,10 +10652,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -7390,7 +10710,14 @@
             "description": "The process instance is modified."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The process instance is not found.",
@@ -7403,10 +10730,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -7444,16 +10785,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -7491,16 +10867,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -7537,16 +10948,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.10"
@@ -7594,7 +11040,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.7"
@@ -7643,7 +11096,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.7"
@@ -7691,7 +11151,14 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The resource is not found.",
@@ -7704,10 +11171,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -7753,7 +11234,14 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request lacks valid authentication credentials.",
@@ -7783,10 +11271,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -7823,16 +11325,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -7879,10 +11416,31 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -7895,7 +11453,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -7950,10 +11515,31 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role with the ID is not found.",
@@ -7966,10 +11552,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8007,7 +11607,21 @@
             "description": "The role was deleted successfully."
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role with the ID was not found.",
@@ -8020,10 +11634,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8063,36 +11691,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SearchQueryRequest"
-                  }
-                ],
-                "type": "object",
-                "properties": {
-                  "sort": {
-                    "description": "Sort field criteria.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "description": "The field to sort by.",
-                          "type": "string",
-                          "enum": [
-                            "clientId"
-                          ]
-                        },
-                        "order": {
-                          "$ref": "#/components/schemas/SortOrderEnum"
-                        }
-                      },
-                      "required": [
-                        "field"
-                      ]
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/RoleClientSearchQueryRequest"
               }
             }
           }
@@ -8103,49 +11702,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "items"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching clients.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "clientId": {
-                            "description": "The ID of the client.",
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/ClientId"
-                              }
-                            ]
-                          }
-                        },
-                        "required": [
-                          "clientId"
-                        ]
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/RoleClientSearchResult"
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -8158,7 +11755,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8214,10 +11818,24 @@
             "description": "The role was assigned successfully to the client."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -8240,10 +11858,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8294,10 +11926,24 @@
             "description": "The role was unassigned successfully from the client."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role or client with the given ID or username was not found.",
@@ -8310,10 +11956,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8370,13 +12030,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -8389,7 +12077,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8446,10 +12141,24 @@
             "description": "The role was assigned successfully to the group."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role or group with the given ID was not found.",
@@ -8472,10 +12181,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8526,10 +12249,24 @@
             "description": "The role was unassigned successfully from the group."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role or group with the given ID was not found.",
@@ -8542,10 +12279,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8596,36 +12347,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "items"
-                  ],
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching mapping rules.",
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/MappingRuleResult"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/RoleMappingRuleSearchResult"
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -8638,7 +12400,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8694,10 +12463,24 @@
             "description": "The role was assigned successfully to the mapping rule."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role or mapping rule with the given ID was not found.",
@@ -8720,10 +12503,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8774,10 +12571,24 @@
             "description": "The role was unassigned successfully from the mapping rule."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role or mapping rule with the given ID was not found.",
@@ -8790,10 +12601,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8833,36 +12658,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SearchQueryRequest"
-                  }
-                ],
-                "type": "object",
-                "properties": {
-                  "sort": {
-                    "description": "Sort field criteria.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "description": "The field to sort by.",
-                          "type": "string",
-                          "enum": [
-                            "username"
-                          ]
-                        },
-                        "order": {
-                          "$ref": "#/components/schemas/SortOrderEnum"
-                        }
-                      },
-                      "required": [
-                        "field"
-                      ]
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/RoleUserSearchQueryRequest"
               }
             }
           }
@@ -8873,44 +12669,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "items"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching users.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "username": {
-                            "$ref": "#/components/schemas/Username"
-                          }
-                        },
-                        "required": [
-                          "username"
-                        ]
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/RoleUserSearchResult"
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role with the given ID was not found.",
@@ -8923,7 +12722,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -8979,10 +12785,24 @@
             "description": "The role was assigned successfully to the user."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role or user with the given ID or username was not found.",
@@ -9005,10 +12825,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -9059,10 +12893,24 @@
             "description": "The role was unassigned successfully from the user."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The role or user with the given ID or username was not found.",
@@ -9075,10 +12923,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -9115,16 +12977,44 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -9161,7 +13051,14 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The signal is not found.",
@@ -9174,10 +13071,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -9298,16 +13209,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -9348,10 +13294,31 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -9398,10 +13365,24 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The resource was not found.",
@@ -9417,10 +13398,24 @@
             "description": "Tenant with this id already exists."
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -9457,13 +13452,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found",
@@ -9476,7 +13499,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -9523,13 +13553,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Tenant not found.",
@@ -9542,7 +13600,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -9597,10 +13662,24 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The tenant was not found.",
@@ -9613,10 +13692,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -9654,10 +13747,24 @@
             "description": "The tenant was deleted successfully."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The tenant was not found.",
@@ -9670,10 +13777,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -9713,37 +13834,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "additionalProperties": false,
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SearchQueryRequest"
-                  }
-                ],
-                "type": "object",
-                "properties": {
-                  "sort": {
-                    "description": "Sort field criteria.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "description": "The field to sort by.",
-                          "type": "string",
-                          "enum": [
-                            "clientId"
-                          ]
-                        },
-                        "order": {
-                          "$ref": "#/components/schemas/SortOrderEnum"
-                        }
-                      },
-                      "required": [
-                        "field"
-                      ]
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/TenantClientSearchQueryRequest"
               }
             }
           }
@@ -9754,37 +13845,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "items"
-                  ],
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching clients.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "clientId": {
-                            "description": "The ID of the client.",
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/ClientId"
-                              }
-                            ]
-                          }
-                        },
-                        "required": [
-                          "clientId"
-                        ]
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/TenantClientSearchResult"
                 }
               }
             }
@@ -9843,10 +13904,24 @@
             "description": "The client was successfully assigned to the tenant."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The tenant was not found.",
@@ -9859,10 +13934,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -9913,10 +14002,24 @@
             "description": "The client was successfully unassigned from the tenant."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The tenant does not exist or the client was not assigned to it.",
@@ -9929,10 +14032,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -10043,10 +14160,24 @@
             "description": "The group was successfully assigned to the tenant."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The tenant or group was not found.",
@@ -10059,10 +14190,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -10113,10 +14258,24 @@
             "description": "The group was successfully unassigned from the tenant."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The tenant or group was not found.",
@@ -10129,10 +14288,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -10183,24 +14356,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "items"
-                  ],
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching mapping rules.",
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/MappingRuleResult"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/TenantMappingRuleSearchResult"
                 }
               }
             }
@@ -10259,10 +14415,24 @@
             "description": "The mapping rule was successfully assigned to the tenant."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The tenant or mapping rule was not found.",
@@ -10275,10 +14445,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -10329,10 +14513,24 @@
             "description": "The mapping rule was successfully unassigned from the tenant."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The tenant or mapping rule was not found.",
@@ -10345,10 +14543,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -10399,24 +14611,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "items"
-                  ],
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching roles.",
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/RoleResult"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/TenantRoleSearchResult"
                 }
               }
             }
@@ -10475,10 +14670,24 @@
             "description": "The role was successfully assigned to the tenant."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The tenant or role was not found.",
@@ -10491,10 +14700,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -10545,10 +14768,24 @@
             "description": "The role was successfully unassigned from the tenant."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The tenant or role was not found.",
@@ -10561,10 +14798,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -10604,37 +14855,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "additionalProperties": false,
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SearchQueryRequest"
-                  }
-                ],
-                "type": "object",
-                "properties": {
-                  "sort": {
-                    "description": "Sort field criteria.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "description": "The field to sort by.",
-                          "type": "string",
-                          "enum": [
-                            "username"
-                          ]
-                        },
-                        "order": {
-                          "$ref": "#/components/schemas/SortOrderEnum"
-                        }
-                      },
-                      "required": [
-                        "field"
-                      ]
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/TenantUserSearchQueryRequest"
               }
             }
           }
@@ -10645,32 +14866,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "items"
-                  ],
-                  "type": "object",
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/SearchQueryResponse"
-                    }
-                  ],
-                  "properties": {
-                    "items": {
-                      "description": "The matching users.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "username": {
-                            "$ref": "#/components/schemas/Username"
-                          }
-                        },
-                        "required": [
-                          "username"
-                        ]
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/TenantUserSearchResult"
                 }
               }
             }
@@ -10729,10 +14925,24 @@
             "description": "The user was successfully assigned to the tenant."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The tenant or user was not found.",
@@ -10745,10 +14955,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -10799,10 +15023,24 @@
             "description": "The user was successfully unassigned from the tenant."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found. The tenant or user was not found.",
@@ -10815,10 +15053,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -10845,10 +15097,31 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.5"
@@ -10895,13 +15168,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "409": {
             "description": "A user with this username already exists.",
@@ -10914,10 +15215,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -10953,16 +15268,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -11009,10 +15359,31 @@
             }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The user with the given username was not found.",
@@ -11025,7 +15396,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -11080,10 +15458,24 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The user was not found.",
@@ -11096,10 +15488,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -11137,7 +15543,14 @@
             "description": "The user was deleted successfully."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The user is not found.",
@@ -11150,10 +15563,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -11190,16 +15617,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.6"
@@ -11237,13 +15699,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The user task with the given key was not found.",
@@ -11256,7 +15746,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -11295,7 +15792,14 @@
             "description": "The user task was updated successfully."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The user task with the given key was not found.",
@@ -11318,10 +15822,24 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "504": {
             "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
@@ -11373,7 +15891,14 @@
             "description": "The user task was unassigned successfully."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The user task with the given key was not found.",
@@ -11396,13 +15921,45 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "504": {
-            "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
+            "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                },
+                "examples": {
+                  "taskListenerTimeout": {
+                    "value": {
+                      "type": "about:blank",
+                      "title": "DEADLINE_EXCEEDED",
+                      "status": 504,
+                      "detail": "Expected to handle request, but request timed out between gateway and broker",
+                      "instance": "/v2/user-tasks/123/completion"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.5"
@@ -11443,7 +16000,14 @@
             "description": "The user task's assignment was adjusted."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The user task with the given key was not found.",
@@ -11466,13 +16030,45 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "504": {
-            "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
+            "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                },
+                "examples": {
+                  "taskListenerTimeout": {
+                    "value": {
+                      "type": "about:blank",
+                      "title": "DEADLINE_EXCEEDED",
+                      "status": 504,
+                      "detail": "Expected to handle request, but request timed out between gateway and broker",
+                      "instance": "/v2/user-tasks/123/completion"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.5"
@@ -11520,10 +16116,24 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.9"
@@ -11564,7 +16174,14 @@
             "description": "The user task was completed successfully."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "The user task with the given key was not found.",
@@ -11587,13 +16204,45 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "503": {
-            "$ref": "#/paths/~1clock/put/responses/503"
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "504": {
-            "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
+            "description": "The request timed out between the gateway and the broker. For these endpoints, this often happens when user task listeners are configured and the corresponding listener job is not completed within the request timeout. Common causes include no available job workers for the listener type, busy or crashed job workers, or delayed job completion. As with any gateway timeout, general timeout causes (for example transient network issues) can also result in a 504 response.\nTroubleshooting: - verify that job workers for the listener type are running and healthy - check worker logs for crashes, retries, and completion failures - check network connectivity between workers, gateway, and broker - retry with backoff after transient failures - fail without retries if a problem persists\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                },
+                "examples": {
+                  "taskListenerTimeout": {
+                    "value": {
+                      "type": "about:blank",
+                      "title": "DEADLINE_EXCEEDED",
+                      "status": 504,
+                      "detail": "Expected to handle request, but request timed out between gateway and broker",
+                      "instance": "/v2/user-tasks/123/completion"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.5"
@@ -11633,34 +16282,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "description": "User task effective variable search query request. Uses offset-based pagination only.\n",
-                "additionalProperties": false,
-                "type": "object",
-                "properties": {
-                  "page": {
-                    "description": "Pagination parameters.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/OffsetPagination"
-                      }
-                    ]
-                  },
-                  "sort": {
-                    "description": "Sort field criteria.",
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/paths/~1user-tasks~1{userTaskKey}~1variables~1search/post/requestBody/content/application~1json/schema/properties/sort/items"
-                    }
-                  },
-                  "filter": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/UserTaskVariableFilter"
-                      }
-                    ],
-                    "description": "The user task variable search filters."
-                  }
-                }
+                "$ref": "#/components/schemas/UserTaskEffectiveVariableSearchQueryRequest"
               }
             }
           }
@@ -11677,10 +16299,24 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -11721,13 +16357,41 @@
             "description": "The user task was found, but no form is associated with it."
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found",
@@ -11740,7 +16404,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -11780,51 +16451,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SearchQueryRequest"
-                  }
-                ],
-                "description": "User task search query request.",
-                "additionalProperties": false,
-                "type": "object",
-                "properties": {
-                  "sort": {
-                    "description": "Sort field criteria.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "description": "The field to sort by.",
-                          "type": "string",
-                          "enum": [
-                            "value",
-                            "name",
-                            "tenantId",
-                            "variableKey",
-                            "scopeKey",
-                            "processInstanceKey"
-                          ]
-                        },
-                        "order": {
-                          "$ref": "#/components/schemas/SortOrderEnum"
-                        }
-                      },
-                      "required": [
-                        "field"
-                      ]
-                    }
-                  },
-                  "filter": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/UserTaskVariableFilter"
-                      }
-                    ],
-                    "description": "The user task variable search filters."
-                  }
-                }
+                "$ref": "#/components/schemas/UserTaskVariableSearchQueryRequest"
               }
             }
           }
@@ -11841,10 +16468,24 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -11875,51 +16516,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "description": "Variable search query request.",
-                "additionalProperties": false,
-                "type": "object",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SearchQueryRequest"
-                  }
-                ],
-                "properties": {
-                  "sort": {
-                    "description": "Sort field criteria.",
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "description": "The field to sort by.",
-                          "type": "string",
-                          "enum": [
-                            "value",
-                            "name",
-                            "tenantId",
-                            "variableKey",
-                            "scopeKey",
-                            "processInstanceKey"
-                          ]
-                        },
-                        "order": {
-                          "$ref": "#/components/schemas/SortOrderEnum"
-                        }
-                      },
-                      "required": [
-                        "field"
-                      ]
-                    }
-                  },
-                  "filter": {
-                    "description": "The variable search filters.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/VariableFilter"
-                      }
-                    ]
-                  }
-                }
+                "$ref": "#/components/schemas/VariableSearchQuery"
               }
             }
           }
@@ -11936,16 +16533,51 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"
@@ -11983,13 +16615,41 @@
             }
           },
           "400": {
-            "$ref": "#/paths/~1clock/put/responses/400"
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/paths/~1roles/post/responses/401"
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/paths/~1roles/post/responses/403"
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found",
@@ -12002,7 +16662,14 @@
             }
           },
           "500": {
-            "$ref": "#/paths/~1clock/put/responses/500"
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         },
         "x-added-in-version": "8.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.0.3",
         "@semantic-release/git": "^10.0.1",
-        "camunda-schema-bundler": "^1.6.1",
+        "camunda-schema-bundler": "^2.4.1",
         "semantic-release": "^25.0.2"
       }
     },
@@ -1384,9 +1384,9 @@
       }
     },
     "node_modules/camunda-schema-bundler": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/camunda-schema-bundler/-/camunda-schema-bundler-1.6.1.tgz",
-      "integrity": "sha512-gpudhXk6wTOgRcujdUtJlMoGp6AS1kms4ZzZrgj/dwKzZ1CvL8c+wXgGM9sdxONdWyWDRmO8wQ1BJOSTduZU1A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/camunda-schema-bundler/-/camunda-schema-bundler-2.4.1.tgz",
+      "integrity": "sha512-fG/7I30Nhtb1XPfo1pboAVp9mhO62JIso8XNc9N4AiZk0n2g96ht1bhz0jt27zmD+/b/wXPOGBuYyhzY4bna9w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.0.3",
     "@semantic-release/git": "^10.0.1",
-    "camunda-schema-bundler": "^1.6.1",
+    "camunda-schema-bundler": "^2.4.1",
     "semantic-release": "^25.0.2"
   }
 }

--- a/scripts/bundle-spec.sh
+++ b/scripts/bundle-spec.sh
@@ -26,7 +26,7 @@ if [ "${CAMUNDA_SDK_SKIP_FETCH_SPEC:-0}" = "1" ]; then
         --output-spec "$BUNDLED_SPEC" \
         --output-metadata "$METADATA"
 else
-    REF="${SPEC_REF:-stable/8.9}"
+    REF="${SPEC_REF:-main}"
     echo "[bundle-spec] Fetching (ref: $REF) and bundling spec"
     npx camunda-schema-bundler \
         --ref "$REF" \

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -134,7 +134,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignClientToGroupAsync(string groupId, string clientId, CancellationToken ct = default)
+    public async Task AssignClientToGroupAsync(GroupId groupId, ClientId clientId, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}/clients/{Uri.EscapeDataString(clientId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignClientToGroup", false, ct);
@@ -173,7 +173,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignClientToTenantAsync(TenantId tenantId, string clientId, CancellationToken ct = default)
+    public async Task AssignClientToTenantAsync(TenantId tenantId, ClientId clientId, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/clients/{Uri.EscapeDataString(clientId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignClientToTenant", false, ct);
@@ -212,7 +212,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignGroupToTenantAsync(TenantId tenantId, string groupId, CancellationToken ct = default)
+    public async Task AssignGroupToTenantAsync(TenantId tenantId, GroupId groupId, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/groups/{Uri.EscapeDataString(groupId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignGroupToTenant", false, ct);
@@ -245,7 +245,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignMappingRuleToGroupAsync(string groupId, string mappingRuleId, CancellationToken ct = default)
+    public async Task AssignMappingRuleToGroupAsync(GroupId groupId, MappingRuleId mappingRuleId, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}/mapping-rules/{Uri.EscapeDataString(mappingRuleId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignMappingRuleToGroup", false, ct);
@@ -282,7 +282,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignMappingRuleToTenantAsync(TenantId tenantId, string mappingRuleId, CancellationToken ct = default)
+    public async Task AssignMappingRuleToTenantAsync(TenantId tenantId, MappingRuleId mappingRuleId, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/mapping-rules/{Uri.EscapeDataString(mappingRuleId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignMappingRuleToTenant", false, ct);
@@ -315,7 +315,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignRoleToClientAsync(string roleId, string clientId, CancellationToken ct = default)
+    public async Task AssignRoleToClientAsync(RoleId roleId, ClientId clientId, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/clients/{Uri.EscapeDataString(clientId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignRoleToClient", false, ct);
@@ -348,7 +348,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignRoleToGroupAsync(string roleId, string groupId, CancellationToken ct = default)
+    public async Task AssignRoleToGroupAsync(RoleId roleId, GroupId groupId, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/groups/{Uri.EscapeDataString(groupId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignRoleToGroup", false, ct);
@@ -381,7 +381,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignRoleToMappingRuleAsync(string roleId, string mappingRuleId, CancellationToken ct = default)
+    public async Task AssignRoleToMappingRuleAsync(RoleId roleId, MappingRuleId mappingRuleId, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/mapping-rules/{Uri.EscapeDataString(mappingRuleId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignRoleToMappingRule", false, ct);
@@ -420,7 +420,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignRoleToTenantAsync(TenantId tenantId, string roleId, CancellationToken ct = default)
+    public async Task AssignRoleToTenantAsync(TenantId tenantId, RoleId roleId, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/roles/{Uri.EscapeDataString(roleId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignRoleToTenant", false, ct);
@@ -453,7 +453,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignRoleToUserAsync(string roleId, Username username, CancellationToken ct = default)
+    public async Task AssignRoleToUserAsync(RoleId roleId, Username username, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/users/{Uri.EscapeDataString(username.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignRoleToUser", false, ct);
@@ -532,7 +532,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task AssignUserToGroupAsync(string groupId, Username username, CancellationToken ct = default)
+    public async Task AssignUserToGroupAsync(GroupId groupId, Username username, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}/users/{Uri.EscapeDataString(username.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Put, path, null, ct); return 0; }, "assignUserToGroup", false, ct);
@@ -1010,7 +1010,7 @@ public partial class CamundaClient
     /// Upload document
     /// Upload a document to the Camunda 8 cluster.
     /// 
-    /// Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
+    /// Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
     /// 
     /// </summary>
     /// <remarks>
@@ -1059,7 +1059,7 @@ public partial class CamundaClient
     /// Create document link
     /// Create a link to a document in the Camunda 8 cluster.
     /// 
-    /// Note that this is currently supported for document stores of type: AWS, GCP
+    /// Note that this is currently supported for document stores of type: AWS, Azure, GCP
     /// 
     /// </summary>
     /// <remarks>
@@ -1118,7 +1118,7 @@ public partial class CamundaClient
     /// each of which contains the file name of the document that failed to upload and the reason for the failure.
     /// The client can choose to retry the whole batch or individual documents based on the response.
     /// 
-    /// Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
+    /// Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
     /// 
     /// </summary>
     /// <remarks>
@@ -1310,6 +1310,22 @@ public partial class CamundaClient
     /// <summary>
     /// Create group
     /// Create a new group.
+    /// 
+    /// The supplied `groupId` is validated against `^[a-zA-Z0-9_~@.+-]+$`
+    /// (max 256 characters) by `IdentifierValidator.validateId` in the
+    /// runtime. This strict validation applies wherever the Groups API
+    /// is available: in OIDC deployments that set
+    /// `camunda.security.authentication.oidc.groupsClaim` the Groups
+    /// API (including this endpoint) is disabled entirely, so group
+    /// CRUD never sees externally-minted IdP IDs. The BYOG relaxation
+    /// only loosens validation when a group is referenced *as a member*
+    /// of a role or tenant (`assignRoleToGroup`,
+    /// `assignGroupToTenant`); group CRUD itself always uses the strict
+    /// default-id regex. The constraint is not advertised on the
+    /// `GroupId` schema so that the same schema can be reused at
+    /// member-reference sites without falsely rejecting
+    /// externally-minted IdP group IDs there.
+    /// 
     /// </summary>
     /// <remarks>
     /// Operation: createGroup
@@ -1394,10 +1410,10 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<CreateMappingRuleResponse> CreateMappingRuleAsync(MappingRuleCreateRequest body, CancellationToken ct = default)
+    public async Task<MappingRuleCreateResult> CreateMappingRuleAsync(MappingRuleCreateRequest body, CancellationToken ct = default)
     {
         var path = $"/mapping-rules";
-        return await InvokeWithRetryAsync(() => SendAsync<CreateMappingRuleResponse>(HttpMethod.Post, path, body, ct), "createMappingRule", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<MappingRuleCreateResult>(HttpMethod.Post, path, body, ct), "createMappingRule", false, ct);
     }
 
     /// <summary>
@@ -1781,7 +1797,7 @@ public partial class CamundaClient
     /// Delete document
     /// Delete a document from the Camunda 8 cluster.
     /// 
-    /// Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
+    /// Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
     /// 
     /// </summary>
     /// <remarks>
@@ -1842,7 +1858,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task DeleteGlobalClusterVariableAsync(string name, CancellationToken ct = default)
+    public async Task DeleteGlobalClusterVariableAsync(ClusterVariableName name, CancellationToken ct = default)
     {
         var path = $"/cluster-variables/global/{Uri.EscapeDataString(name.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "deleteGlobalClusterVariable", false, ct);
@@ -1910,7 +1926,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task DeleteGroupAsync(string groupId, CancellationToken ct = default)
+    public async Task DeleteGroupAsync(GroupId groupId, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "deleteGroup", false, ct);
@@ -1944,7 +1960,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task DeleteMappingRuleAsync(string mappingRuleId, CancellationToken ct = default)
+    public async Task DeleteMappingRuleAsync(MappingRuleId mappingRuleId, CancellationToken ct = default)
     {
         var path = $"/mapping-rules/{Uri.EscapeDataString(mappingRuleId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "deleteMappingRule", false, ct);
@@ -2105,7 +2121,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task DeleteRoleAsync(string roleId, CancellationToken ct = default)
+    public async Task DeleteRoleAsync(RoleId roleId, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "deleteRole", false, ct);
@@ -2175,7 +2191,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task DeleteTenantClusterVariableAsync(TenantId tenantId, string name, CancellationToken ct = default)
+    public async Task DeleteTenantClusterVariableAsync(TenantId tenantId, ClusterVariableName name, CancellationToken ct = default)
     {
         var path = $"/cluster-variables/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/{Uri.EscapeDataString(name.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "deleteTenantClusterVariable", false, ct);
@@ -2427,6 +2443,48 @@ public partial class CamundaClient
     {
         var path = $"/jobs/{Uri.EscapeDataString(jobKey.ToString()!)}/failure";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Post, path, body, ct); return 0; }, "failJob", true, ct);
+    }
+
+    /// <summary>
+    /// Get agent instance
+    /// Returns agent instance as JSON.
+    /// </summary>
+    /// <remarks>
+    /// Operation: getAgentInstance
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task GetAgentInstanceExample(AgentInstanceKey agentInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.GetAgentInstanceAsync(agentInstanceKey);
+    ///     Console.WriteLine($&quot;Agent instance: {result.AgentInstanceKey}, status: {result.Status}&quot;);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task GetAgentInstanceExample(AgentInstanceKey agentInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.GetAgentInstanceAsync(agentInstanceKey);
+    ///     Console.WriteLine($&quot;Agent instance: {result.AgentInstanceKey}, status: {result.Status}&quot;);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<AgentInstanceResult> GetAgentInstanceAsync(AgentInstanceKey agentInstanceKey, ConsistencyOptions<AgentInstanceResult>? consistency = null, CancellationToken ct = default)
+    {
+        var path = $"/agent-instances/{Uri.EscapeDataString(agentInstanceKey.ToString()!)}";
+        if (consistency != null && consistency.WaitUpToMs > 0)
+        {
+            return await EventualPoller.PollAsync("getAgentInstance", true,
+                () => InvokeWithRetryAsync(() => SendAsync<AgentInstanceResult>(HttpMethod.Get, path, null, ct), "getAgentInstance", false, ct),
+                consistency!, _logger, ct);
+        }
+
+        return await InvokeWithRetryAsync(() => SendAsync<AgentInstanceResult>(HttpMethod.Get, path, null, ct), "getAgentInstance", false, ct);
     }
 
     /// <summary>
@@ -2832,7 +2890,7 @@ public partial class CamundaClient
     /// Download document
     /// Download a document from the Camunda 8 cluster.
     /// 
-    /// Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
+    /// Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
     /// 
     /// </summary>
     /// <remarks>
@@ -2946,7 +3004,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<ClusterVariableResult> GetGlobalClusterVariableAsync(string name, ConsistencyOptions<ClusterVariableResult>? consistency = null, CancellationToken ct = default)
+    public async Task<ClusterVariableResult> GetGlobalClusterVariableAsync(ClusterVariableName name, ConsistencyOptions<ClusterVariableResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/cluster-variables/global/{Uri.EscapeDataString(name.ToString()!)}";
         if (consistency != null && consistency.WaitUpToMs > 0)
@@ -3087,7 +3145,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<GroupResult> GetGroupAsync(string groupId, ConsistencyOptions<GroupResult>? consistency = null, CancellationToken ct = default)
+    public async Task<GroupResult> GetGroupAsync(GroupId groupId, ConsistencyOptions<GroupResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}";
         if (consistency != null && consistency.WaitUpToMs > 0)
@@ -3422,7 +3480,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<MappingRuleResult> GetMappingRuleAsync(string mappingRuleId, ConsistencyOptions<MappingRuleResult>? consistency = null, CancellationToken ct = default)
+    public async Task<MappingRuleResult> GetMappingRuleAsync(MappingRuleId mappingRuleId, ConsistencyOptions<MappingRuleResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/mapping-rules/{Uri.EscapeDataString(mappingRuleId.ToString()!)}";
         if (consistency != null && consistency.WaitUpToMs > 0)
@@ -4058,7 +4116,9 @@ public partial class CamundaClient
     /// Get resource
     /// Returns a deployed resource.
     /// :::info
-    /// Currently, this endpoint only supports RPA resources.
+    /// This endpoint does not return BPMN process definitions, DMN decision definitions, or form
+    /// resources. To query BPMN process definitions or DMN decision definitions, use their
+    /// respective APIs.
     /// :::
     /// 
     /// </summary>
@@ -4087,9 +4147,16 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<ResourceResult> GetResourceAsync(ResourceKey resourceKey, CancellationToken ct = default)
+    public async Task<ResourceResult> GetResourceAsync(ResourceKey resourceKey, ConsistencyOptions<ResourceResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/resources/{Uri.EscapeDataString(resourceKey.ToString()!)}";
+        if (consistency != null && consistency.WaitUpToMs > 0)
+        {
+            return await EventualPoller.PollAsync("getResource", true,
+                () => InvokeWithRetryAsync(() => SendAsync<ResourceResult>(HttpMethod.Get, path, null, ct), "getResource", false, ct),
+                consistency!, _logger, ct);
+        }
+
         return await InvokeWithRetryAsync(() => SendAsync<ResourceResult>(HttpMethod.Get, path, null, ct), "getResource", false, ct);
     }
 
@@ -4126,9 +4193,16 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<object> GetResourceContentAsync(ResourceKey resourceKey, CancellationToken ct = default)
+    public async Task<object> GetResourceContentAsync(ResourceKey resourceKey, ConsistencyOptions<object>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/resources/{Uri.EscapeDataString(resourceKey.ToString()!)}/content";
+        if (consistency != null && consistency.WaitUpToMs > 0)
+        {
+            return await EventualPoller.PollAsync("getResourceContent", true,
+                () => InvokeWithRetryAsync(() => SendAsync<object>(HttpMethod.Get, path, null, ct), "getResourceContent", false, ct),
+                consistency!, _logger, ct);
+        }
+
         return await InvokeWithRetryAsync(() => SendAsync<object>(HttpMethod.Get, path, null, ct), "getResourceContent", false, ct);
     }
 
@@ -4161,7 +4235,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<RoleResult> GetRoleAsync(string roleId, ConsistencyOptions<RoleResult>? consistency = null, CancellationToken ct = default)
+    public async Task<RoleResult> GetRoleAsync(RoleId roleId, ConsistencyOptions<RoleResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}";
         if (consistency != null && consistency.WaitUpToMs > 0)
@@ -4374,7 +4448,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<ClusterVariableResult> GetTenantClusterVariableAsync(TenantId tenantId, string name, ConsistencyOptions<ClusterVariableResult>? consistency = null, CancellationToken ct = default)
+    public async Task<ClusterVariableResult> GetTenantClusterVariableAsync(TenantId tenantId, ClusterVariableName name, ConsistencyOptions<ClusterVariableResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/cluster-variables/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/{Uri.EscapeDataString(name.ToString()!)}";
         if (consistency != null && consistency.WaitUpToMs > 0)
@@ -4504,17 +4578,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<GetUserResponse> GetUserAsync(Username username, ConsistencyOptions<GetUserResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<UserResult> GetUserAsync(Username username, ConsistencyOptions<UserResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/users/{Uri.EscapeDataString(username.ToString()!)}";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("getUser", true,
-                () => InvokeWithRetryAsync(() => SendAsync<GetUserResponse>(HttpMethod.Get, path, null, ct), "getUser", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<UserResult>(HttpMethod.Get, path, null, ct), "getUser", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<GetUserResponse>(HttpMethod.Get, path, null, ct), "getUser", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<UserResult>(HttpMethod.Get, path, null, ct), "getUser", false, ct);
     }
 
     /// <summary>
@@ -5138,6 +5212,56 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Search agent instances
+    /// Search for agent instances based on given criteria.
+    /// </summary>
+    /// <remarks>
+    /// Operation: searchAgentInstances
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SearchAgentInstancesExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SearchAgentInstancesAsync(new AgentInstanceSearchQuery());
+    /// 
+    ///     foreach (var instance in result.Items)
+    ///     {
+    ///         Console.WriteLine($&quot;Agent instance: {instance.AgentInstanceKey}, status: {instance.Status}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SearchAgentInstancesExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SearchAgentInstancesAsync(new AgentInstanceSearchQuery());
+    /// 
+    ///     foreach (var instance in result.Items)
+    ///     {
+    ///         Console.WriteLine($&quot;Agent instance: {instance.AgentInstanceKey}, status: {instance.Status}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<AgentInstanceSearchQueryResult> SearchAgentInstancesAsync(AgentInstanceSearchQuery body, ConsistencyOptions<AgentInstanceSearchQueryResult>? consistency = null, CancellationToken ct = default)
+    {
+        var path = $"/agent-instances/search";
+        if (consistency != null && consistency.WaitUpToMs > 0)
+        {
+            return await EventualPoller.PollAsync("searchAgentInstances", false,
+                () => InvokeWithRetryAsync(() => SendAsync<AgentInstanceSearchQueryResult>(HttpMethod.Post, path, body, ct), "searchAgentInstances", false, ct),
+                consistency!, _logger, ct);
+        }
+
+        return await InvokeWithRetryAsync(() => SendAsync<AgentInstanceSearchQueryResult>(HttpMethod.Post, path, body, ct), "searchAgentInstances", false, ct);
+    }
+
+    /// <summary>
     /// Search audit logs
     /// Search for audit logs based on given criteria.
     /// </summary>
@@ -5359,7 +5483,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchClientsForGroupAsync(
     ///         groupId,
-    ///         new SearchClientsForGroupRequest());
+    ///         new GroupClientSearchQueryRequest());
     /// 
     ///     foreach (var c in result.Items)
     ///     {
@@ -5377,7 +5501,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchClientsForGroupAsync(
     ///         groupId,
-    ///         new SearchClientsForGroupRequest());
+    ///         new GroupClientSearchQueryRequest());
     /// 
     ///     foreach (var c in result.Items)
     ///     {
@@ -5386,17 +5510,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchClientsForGroupResponse> SearchClientsForGroupAsync(string groupId, SearchClientsForGroupRequest body, ConsistencyOptions<SearchClientsForGroupResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<GroupClientSearchResult> SearchClientsForGroupAsync(GroupId groupId, GroupClientSearchQueryRequest body, ConsistencyOptions<GroupClientSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}/clients/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchClientsForGroup", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchClientsForGroupResponse>(HttpMethod.Post, path, body, ct), "searchClientsForGroup", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<GroupClientSearchResult>(HttpMethod.Post, path, body, ct), "searchClientsForGroup", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchClientsForGroupResponse>(HttpMethod.Post, path, body, ct), "searchClientsForGroup", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<GroupClientSearchResult>(HttpMethod.Post, path, body, ct), "searchClientsForGroup", false, ct);
     }
 
     /// <summary>
@@ -5413,7 +5537,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchClientsForRoleAsync(
     ///         roleId,
-    ///         new SearchClientsForRoleRequest());
+    ///         new RoleClientSearchQueryRequest());
     /// 
     ///     foreach (var c in result.Items)
     ///     {
@@ -5431,7 +5555,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchClientsForRoleAsync(
     ///         roleId,
-    ///         new SearchClientsForRoleRequest());
+    ///         new RoleClientSearchQueryRequest());
     /// 
     ///     foreach (var c in result.Items)
     ///     {
@@ -5440,17 +5564,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchClientsForRoleResponse> SearchClientsForRoleAsync(string roleId, SearchClientsForRoleRequest body, ConsistencyOptions<SearchClientsForRoleResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<RoleClientSearchResult> SearchClientsForRoleAsync(RoleId roleId, RoleClientSearchQueryRequest body, ConsistencyOptions<RoleClientSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/clients/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchClientsForRole", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchClientsForRoleResponse>(HttpMethod.Post, path, body, ct), "searchClientsForRole", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<RoleClientSearchResult>(HttpMethod.Post, path, body, ct), "searchClientsForRole", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchClientsForRoleResponse>(HttpMethod.Post, path, body, ct), "searchClientsForRole", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<RoleClientSearchResult>(HttpMethod.Post, path, body, ct), "searchClientsForRole", false, ct);
     }
 
     /// <summary>
@@ -5467,7 +5591,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchClientsForTenantAsync(
     ///         tenantId,
-    ///         new SearchClientsForTenantRequest());
+    ///         new TenantClientSearchQueryRequest());
     /// 
     ///     foreach (var c in result.Items)
     ///     {
@@ -5485,7 +5609,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchClientsForTenantAsync(
     ///         tenantId,
-    ///         new SearchClientsForTenantRequest());
+    ///         new TenantClientSearchQueryRequest());
     /// 
     ///     foreach (var c in result.Items)
     ///     {
@@ -5494,17 +5618,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchClientsForTenantResponse> SearchClientsForTenantAsync(TenantId tenantId, SearchClientsForTenantRequest body, ConsistencyOptions<SearchClientsForTenantResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<TenantClientSearchResult> SearchClientsForTenantAsync(TenantId tenantId, TenantClientSearchQueryRequest body, ConsistencyOptions<TenantClientSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/clients/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchClientsForTenant", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchClientsForTenantResponse>(HttpMethod.Post, path, body, ct), "searchClientsForTenant", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<TenantClientSearchResult>(HttpMethod.Post, path, body, ct), "searchClientsForTenant", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchClientsForTenantResponse>(HttpMethod.Post, path, body, ct), "searchClientsForTenant", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<TenantClientSearchResult>(HttpMethod.Post, path, body, ct), "searchClientsForTenant", false, ct);
     }
 
     /// <summary>
@@ -6078,7 +6202,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<RoleGroupSearchResult> SearchGroupsForRoleAsync(string roleId, RoleGroupSearchQueryRequest body, ConsistencyOptions<RoleGroupSearchResult>? consistency = null, CancellationToken ct = default)
+    public async Task<RoleGroupSearchResult> SearchGroupsForRoleAsync(RoleId roleId, RoleGroupSearchQueryRequest body, ConsistencyOptions<RoleGroupSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/groups/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
@@ -6232,17 +6356,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchMappingRuleResponse> SearchMappingRuleAsync(MappingRuleSearchQueryRequest body, ConsistencyOptions<SearchMappingRuleResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<MappingRuleSearchQueryResult> SearchMappingRuleAsync(MappingRuleSearchQueryRequest body, ConsistencyOptions<MappingRuleSearchQueryResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/mapping-rules/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchMappingRule", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchMappingRuleResponse>(HttpMethod.Post, path, body, ct), "searchMappingRule", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<MappingRuleSearchQueryResult>(HttpMethod.Post, path, body, ct), "searchMappingRule", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchMappingRuleResponse>(HttpMethod.Post, path, body, ct), "searchMappingRule", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<MappingRuleSearchQueryResult>(HttpMethod.Post, path, body, ct), "searchMappingRule", false, ct);
     }
 
     /// <summary>
@@ -6286,17 +6410,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchMappingRulesForGroupResponse> SearchMappingRulesForGroupAsync(string groupId, MappingRuleSearchQueryRequest body, ConsistencyOptions<SearchMappingRulesForGroupResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<GroupMappingRuleSearchResult> SearchMappingRulesForGroupAsync(GroupId groupId, MappingRuleSearchQueryRequest body, ConsistencyOptions<GroupMappingRuleSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}/mapping-rules/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchMappingRulesForGroup", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchMappingRulesForGroupResponse>(HttpMethod.Post, path, body, ct), "searchMappingRulesForGroup", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<GroupMappingRuleSearchResult>(HttpMethod.Post, path, body, ct), "searchMappingRulesForGroup", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchMappingRulesForGroupResponse>(HttpMethod.Post, path, body, ct), "searchMappingRulesForGroup", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<GroupMappingRuleSearchResult>(HttpMethod.Post, path, body, ct), "searchMappingRulesForGroup", false, ct);
     }
 
     /// <summary>
@@ -6340,17 +6464,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchMappingRulesForRoleResponse> SearchMappingRulesForRoleAsync(string roleId, MappingRuleSearchQueryRequest body, ConsistencyOptions<SearchMappingRulesForRoleResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<RoleMappingRuleSearchResult> SearchMappingRulesForRoleAsync(RoleId roleId, MappingRuleSearchQueryRequest body, ConsistencyOptions<RoleMappingRuleSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/mapping-rules/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchMappingRulesForRole", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchMappingRulesForRoleResponse>(HttpMethod.Post, path, body, ct), "searchMappingRulesForRole", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<RoleMappingRuleSearchResult>(HttpMethod.Post, path, body, ct), "searchMappingRulesForRole", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchMappingRulesForRoleResponse>(HttpMethod.Post, path, body, ct), "searchMappingRulesForRole", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<RoleMappingRuleSearchResult>(HttpMethod.Post, path, body, ct), "searchMappingRulesForRole", false, ct);
     }
 
     /// <summary>
@@ -6394,22 +6518,35 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchMappingRulesForTenantResponse> SearchMappingRulesForTenantAsync(TenantId tenantId, MappingRuleSearchQueryRequest body, ConsistencyOptions<SearchMappingRulesForTenantResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<TenantMappingRuleSearchResult> SearchMappingRulesForTenantAsync(TenantId tenantId, MappingRuleSearchQueryRequest body, ConsistencyOptions<TenantMappingRuleSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/mapping-rules/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchMappingRulesForTenant", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchMappingRulesForTenantResponse>(HttpMethod.Post, path, body, ct), "searchMappingRulesForTenant", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<TenantMappingRuleSearchResult>(HttpMethod.Post, path, body, ct), "searchMappingRulesForTenant", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchMappingRulesForTenantResponse>(HttpMethod.Post, path, body, ct), "searchMappingRulesForTenant", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<TenantMappingRuleSearchResult>(HttpMethod.Post, path, body, ct), "searchMappingRulesForTenant", false, ct);
     }
 
     /// <summary>
     /// Search message subscriptions
     /// Search for message subscriptions based on given criteria.
+    /// 
+    /// By default, both start and intermediate event subscriptions are returned. Use the
+    /// `messageSubscriptionType` filter to restrict results to a single type.
+    /// 
+    /// **Version notes:**
+    /// - Start event subscriptions are only captured for deployments made with 8.10 or later.
+    /// - The `messageSubscriptionType` field is only populated for data created
+    ///   with Camunda 8.10 or later. For pre-8.10 data, intermediate event entries have no
+    ///   `messageSubscriptionType` value stored. For convenience, the API returns `PROCESS_EVENT`
+    ///   as a default for such search results, though.
+    /// - Searching for intermediate event subscriptions **including legacy data** can be achieved
+    ///   by filtering for `messageSubscriptionType` not matching `START_EVENT`.
+    /// 
     /// </summary>
     /// <remarks>
     /// Operation: searchMessageSubscriptions
@@ -6622,6 +6759,60 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Search resources
+    /// Search for deployed resources based on given criteria.
+    /// :::info
+    /// This endpoint does not return BPMN process definitions, DMN decision definitions, or form
+    /// resources. To query BPMN process definitions or DMN decision definitions, use their
+    /// respective search APIs.
+    /// :::
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: searchResources
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SearchResourcesExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SearchResourcesAsync(new ResourceSearchQuery());
+    ///     foreach (var resource in result.Items!)
+    ///     {
+    ///         Console.WriteLine($&quot;Resource: {resource.ResourceName}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SearchResourcesExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SearchResourcesAsync(new ResourceSearchQuery());
+    ///     foreach (var resource in result.Items!)
+    ///     {
+    ///         Console.WriteLine($&quot;Resource: {resource.ResourceName}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<ResourceSearchQueryResult> SearchResourcesAsync(ResourceSearchQuery body, ConsistencyOptions<ResourceSearchQueryResult>? consistency = null, CancellationToken ct = default)
+    {
+        var path = $"/resources/search";
+        if (consistency != null && consistency.WaitUpToMs > 0)
+        {
+            return await EventualPoller.PollAsync("searchResources", false,
+                () => InvokeWithRetryAsync(() => SendAsync<ResourceSearchQueryResult>(HttpMethod.Post, path, body, ct), "searchResources", false, ct),
+                consistency!, _logger, ct);
+        }
+
+        return await InvokeWithRetryAsync(() => SendAsync<ResourceSearchQueryResult>(HttpMethod.Post, path, body, ct), "searchResources", false, ct);
+    }
+
+    /// <summary>
     /// Search roles
     /// Search for roles based on given criteria.
     /// </summary>
@@ -6712,17 +6903,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchRolesForGroupResponse> SearchRolesForGroupAsync(string groupId, RoleSearchQueryRequest body, ConsistencyOptions<SearchRolesForGroupResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<GroupRoleSearchResult> SearchRolesForGroupAsync(GroupId groupId, RoleSearchQueryRequest body, ConsistencyOptions<GroupRoleSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}/roles/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchRolesForGroup", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchRolesForGroupResponse>(HttpMethod.Post, path, body, ct), "searchRolesForGroup", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<GroupRoleSearchResult>(HttpMethod.Post, path, body, ct), "searchRolesForGroup", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchRolesForGroupResponse>(HttpMethod.Post, path, body, ct), "searchRolesForGroup", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<GroupRoleSearchResult>(HttpMethod.Post, path, body, ct), "searchRolesForGroup", false, ct);
     }
 
     /// <summary>
@@ -6766,17 +6957,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchRolesForTenantResponse> SearchRolesForTenantAsync(TenantId tenantId, RoleSearchQueryRequest body, ConsistencyOptions<SearchRolesForTenantResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<TenantRoleSearchResult> SearchRolesForTenantAsync(TenantId tenantId, RoleSearchQueryRequest body, ConsistencyOptions<TenantRoleSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/roles/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchRolesForTenant", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchRolesForTenantResponse>(HttpMethod.Post, path, body, ct), "searchRolesForTenant", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<TenantRoleSearchResult>(HttpMethod.Post, path, body, ct), "searchRolesForTenant", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchRolesForTenantResponse>(HttpMethod.Post, path, body, ct), "searchRolesForTenant", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<TenantRoleSearchResult>(HttpMethod.Post, path, body, ct), "searchRolesForTenant", false, ct);
     }
 
     /// <summary>
@@ -6903,7 +7094,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchUserTaskEffectiveVariablesAsync(
     ///         userTaskKey,
-    ///         new SearchUserTaskEffectiveVariablesRequest());
+    ///         new UserTaskEffectiveVariableSearchQueryRequest());
     /// 
     ///     foreach (var variable in result.Items)
     ///     {
@@ -6921,7 +7112,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchUserTaskEffectiveVariablesAsync(
     ///         userTaskKey,
-    ///         new SearchUserTaskEffectiveVariablesRequest());
+    ///         new UserTaskEffectiveVariableSearchQueryRequest());
     /// 
     ///     foreach (var variable in result.Items)
     ///     {
@@ -6930,7 +7121,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<VariableSearchQueryResult> SearchUserTaskEffectiveVariablesAsync(UserTaskKey userTaskKey, SearchUserTaskEffectiveVariablesRequest body, bool? truncateValues = null, ConsistencyOptions<VariableSearchQueryResult>? consistency = null, CancellationToken ct = default)
+    public async Task<VariableSearchQueryResult> SearchUserTaskEffectiveVariablesAsync(UserTaskKey userTaskKey, UserTaskEffectiveVariableSearchQueryRequest body, bool? truncateValues = null, ConsistencyOptions<VariableSearchQueryResult>? consistency = null, CancellationToken ct = default)
     {
         var queryParts = new List<string>();
         if (truncateValues != null) queryParts.Add($"truncateValues={Uri.EscapeDataString(truncateValues.ToString()!)}");
@@ -6966,7 +7157,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchUserTaskVariablesAsync(
     ///         userTaskKey,
-    ///         new SearchUserTaskVariablesRequest());
+    ///         new UserTaskVariableSearchQueryRequest());
     /// 
     ///     foreach (var variable in result.Items)
     ///     {
@@ -6984,7 +7175,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchUserTaskVariablesAsync(
     ///         userTaskKey,
-    ///         new SearchUserTaskVariablesRequest());
+    ///         new UserTaskVariableSearchQueryRequest());
     /// 
     ///     foreach (var variable in result.Items)
     ///     {
@@ -6993,7 +7184,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<VariableSearchQueryResult> SearchUserTaskVariablesAsync(UserTaskKey userTaskKey, SearchUserTaskVariablesRequest body, bool? truncateValues = null, ConsistencyOptions<VariableSearchQueryResult>? consistency = null, CancellationToken ct = default)
+    public async Task<VariableSearchQueryResult> SearchUserTaskVariablesAsync(UserTaskKey userTaskKey, UserTaskVariableSearchQueryRequest body, bool? truncateValues = null, ConsistencyOptions<VariableSearchQueryResult>? consistency = null, CancellationToken ct = default)
     {
         var queryParts = new List<string>();
         if (truncateValues != null) queryParts.Add($"truncateValues={Uri.EscapeDataString(truncateValues.ToString()!)}");
@@ -7095,17 +7286,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchUsersResponse> SearchUsersAsync(UserSearchQueryRequest body, ConsistencyOptions<SearchUsersResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<UserSearchResult> SearchUsersAsync(UserSearchQueryRequest body, ConsistencyOptions<UserSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/users/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchUsers", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchUsersResponse>(HttpMethod.Post, path, body, ct), "searchUsers", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<UserSearchResult>(HttpMethod.Post, path, body, ct), "searchUsers", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchUsersResponse>(HttpMethod.Post, path, body, ct), "searchUsers", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<UserSearchResult>(HttpMethod.Post, path, body, ct), "searchUsers", false, ct);
     }
 
     /// <summary>
@@ -7122,7 +7313,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchUsersForGroupAsync(
     ///         groupId,
-    ///         new SearchUsersForGroupRequest());
+    ///         new GroupUserSearchQueryRequest());
     /// 
     ///     foreach (var user in result.Items)
     ///     {
@@ -7140,7 +7331,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchUsersForGroupAsync(
     ///         groupId,
-    ///         new SearchUsersForGroupRequest());
+    ///         new GroupUserSearchQueryRequest());
     /// 
     ///     foreach (var user in result.Items)
     ///     {
@@ -7149,17 +7340,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchUsersForGroupResponse> SearchUsersForGroupAsync(string groupId, SearchUsersForGroupRequest body, ConsistencyOptions<SearchUsersForGroupResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<GroupUserSearchResult> SearchUsersForGroupAsync(GroupId groupId, GroupUserSearchQueryRequest body, ConsistencyOptions<GroupUserSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}/users/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchUsersForGroup", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchUsersForGroupResponse>(HttpMethod.Post, path, body, ct), "searchUsersForGroup", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<GroupUserSearchResult>(HttpMethod.Post, path, body, ct), "searchUsersForGroup", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchUsersForGroupResponse>(HttpMethod.Post, path, body, ct), "searchUsersForGroup", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<GroupUserSearchResult>(HttpMethod.Post, path, body, ct), "searchUsersForGroup", false, ct);
     }
 
     /// <summary>
@@ -7176,7 +7367,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchUsersForRoleAsync(
     ///         roleId,
-    ///         new SearchUsersForRoleRequest());
+    ///         new RoleUserSearchQueryRequest());
     /// 
     ///     foreach (var user in result.Items)
     ///     {
@@ -7194,7 +7385,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchUsersForRoleAsync(
     ///         roleId,
-    ///         new SearchUsersForRoleRequest());
+    ///         new RoleUserSearchQueryRequest());
     /// 
     ///     foreach (var user in result.Items)
     ///     {
@@ -7203,17 +7394,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchUsersForRoleResponse> SearchUsersForRoleAsync(string roleId, SearchUsersForRoleRequest body, ConsistencyOptions<SearchUsersForRoleResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<RoleUserSearchResult> SearchUsersForRoleAsync(RoleId roleId, RoleUserSearchQueryRequest body, ConsistencyOptions<RoleUserSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/users/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchUsersForRole", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchUsersForRoleResponse>(HttpMethod.Post, path, body, ct), "searchUsersForRole", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<RoleUserSearchResult>(HttpMethod.Post, path, body, ct), "searchUsersForRole", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchUsersForRoleResponse>(HttpMethod.Post, path, body, ct), "searchUsersForRole", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<RoleUserSearchResult>(HttpMethod.Post, path, body, ct), "searchUsersForRole", false, ct);
     }
 
     /// <summary>
@@ -7230,7 +7421,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchUsersForTenantAsync(
     ///         tenantId,
-    ///         new SearchUsersForTenantRequest());
+    ///         new TenantUserSearchQueryRequest());
     /// 
     ///     foreach (var user in result.Items)
     ///     {
@@ -7248,7 +7439,7 @@ public partial class CamundaClient
     /// 
     ///     var result = await client.SearchUsersForTenantAsync(
     ///         tenantId,
-    ///         new SearchUsersForTenantRequest());
+    ///         new TenantUserSearchQueryRequest());
     /// 
     ///     foreach (var user in result.Items)
     ///     {
@@ -7257,17 +7448,17 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<SearchUsersForTenantResponse> SearchUsersForTenantAsync(TenantId tenantId, SearchUsersForTenantRequest body, ConsistencyOptions<SearchUsersForTenantResponse>? consistency = null, CancellationToken ct = default)
+    public async Task<TenantUserSearchResult> SearchUsersForTenantAsync(TenantId tenantId, TenantUserSearchQueryRequest body, ConsistencyOptions<TenantUserSearchResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/users/search";
         if (consistency != null && consistency.WaitUpToMs > 0)
         {
             return await EventualPoller.PollAsync("searchUsersForTenant", false,
-                () => InvokeWithRetryAsync(() => SendAsync<SearchUsersForTenantResponse>(HttpMethod.Post, path, body, ct), "searchUsersForTenant", false, ct),
+                () => InvokeWithRetryAsync(() => SendAsync<TenantUserSearchResult>(HttpMethod.Post, path, body, ct), "searchUsersForTenant", false, ct),
                 consistency!, _logger, ct);
         }
 
-        return await InvokeWithRetryAsync(() => SendAsync<SearchUsersForTenantResponse>(HttpMethod.Post, path, body, ct), "searchUsersForTenant", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<TenantUserSearchResult>(HttpMethod.Post, path, body, ct), "searchUsersForTenant", false, ct);
     }
 
     /// <summary>
@@ -7290,7 +7481,7 @@ public partial class CamundaClient
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     var result = await client.SearchVariablesAsync(new SearchVariablesRequest());
+    ///     var result = await client.SearchVariablesAsync(new VariableSearchQuery());
     /// 
     ///     foreach (var variable in result.Items)
     ///     {
@@ -7306,7 +7497,7 @@ public partial class CamundaClient
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     var result = await client.SearchVariablesAsync(new SearchVariablesRequest());
+    ///     var result = await client.SearchVariablesAsync(new VariableSearchQuery());
     /// 
     ///     foreach (var variable in result.Items)
     ///     {
@@ -7315,7 +7506,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<VariableSearchQueryResult> SearchVariablesAsync(SearchVariablesRequest body, bool? truncateValues = null, ConsistencyOptions<VariableSearchQueryResult>? consistency = null, CancellationToken ct = default)
+    public async Task<VariableSearchQueryResult> SearchVariablesAsync(VariableSearchQuery body, bool? truncateValues = null, ConsistencyOptions<VariableSearchQueryResult>? consistency = null, CancellationToken ct = default)
     {
         var queryParts = new List<string>();
         if (truncateValues != null) queryParts.Add($"truncateValues={Uri.EscapeDataString(truncateValues.ToString()!)}");
@@ -7440,7 +7631,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignClientFromGroupAsync(string groupId, string clientId, CancellationToken ct = default)
+    public async Task UnassignClientFromGroupAsync(GroupId groupId, ClientId clientId, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}/clients/{Uri.EscapeDataString(clientId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignClientFromGroup", false, ct);
@@ -7479,7 +7670,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignClientFromTenantAsync(TenantId tenantId, string clientId, CancellationToken ct = default)
+    public async Task UnassignClientFromTenantAsync(TenantId tenantId, ClientId clientId, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/clients/{Uri.EscapeDataString(clientId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignClientFromTenant", false, ct);
@@ -7518,7 +7709,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignGroupFromTenantAsync(TenantId tenantId, string groupId, CancellationToken ct = default)
+    public async Task UnassignGroupFromTenantAsync(TenantId tenantId, GroupId groupId, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/groups/{Uri.EscapeDataString(groupId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignGroupFromTenant", false, ct);
@@ -7551,7 +7742,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignMappingRuleFromGroupAsync(string groupId, string mappingRuleId, CancellationToken ct = default)
+    public async Task UnassignMappingRuleFromGroupAsync(GroupId groupId, MappingRuleId mappingRuleId, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}/mapping-rules/{Uri.EscapeDataString(mappingRuleId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignMappingRuleFromGroup", false, ct);
@@ -7588,7 +7779,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignMappingRuleFromTenantAsync(TenantId tenantId, string mappingRuleId, CancellationToken ct = default)
+    public async Task UnassignMappingRuleFromTenantAsync(TenantId tenantId, MappingRuleId mappingRuleId, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/mapping-rules/{Uri.EscapeDataString(mappingRuleId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignMappingRuleFromTenant", false, ct);
@@ -7621,7 +7812,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignRoleFromClientAsync(string roleId, string clientId, CancellationToken ct = default)
+    public async Task UnassignRoleFromClientAsync(RoleId roleId, ClientId clientId, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/clients/{Uri.EscapeDataString(clientId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignRoleFromClient", false, ct);
@@ -7654,7 +7845,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignRoleFromGroupAsync(string roleId, string groupId, CancellationToken ct = default)
+    public async Task UnassignRoleFromGroupAsync(RoleId roleId, GroupId groupId, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/groups/{Uri.EscapeDataString(groupId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignRoleFromGroup", false, ct);
@@ -7687,7 +7878,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignRoleFromMappingRuleAsync(string roleId, string mappingRuleId, CancellationToken ct = default)
+    public async Task UnassignRoleFromMappingRuleAsync(RoleId roleId, MappingRuleId mappingRuleId, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/mapping-rules/{Uri.EscapeDataString(mappingRuleId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignRoleFromMappingRule", false, ct);
@@ -7727,7 +7918,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignRoleFromTenantAsync(TenantId tenantId, string roleId, CancellationToken ct = default)
+    public async Task UnassignRoleFromTenantAsync(TenantId tenantId, RoleId roleId, CancellationToken ct = default)
     {
         var path = $"/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/roles/{Uri.EscapeDataString(roleId.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignRoleFromTenant", false, ct);
@@ -7760,7 +7951,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignRoleFromUserAsync(string roleId, Username username, CancellationToken ct = default)
+    public async Task UnassignRoleFromUserAsync(RoleId roleId, Username username, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}/users/{Uri.EscapeDataString(username.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignRoleFromUser", false, ct);
@@ -7795,7 +7986,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UnassignUserFromGroupAsync(string groupId, Username username, CancellationToken ct = default)
+    public async Task UnassignUserFromGroupAsync(GroupId groupId, Username username, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}/users/{Uri.EscapeDataString(username.ToString()!)}";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignUserFromGroup", false, ct);
@@ -7968,7 +8159,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<ClusterVariableResult> UpdateGlobalClusterVariableAsync(string name, UpdateClusterVariableRequest body, CancellationToken ct = default)
+    public async Task<ClusterVariableResult> UpdateGlobalClusterVariableAsync(ClusterVariableName name, UpdateClusterVariableRequest body, CancellationToken ct = default)
     {
         var path = $"/cluster-variables/global/{Uri.EscapeDataString(name.ToString()!)}";
         return await InvokeWithRetryAsync(() => SendAsync<ClusterVariableResult>(HttpMethod.Put, path, body, ct), "updateGlobalClusterVariable", false, ct);
@@ -8056,7 +8247,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<GroupUpdateResult> UpdateGroupAsync(string groupId, GroupUpdateRequest body, CancellationToken ct = default)
+    public async Task<GroupUpdateResult> UpdateGroupAsync(GroupId groupId, GroupUpdateRequest body, CancellationToken ct = default)
     {
         var path = $"/groups/{Uri.EscapeDataString(groupId.ToString()!)}";
         return await InvokeWithRetryAsync(() => SendAsync<GroupUpdateResult>(HttpMethod.Put, path, body, ct), "updateGroup", false, ct);
@@ -8143,10 +8334,10 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<UpdateMappingRuleResponse> UpdateMappingRuleAsync(string mappingRuleId, MappingRuleUpdateRequest body, CancellationToken ct = default)
+    public async Task<MappingRuleUpdateResult> UpdateMappingRuleAsync(MappingRuleId mappingRuleId, MappingRuleUpdateRequest body, CancellationToken ct = default)
     {
         var path = $"/mapping-rules/{Uri.EscapeDataString(mappingRuleId.ToString()!)}";
-        return await InvokeWithRetryAsync(() => SendAsync<UpdateMappingRuleResponse>(HttpMethod.Put, path, body, ct), "updateMappingRule", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<MappingRuleUpdateResult>(HttpMethod.Put, path, body, ct), "updateMappingRule", false, ct);
     }
 
     /// <summary>
@@ -8182,7 +8373,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<RoleUpdateResult> UpdateRoleAsync(string roleId, RoleUpdateRequest body, CancellationToken ct = default)
+    public async Task<RoleUpdateResult> UpdateRoleAsync(RoleId roleId, RoleUpdateRequest body, CancellationToken ct = default)
     {
         var path = $"/roles/{Uri.EscapeDataString(roleId.ToString()!)}";
         return await InvokeWithRetryAsync(() => SendAsync<RoleUpdateResult>(HttpMethod.Put, path, body, ct), "updateRole", false, ct);
@@ -8276,7 +8467,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<ClusterVariableResult> UpdateTenantClusterVariableAsync(TenantId tenantId, string name, UpdateClusterVariableRequest body, CancellationToken ct = default)
+    public async Task<ClusterVariableResult> UpdateTenantClusterVariableAsync(TenantId tenantId, ClusterVariableName name, UpdateClusterVariableRequest body, CancellationToken ct = default)
     {
         var path = $"/cluster-variables/tenants/{Uri.EscapeDataString(tenantId.ToString()!)}/{Uri.EscapeDataString(name.ToString()!)}";
         return await InvokeWithRetryAsync(() => SendAsync<ClusterVariableResult>(HttpMethod.Put, path, body, ct), "updateTenantClusterVariable", false, ct);
@@ -8321,10 +8512,10 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<UpdateUserResponse> UpdateUserAsync(Username username, UserUpdateRequest body, CancellationToken ct = default)
+    public async Task<UserUpdateResult> UpdateUserAsync(Username username, UserUpdateRequest body, CancellationToken ct = default)
     {
         var path = $"/users/{Uri.EscapeDataString(username.ToString()!)}";
-        return await InvokeWithRetryAsync(() => SendAsync<UpdateUserResponse>(HttpMethod.Put, path, body, ct), "updateUser", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<UserUpdateResult>(HttpMethod.Put, path, body, ct), "updateUser", false, ct);
     }
 
     /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -115,22 +115,22 @@ public partial class CamundaClient
     /// Operation: assignClientToGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignClientToGroupExample()
+    /// public static async Task AssignClientToGroupExample(GroupId groupId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignClientToGroupAsync(&quot;engineering&quot;, &quot;my-service-account&quot;);
+    ///     await client.AssignClientToGroupAsync(groupId, clientId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignClientToGroupExample()
+    /// public static async Task AssignClientToGroupExample(GroupId groupId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignClientToGroupAsync(&quot;engineering&quot;, &quot;my-service-account&quot;);
+    ///     await client.AssignClientToGroupAsync(groupId, clientId);
     /// }
     /// </code>
     /// </example>
@@ -150,26 +150,26 @@ public partial class CamundaClient
     /// Operation: assignClientToTenant
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignClientToTenantExample(TenantId tenantId)
+    /// public static async Task AssignClientToTenantExample(TenantId tenantId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.AssignClientToTenantAsync(
     ///         tenantId,
-    ///         &quot;my-service-account&quot;);
+    ///         clientId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignClientToTenantExample(TenantId tenantId)
+    /// public static async Task AssignClientToTenantExample(TenantId tenantId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.AssignClientToTenantAsync(
     ///         tenantId,
-    ///         &quot;my-service-account&quot;);
+    ///         clientId);
     /// }
     /// </code>
     /// </example>
@@ -189,26 +189,26 @@ public partial class CamundaClient
     /// Operation: assignGroupToTenant
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignGroupToTenantExample(TenantId tenantId)
+    /// public static async Task AssignGroupToTenantExample(TenantId tenantId, GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.AssignGroupToTenantAsync(
     ///         tenantId,
-    ///         &quot;engineering&quot;);
+    ///         groupId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignGroupToTenantExample(TenantId tenantId)
+    /// public static async Task AssignGroupToTenantExample(TenantId tenantId, GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.AssignGroupToTenantAsync(
     ///         tenantId,
-    ///         &quot;engineering&quot;);
+    ///         groupId);
     /// }
     /// </code>
     /// </example>
@@ -226,22 +226,22 @@ public partial class CamundaClient
     /// Operation: assignMappingRuleToGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignMappingRuleToGroupExample()
+    /// public static async Task AssignMappingRuleToGroupExample(GroupId groupId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignMappingRuleToGroupAsync(&quot;engineering&quot;, &quot;rule-123&quot;);
+    ///     await client.AssignMappingRuleToGroupAsync(groupId, mappingRuleId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignMappingRuleToGroupExample()
+    /// public static async Task AssignMappingRuleToGroupExample(GroupId groupId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignMappingRuleToGroupAsync(&quot;engineering&quot;, &quot;rule-123&quot;);
+    ///     await client.AssignMappingRuleToGroupAsync(groupId, mappingRuleId);
     /// }
     /// </code>
     /// </example>
@@ -259,26 +259,26 @@ public partial class CamundaClient
     /// Operation: assignMappingRuleToTenant
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignMappingRuleToTenantExample(TenantId tenantId)
+    /// public static async Task AssignMappingRuleToTenantExample(TenantId tenantId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.AssignMappingRuleToTenantAsync(
     ///         tenantId,
-    ///         &quot;rule-123&quot;);
+    ///         mappingRuleId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignMappingRuleToTenantExample(TenantId tenantId)
+    /// public static async Task AssignMappingRuleToTenantExample(TenantId tenantId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.AssignMappingRuleToTenantAsync(
     ///         tenantId,
-    ///         &quot;rule-123&quot;);
+    ///         mappingRuleId);
     /// }
     /// </code>
     /// </example>
@@ -296,22 +296,22 @@ public partial class CamundaClient
     /// Operation: assignRoleToClient
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignRoleToClientExample()
+    /// public static async Task AssignRoleToClientExample(RoleId roleId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignRoleToClientAsync(&quot;developer&quot;, &quot;my-service-account&quot;);
+    ///     await client.AssignRoleToClientAsync(roleId, clientId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignRoleToClientExample()
+    /// public static async Task AssignRoleToClientExample(RoleId roleId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignRoleToClientAsync(&quot;developer&quot;, &quot;my-service-account&quot;);
+    ///     await client.AssignRoleToClientAsync(roleId, clientId);
     /// }
     /// </code>
     /// </example>
@@ -329,22 +329,22 @@ public partial class CamundaClient
     /// Operation: assignRoleToGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignRoleToGroupExample()
+    /// public static async Task AssignRoleToGroupExample(RoleId roleId, GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignRoleToGroupAsync(&quot;developer&quot;, &quot;engineering&quot;);
+    ///     await client.AssignRoleToGroupAsync(roleId, groupId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignRoleToGroupExample()
+    /// public static async Task AssignRoleToGroupExample(RoleId roleId, GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignRoleToGroupAsync(&quot;developer&quot;, &quot;engineering&quot;);
+    ///     await client.AssignRoleToGroupAsync(roleId, groupId);
     /// }
     /// </code>
     /// </example>
@@ -362,22 +362,22 @@ public partial class CamundaClient
     /// Operation: assignRoleToMappingRule
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignRoleToMappingRuleExample()
+    /// public static async Task AssignRoleToMappingRuleExample(RoleId roleId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignRoleToMappingRuleAsync(&quot;developer&quot;, &quot;rule-123&quot;);
+    ///     await client.AssignRoleToMappingRuleAsync(roleId, mappingRuleId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignRoleToMappingRuleExample()
+    /// public static async Task AssignRoleToMappingRuleExample(RoleId roleId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignRoleToMappingRuleAsync(&quot;developer&quot;, &quot;rule-123&quot;);
+    ///     await client.AssignRoleToMappingRuleAsync(roleId, mappingRuleId);
     /// }
     /// </code>
     /// </example>
@@ -397,26 +397,26 @@ public partial class CamundaClient
     /// Operation: assignRoleToTenant
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignRoleToTenantExample(TenantId tenantId)
+    /// public static async Task AssignRoleToTenantExample(TenantId tenantId, RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.AssignRoleToTenantAsync(
     ///         tenantId,
-    ///         &quot;developer&quot;);
+    ///         roleId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignRoleToTenantExample(TenantId tenantId)
+    /// public static async Task AssignRoleToTenantExample(TenantId tenantId, RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.AssignRoleToTenantAsync(
     ///         tenantId,
-    ///         &quot;developer&quot;);
+    ///         roleId);
     /// }
     /// </code>
     /// </example>
@@ -434,22 +434,22 @@ public partial class CamundaClient
     /// Operation: assignRoleToUser
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignRoleToUserExample(Username username)
+    /// public static async Task AssignRoleToUserExample(RoleId roleId, Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignRoleToUserAsync(&quot;developer&quot;, username);
+    ///     await client.AssignRoleToUserAsync(roleId, username);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignRoleToUserExample(Username username)
+    /// public static async Task AssignRoleToUserExample(RoleId roleId, Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignRoleToUserAsync(&quot;developer&quot;, username);
+    ///     await client.AssignRoleToUserAsync(roleId, username);
     /// }
     /// </code>
     /// </example>
@@ -513,22 +513,22 @@ public partial class CamundaClient
     /// Operation: assignUserToGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignUserToGroupExample(Username username)
+    /// public static async Task AssignUserToGroupExample(GroupId groupId, Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignUserToGroupAsync(&quot;engineering&quot;, username);
+    ///     await client.AssignUserToGroupAsync(groupId, username);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task AssignUserToGroupExample(Username username)
+    /// public static async Task AssignUserToGroupExample(GroupId groupId, Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.AssignUserToGroupAsync(&quot;engineering&quot;, username);
+    ///     await client.AssignUserToGroupAsync(groupId, username);
     /// }
     /// </code>
     /// </example>
@@ -869,13 +869,13 @@ public partial class CamundaClient
     /// Operation: createAdminUser
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateAdminUserExample()
+    /// public static async Task CreateAdminUserExample(Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.CreateAdminUserAsync(new UserRequest
     ///     {
-    ///         Username = &quot;admin&quot;,
+    ///         Username = username,
     ///         Name = &quot;Admin User&quot;,
     ///         Email = &quot;admin@example.com&quot;,
     ///         Password = &quot;admin-password&quot;,
@@ -888,13 +888,13 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateAdminUserExample()
+    /// public static async Task CreateAdminUserExample(Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.CreateAdminUserAsync(new UserRequest
     ///     {
-    ///         Username = &quot;admin&quot;,
+    ///         Username = username,
     ///         Name = &quot;Admin User&quot;,
     ///         Email = &quot;admin@example.com&quot;,
     ///         Password = &quot;admin-password&quot;,
@@ -1010,7 +1010,7 @@ public partial class CamundaClient
     /// Upload document
     /// Upload a document to the Camunda 8 cluster.
     /// 
-    /// Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
+    /// Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
     /// 
     /// </summary>
     /// <remarks>
@@ -1059,7 +1059,7 @@ public partial class CamundaClient
     /// Create document link
     /// Create a link to a document in the Camunda 8 cluster.
     /// 
-    /// Note that this is currently supported for document stores of type: AWS, Azure, GCP
+    /// Note that this is currently supported for document stores of type: AWS, GCP
     /// 
     /// </summary>
     /// <remarks>
@@ -1118,7 +1118,7 @@ public partial class CamundaClient
     /// each of which contains the file name of the document that failed to upload and the reason for the failure.
     /// The client can choose to retry the whole batch or individual documents based on the response.
     /// 
-    /// Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
+    /// Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
     /// 
     /// </summary>
     /// <remarks>
@@ -1221,14 +1221,14 @@ public partial class CamundaClient
     /// Operation: createGlobalClusterVariable
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateGlobalClusterVariableExample()
+    /// public static async Task CreateGlobalClusterVariableExample(ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.CreateGlobalClusterVariableAsync(
     ///         new CreateClusterVariableRequest
     ///         {
-    ///             Name = &quot;my-variable&quot;,
+    ///             Name = name,
     ///             Value = &quot;my-value&quot;,
     ///         });
     /// 
@@ -1239,14 +1239,14 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateGlobalClusterVariableExample()
+    /// public static async Task CreateGlobalClusterVariableExample(ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.CreateGlobalClusterVariableAsync(
     ///         new CreateClusterVariableRequest
     ///         {
-    ///             Name = &quot;my-variable&quot;,
+    ///             Name = name,
     ///             Value = &quot;my-value&quot;,
     ///         });
     /// 
@@ -1315,13 +1315,13 @@ public partial class CamundaClient
     /// Operation: createGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateGroupExample()
+    /// public static async Task CreateGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.CreateGroupAsync(new GroupCreateRequest
     ///     {
-    ///         GroupId = &quot;engineering&quot;,
+    ///         GroupId = groupId,
     ///         Name = &quot;Engineering&quot;,
     ///     });
     /// 
@@ -1332,13 +1332,13 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateGroupExample()
+    /// public static async Task CreateGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.CreateGroupAsync(new GroupCreateRequest
     ///     {
-    ///         GroupId = &quot;engineering&quot;,
+    ///         GroupId = groupId,
     ///         Name = &quot;Engineering&quot;,
     ///     });
     /// 
@@ -1531,13 +1531,13 @@ public partial class CamundaClient
     /// Operation: createTenant
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateTenantExample()
+    /// public static async Task CreateTenantExample(TenantId tenantId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.CreateTenantAsync(new TenantCreateRequest
     ///     {
-    ///         TenantId = &quot;acme-corp&quot;,
+    ///         TenantId = tenantId,
     ///         Name = &quot;Acme Corporation&quot;,
     ///     });
     /// 
@@ -1548,13 +1548,13 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateTenantExample()
+    /// public static async Task CreateTenantExample(TenantId tenantId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.CreateTenantAsync(new TenantCreateRequest
     ///     {
-    ///         TenantId = &quot;acme-corp&quot;,
+    ///         TenantId = tenantId,
     ///         Name = &quot;Acme Corporation&quot;,
     ///     });
     /// 
@@ -1576,7 +1576,7 @@ public partial class CamundaClient
     /// Operation: createTenantClusterVariable
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateTenantClusterVariableExample(TenantId tenantId)
+    /// public static async Task CreateTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
@@ -1584,7 +1584,7 @@ public partial class CamundaClient
     ///         tenantId,
     ///         new CreateClusterVariableRequest
     ///         {
-    ///             Name = &quot;my-variable&quot;,
+    ///             Name = name,
     ///             Value = &quot;tenant-value&quot;,
     ///         });
     /// 
@@ -1595,7 +1595,7 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateTenantClusterVariableExample(TenantId tenantId)
+    /// public static async Task CreateTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
@@ -1603,7 +1603,7 @@ public partial class CamundaClient
     ///         tenantId,
     ///         new CreateClusterVariableRequest
     ///         {
-    ///             Name = &quot;my-variable&quot;,
+    ///             Name = name,
     ///             Value = &quot;tenant-value&quot;,
     ///         });
     /// 
@@ -1625,13 +1625,13 @@ public partial class CamundaClient
     /// Operation: createUser
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateUserExample()
+    /// public static async Task CreateUserExample(Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.CreateUserAsync(new UserRequest
     ///     {
-    ///         Username = &quot;jdoe&quot;,
+    ///         Username = username,
     ///         Name = &quot;Jane Doe&quot;,
     ///         Email = &quot;jdoe@example.com&quot;,
     ///         Password = &quot;secure-password&quot;,
@@ -1644,13 +1644,13 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task CreateUserExample()
+    /// public static async Task CreateUserExample(Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.CreateUserAsync(new UserRequest
     ///     {
-    ///         Username = &quot;jdoe&quot;,
+    ///         Username = username,
     ///         Name = &quot;Jane Doe&quot;,
     ///         Email = &quot;jdoe@example.com&quot;,
     ///         Password = &quot;secure-password&quot;,
@@ -1781,7 +1781,7 @@ public partial class CamundaClient
     /// Delete document
     /// Delete a document from the Camunda 8 cluster.
     /// 
-    /// Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
+    /// Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
     /// 
     /// </summary>
     /// <remarks>
@@ -1823,22 +1823,22 @@ public partial class CamundaClient
     /// Operation: deleteGlobalClusterVariable
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task DeleteGlobalClusterVariableExample()
+    /// public static async Task DeleteGlobalClusterVariableExample(ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.DeleteGlobalClusterVariableAsync(&quot;my-variable&quot;);
+    ///     await client.DeleteGlobalClusterVariableAsync(name);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task DeleteGlobalClusterVariableExample()
+    /// public static async Task DeleteGlobalClusterVariableExample(ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.DeleteGlobalClusterVariableAsync(&quot;my-variable&quot;);
+    ///     await client.DeleteGlobalClusterVariableAsync(name);
     /// }
     /// </code>
     /// </example>
@@ -1891,22 +1891,22 @@ public partial class CamundaClient
     /// Operation: deleteGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task DeleteGroupExample()
+    /// public static async Task DeleteGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.DeleteGroupAsync(&quot;engineering&quot;);
+    ///     await client.DeleteGroupAsync(groupId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task DeleteGroupExample()
+    /// public static async Task DeleteGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.DeleteGroupAsync(&quot;engineering&quot;);
+    ///     await client.DeleteGroupAsync(groupId);
     /// }
     /// </code>
     /// </example>
@@ -1925,22 +1925,22 @@ public partial class CamundaClient
     /// Operation: deleteMappingRule
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task DeleteMappingRuleExample()
+    /// public static async Task DeleteMappingRuleExample(MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.DeleteMappingRuleAsync(&quot;rule-123&quot;);
+    ///     await client.DeleteMappingRuleAsync(mappingRuleId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task DeleteMappingRuleExample()
+    /// public static async Task DeleteMappingRuleExample(MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.DeleteMappingRuleAsync(&quot;rule-123&quot;);
+    ///     await client.DeleteMappingRuleAsync(mappingRuleId);
     /// }
     /// </code>
     /// </example>
@@ -2086,22 +2086,22 @@ public partial class CamundaClient
     /// Operation: deleteRole
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task DeleteRoleExample()
+    /// public static async Task DeleteRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.DeleteRoleAsync(&quot;developer&quot;);
+    ///     await client.DeleteRoleAsync(roleId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task DeleteRoleExample()
+    /// public static async Task DeleteRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.DeleteRoleAsync(&quot;developer&quot;);
+    ///     await client.DeleteRoleAsync(roleId);
     /// }
     /// </code>
     /// </example>
@@ -2152,26 +2152,26 @@ public partial class CamundaClient
     /// Operation: deleteTenantClusterVariable
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task DeleteTenantClusterVariableExample(TenantId tenantId)
+    /// public static async Task DeleteTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.DeleteTenantClusterVariableAsync(
     ///         tenantId,
-    ///         &quot;my-variable&quot;);
+    ///         name);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task DeleteTenantClusterVariableExample(TenantId tenantId)
+    /// public static async Task DeleteTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.DeleteTenantClusterVariableAsync(
     ///         tenantId,
-    ///         &quot;my-variable&quot;);
+    ///         name);
     /// }
     /// </code>
     /// </example>
@@ -2832,7 +2832,7 @@ public partial class CamundaClient
     /// Download document
     /// Download a document from the Camunda 8 cluster.
     /// 
-    /// Note that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)
+    /// Note that this is currently supported for document stores of type: AWS, GCP, in-memory (non-production), local (non-production)
     /// 
     /// </summary>
     /// <remarks>
@@ -2925,11 +2925,11 @@ public partial class CamundaClient
     /// Operation: getGlobalClusterVariable
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task GetGlobalClusterVariableExample()
+    /// public static async Task GetGlobalClusterVariableExample(ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     var result = await client.GetGlobalClusterVariableAsync(&quot;my-variable&quot;);
+    ///     var result = await client.GetGlobalClusterVariableAsync(name);
     ///     Console.WriteLine($&quot;Variable: {result.Name} = {result.Value}&quot;);
     /// }
     /// </code>
@@ -2937,11 +2937,11 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task GetGlobalClusterVariableExample()
+    /// public static async Task GetGlobalClusterVariableExample(ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     var result = await client.GetGlobalClusterVariableAsync(&quot;my-variable&quot;);
+    ///     var result = await client.GetGlobalClusterVariableAsync(name);
     ///     Console.WriteLine($&quot;Variable: {result.Name} = {result.Value}&quot;);
     /// }
     /// </code>
@@ -3066,11 +3066,11 @@ public partial class CamundaClient
     /// Operation: getGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task GetGroupExample()
+    /// public static async Task GetGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     var result = await client.GetGroupAsync(&quot;engineering&quot;);
+    ///     var result = await client.GetGroupAsync(groupId);
     ///     Console.WriteLine($&quot;Group: {result.Name}&quot;);
     /// }
     /// </code>
@@ -3078,11 +3078,11 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task GetGroupExample()
+    /// public static async Task GetGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     var result = await client.GetGroupAsync(&quot;engineering&quot;);
+    ///     var result = await client.GetGroupAsync(groupId);
     ///     Console.WriteLine($&quot;Group: {result.Name}&quot;);
     /// }
     /// </code>
@@ -3401,11 +3401,11 @@ public partial class CamundaClient
     /// Operation: getMappingRule
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task GetMappingRuleExample()
+    /// public static async Task GetMappingRuleExample(MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     var result = await client.GetMappingRuleAsync(&quot;rule-123&quot;);
+    ///     var result = await client.GetMappingRuleAsync(mappingRuleId);
     ///     Console.WriteLine($&quot;Mapping rule: {result.Name}&quot;);
     /// }
     /// </code>
@@ -3413,11 +3413,11 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task GetMappingRuleExample()
+    /// public static async Task GetMappingRuleExample(MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     var result = await client.GetMappingRuleAsync(&quot;rule-123&quot;);
+    ///     var result = await client.GetMappingRuleAsync(mappingRuleId);
     ///     Console.WriteLine($&quot;Mapping rule: {result.Name}&quot;);
     /// }
     /// </code>
@@ -4058,9 +4058,7 @@ public partial class CamundaClient
     /// Get resource
     /// Returns a deployed resource.
     /// :::info
-    /// This endpoint does not return BPMN process definitions, DMN decision definitions, or form
-    /// resources. To query BPMN process definitions or DMN decision definitions, use their
-    /// respective APIs.
+    /// Currently, this endpoint only supports RPA resources.
     /// :::
     /// 
     /// </summary>
@@ -4089,16 +4087,9 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<ResourceResult> GetResourceAsync(ResourceKey resourceKey, ConsistencyOptions<ResourceResult>? consistency = null, CancellationToken ct = default)
+    public async Task<ResourceResult> GetResourceAsync(ResourceKey resourceKey, CancellationToken ct = default)
     {
         var path = $"/resources/{Uri.EscapeDataString(resourceKey.ToString()!)}";
-        if (consistency != null && consistency.WaitUpToMs > 0)
-        {
-            return await EventualPoller.PollAsync("getResource", true,
-                () => InvokeWithRetryAsync(() => SendAsync<ResourceResult>(HttpMethod.Get, path, null, ct), "getResource", false, ct),
-                consistency!, _logger, ct);
-        }
-
         return await InvokeWithRetryAsync(() => SendAsync<ResourceResult>(HttpMethod.Get, path, null, ct), "getResource", false, ct);
     }
 
@@ -4135,16 +4126,9 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<object> GetResourceContentAsync(ResourceKey resourceKey, ConsistencyOptions<object>? consistency = null, CancellationToken ct = default)
+    public async Task<object> GetResourceContentAsync(ResourceKey resourceKey, CancellationToken ct = default)
     {
         var path = $"/resources/{Uri.EscapeDataString(resourceKey.ToString()!)}/content";
-        if (consistency != null && consistency.WaitUpToMs > 0)
-        {
-            return await EventualPoller.PollAsync("getResourceContent", true,
-                () => InvokeWithRetryAsync(() => SendAsync<object>(HttpMethod.Get, path, null, ct), "getResourceContent", false, ct),
-                consistency!, _logger, ct);
-        }
-
         return await InvokeWithRetryAsync(() => SendAsync<object>(HttpMethod.Get, path, null, ct), "getResourceContent", false, ct);
     }
 
@@ -4156,11 +4140,11 @@ public partial class CamundaClient
     /// Operation: getRole
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task GetRoleExample()
+    /// public static async Task GetRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     var result = await client.GetRoleAsync(&quot;developer&quot;);
+    ///     var result = await client.GetRoleAsync(roleId);
     ///     Console.WriteLine($&quot;Role: {result.Name}&quot;);
     /// }
     /// </code>
@@ -4168,11 +4152,11 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task GetRoleExample()
+    /// public static async Task GetRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     var result = await client.GetRoleAsync(&quot;developer&quot;);
+    ///     var result = await client.GetRoleAsync(roleId);
     ///     Console.WriteLine($&quot;Role: {result.Name}&quot;);
     /// }
     /// </code>
@@ -4363,13 +4347,13 @@ public partial class CamundaClient
     /// Operation: getTenantClusterVariable
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task GetTenantClusterVariableExample(TenantId tenantId)
+    /// public static async Task GetTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.GetTenantClusterVariableAsync(
     ///         tenantId,
-    ///         &quot;my-variable&quot;);
+    ///         name);
     /// 
     ///     Console.WriteLine($&quot;Variable: {result.Name} = {result.Value}&quot;);
     /// }
@@ -4378,13 +4362,13 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task GetTenantClusterVariableExample(TenantId tenantId)
+    /// public static async Task GetTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.GetTenantClusterVariableAsync(
     ///         tenantId,
-    ///         &quot;my-variable&quot;);
+    ///         name);
     /// 
     ///     Console.WriteLine($&quot;Variable: {result.Name} = {result.Value}&quot;);
     /// }
@@ -5369,12 +5353,12 @@ public partial class CamundaClient
     /// Operation: searchClientsForGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchClientsForGroupExample()
+    /// public static async Task SearchClientsForGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchClientsForGroupAsync(
-    ///         &quot;engineering&quot;,
+    ///         groupId,
     ///         new SearchClientsForGroupRequest());
     /// 
     ///     foreach (var c in result.Items)
@@ -5387,12 +5371,12 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchClientsForGroupExample()
+    /// public static async Task SearchClientsForGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchClientsForGroupAsync(
-    ///         &quot;engineering&quot;,
+    ///         groupId,
     ///         new SearchClientsForGroupRequest());
     /// 
     ///     foreach (var c in result.Items)
@@ -5423,12 +5407,12 @@ public partial class CamundaClient
     /// Operation: searchClientsForRole
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchClientsForRoleExample()
+    /// public static async Task SearchClientsForRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchClientsForRoleAsync(
-    ///         &quot;developer&quot;,
+    ///         roleId,
     ///         new SearchClientsForRoleRequest());
     /// 
     ///     foreach (var c in result.Items)
@@ -5441,12 +5425,12 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchClientsForRoleExample()
+    /// public static async Task SearchClientsForRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchClientsForRoleAsync(
-    ///         &quot;developer&quot;,
+    ///         roleId,
     ///         new SearchClientsForRoleRequest());
     /// 
     ///     foreach (var c in result.Items)
@@ -6061,12 +6045,12 @@ public partial class CamundaClient
     /// Operation: searchGroupsForRole
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchGroupsForRoleExample()
+    /// public static async Task SearchGroupsForRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchGroupsForRoleAsync(
-    ///         &quot;developer&quot;,
+    ///         roleId,
     ///         new RoleGroupSearchQueryRequest());
     /// 
     ///     foreach (var group in result.Items)
@@ -6079,12 +6063,12 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchGroupsForRoleExample()
+    /// public static async Task SearchGroupsForRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchGroupsForRoleAsync(
-    ///         &quot;developer&quot;,
+    ///         roleId,
     ///         new RoleGroupSearchQueryRequest());
     /// 
     ///     foreach (var group in result.Items)
@@ -6269,12 +6253,12 @@ public partial class CamundaClient
     /// Operation: searchMappingRulesForGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchMappingRulesForGroupExample()
+    /// public static async Task SearchMappingRulesForGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchMappingRulesForGroupAsync(
-    ///         &quot;engineering&quot;,
+    ///         groupId,
     ///         new MappingRuleSearchQueryRequest());
     /// 
     ///     foreach (var rule in result.Items)
@@ -6287,12 +6271,12 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchMappingRulesForGroupExample()
+    /// public static async Task SearchMappingRulesForGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchMappingRulesForGroupAsync(
-    ///         &quot;engineering&quot;,
+    ///         groupId,
     ///         new MappingRuleSearchQueryRequest());
     /// 
     ///     foreach (var rule in result.Items)
@@ -6323,12 +6307,12 @@ public partial class CamundaClient
     /// Operation: searchMappingRulesForRole
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchMappingRulesForRoleExample()
+    /// public static async Task SearchMappingRulesForRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchMappingRulesForRoleAsync(
-    ///         &quot;developer&quot;,
+    ///         roleId,
     ///         new MappingRuleSearchQueryRequest());
     /// 
     ///     foreach (var rule in result.Items)
@@ -6341,12 +6325,12 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchMappingRulesForRoleExample()
+    /// public static async Task SearchMappingRulesForRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchMappingRulesForRoleAsync(
-    ///         &quot;developer&quot;,
+    ///         roleId,
     ///         new MappingRuleSearchQueryRequest());
     /// 
     ///     foreach (var rule in result.Items)
@@ -6426,19 +6410,6 @@ public partial class CamundaClient
     /// <summary>
     /// Search message subscriptions
     /// Search for message subscriptions based on given criteria.
-    /// 
-    /// By default, both start and intermediate event subscriptions are returned. Use the
-    /// `messageSubscriptionType` filter to restrict results to a single type.
-    /// 
-    /// **Version notes:**
-    /// - Start event subscriptions are only captured for deployments made with 8.10 or later.
-    /// - The `messageSubscriptionType` field is only populated for data created
-    ///   with Camunda 8.10 or later. For pre-8.10 data, intermediate event entries have no
-    ///   `messageSubscriptionType` value stored. For convenience, the API returns `PROCESS_EVENT`
-    ///   as a default for such search results, though.
-    /// - Searching for intermediate event subscriptions **including legacy data** can be achieved
-    ///   by filtering for `messageSubscriptionType` not matching `START_EVENT`.
-    /// 
     /// </summary>
     /// <remarks>
     /// Operation: searchMessageSubscriptions
@@ -6651,60 +6622,6 @@ public partial class CamundaClient
     }
 
     /// <summary>
-    /// Search resources
-    /// Search for deployed resources based on given criteria.
-    /// :::info
-    /// This endpoint does not return BPMN process definitions, DMN decision definitions, or form
-    /// resources. To query BPMN process definitions or DMN decision definitions, use their
-    /// respective search APIs.
-    /// :::
-    /// 
-    /// </summary>
-    /// <remarks>
-    /// Operation: searchResources
-    /// <para><b>Example:</b></para>
-    /// <code>
-    /// public static async Task SearchResourcesExample()
-    /// {
-    ///     using var client = CamundaClient.Create();
-    /// 
-    ///     var result = await client.SearchResourcesAsync(new ResourceSearchQuery());
-    ///     foreach (var resource in result.Items!)
-    ///     {
-    ///         Console.WriteLine($&quot;Resource: {resource.ResourceName}&quot;);
-    ///     }
-    /// }
-    /// </code>
-    /// </remarks>
-    /// <example>
-    /// <para><b>Example:</b></para>
-    /// <code>
-    /// public static async Task SearchResourcesExample()
-    /// {
-    ///     using var client = CamundaClient.Create();
-    /// 
-    ///     var result = await client.SearchResourcesAsync(new ResourceSearchQuery());
-    ///     foreach (var resource in result.Items!)
-    ///     {
-    ///         Console.WriteLine($&quot;Resource: {resource.ResourceName}&quot;);
-    ///     }
-    /// }
-    /// </code>
-    /// </example>
-    public async Task<ResourceSearchQueryResult> SearchResourcesAsync(ResourceSearchQuery body, ConsistencyOptions<ResourceSearchQueryResult>? consistency = null, CancellationToken ct = default)
-    {
-        var path = $"/resources/search";
-        if (consistency != null && consistency.WaitUpToMs > 0)
-        {
-            return await EventualPoller.PollAsync("searchResources", false,
-                () => InvokeWithRetryAsync(() => SendAsync<ResourceSearchQueryResult>(HttpMethod.Post, path, body, ct), "searchResources", false, ct),
-                consistency!, _logger, ct);
-        }
-
-        return await InvokeWithRetryAsync(() => SendAsync<ResourceSearchQueryResult>(HttpMethod.Post, path, body, ct), "searchResources", false, ct);
-    }
-
-    /// <summary>
     /// Search roles
     /// Search for roles based on given criteria.
     /// </summary>
@@ -6762,12 +6679,12 @@ public partial class CamundaClient
     /// Operation: searchRolesForGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchRolesForGroupExample()
+    /// public static async Task SearchRolesForGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchRolesForGroupAsync(
-    ///         &quot;engineering&quot;,
+    ///         groupId,
     ///         new RoleSearchQueryRequest());
     /// 
     ///     foreach (var role in result.Items)
@@ -6780,12 +6697,12 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchRolesForGroupExample()
+    /// public static async Task SearchRolesForGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchRolesForGroupAsync(
-    ///         &quot;engineering&quot;,
+    ///         groupId,
     ///         new RoleSearchQueryRequest());
     /// 
     ///     foreach (var role in result.Items)
@@ -7199,12 +7116,12 @@ public partial class CamundaClient
     /// Operation: searchUsersForGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchUsersForGroupExample()
+    /// public static async Task SearchUsersForGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchUsersForGroupAsync(
-    ///         &quot;engineering&quot;,
+    ///         groupId,
     ///         new SearchUsersForGroupRequest());
     /// 
     ///     foreach (var user in result.Items)
@@ -7217,12 +7134,12 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchUsersForGroupExample()
+    /// public static async Task SearchUsersForGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchUsersForGroupAsync(
-    ///         &quot;engineering&quot;,
+    ///         groupId,
     ///         new SearchUsersForGroupRequest());
     /// 
     ///     foreach (var user in result.Items)
@@ -7253,12 +7170,12 @@ public partial class CamundaClient
     /// Operation: searchUsersForRole
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchUsersForRoleExample()
+    /// public static async Task SearchUsersForRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchUsersForRoleAsync(
-    ///         &quot;developer&quot;,
+    ///         roleId,
     ///         new SearchUsersForRoleRequest());
     /// 
     ///     foreach (var user in result.Items)
@@ -7271,12 +7188,12 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task SearchUsersForRoleExample()
+    /// public static async Task SearchUsersForRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.SearchUsersForRoleAsync(
-    ///         &quot;developer&quot;,
+    ///         roleId,
     ///         new SearchUsersForRoleRequest());
     /// 
     ///     foreach (var user in result.Items)
@@ -7504,22 +7421,22 @@ public partial class CamundaClient
     /// Operation: unassignClientFromGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignClientFromGroupExample()
+    /// public static async Task UnassignClientFromGroupExample(GroupId groupId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignClientFromGroupAsync(&quot;engineering&quot;, &quot;my-service-account&quot;);
+    ///     await client.UnassignClientFromGroupAsync(groupId, clientId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignClientFromGroupExample()
+    /// public static async Task UnassignClientFromGroupExample(GroupId groupId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignClientFromGroupAsync(&quot;engineering&quot;, &quot;my-service-account&quot;);
+    ///     await client.UnassignClientFromGroupAsync(groupId, clientId);
     /// }
     /// </code>
     /// </example>
@@ -7539,26 +7456,26 @@ public partial class CamundaClient
     /// Operation: unassignClientFromTenant
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignClientFromTenantExample(TenantId tenantId)
+    /// public static async Task UnassignClientFromTenantExample(TenantId tenantId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.UnassignClientFromTenantAsync(
     ///         tenantId,
-    ///         &quot;my-service-account&quot;);
+    ///         clientId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignClientFromTenantExample(TenantId tenantId)
+    /// public static async Task UnassignClientFromTenantExample(TenantId tenantId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.UnassignClientFromTenantAsync(
     ///         tenantId,
-    ///         &quot;my-service-account&quot;);
+    ///         clientId);
     /// }
     /// </code>
     /// </example>
@@ -7578,26 +7495,26 @@ public partial class CamundaClient
     /// Operation: unassignGroupFromTenant
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignGroupFromTenantExample(TenantId tenantId)
+    /// public static async Task UnassignGroupFromTenantExample(TenantId tenantId, GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.UnassignGroupFromTenantAsync(
     ///         tenantId,
-    ///         &quot;engineering&quot;);
+    ///         groupId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignGroupFromTenantExample(TenantId tenantId)
+    /// public static async Task UnassignGroupFromTenantExample(TenantId tenantId, GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.UnassignGroupFromTenantAsync(
     ///         tenantId,
-    ///         &quot;engineering&quot;);
+    ///         groupId);
     /// }
     /// </code>
     /// </example>
@@ -7615,22 +7532,22 @@ public partial class CamundaClient
     /// Operation: unassignMappingRuleFromGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignMappingRuleFromGroupExample()
+    /// public static async Task UnassignMappingRuleFromGroupExample(GroupId groupId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignMappingRuleFromGroupAsync(&quot;engineering&quot;, &quot;rule-123&quot;);
+    ///     await client.UnassignMappingRuleFromGroupAsync(groupId, mappingRuleId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignMappingRuleFromGroupExample()
+    /// public static async Task UnassignMappingRuleFromGroupExample(GroupId groupId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignMappingRuleFromGroupAsync(&quot;engineering&quot;, &quot;rule-123&quot;);
+    ///     await client.UnassignMappingRuleFromGroupAsync(groupId, mappingRuleId);
     /// }
     /// </code>
     /// </example>
@@ -7648,26 +7565,26 @@ public partial class CamundaClient
     /// Operation: unassignMappingRuleFromTenant
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignMappingRuleFromTenantExample(TenantId tenantId)
+    /// public static async Task UnassignMappingRuleFromTenantExample(TenantId tenantId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.UnassignMappingRuleFromTenantAsync(
     ///         tenantId,
-    ///         &quot;rule-123&quot;);
+    ///         mappingRuleId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignMappingRuleFromTenantExample(TenantId tenantId)
+    /// public static async Task UnassignMappingRuleFromTenantExample(TenantId tenantId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.UnassignMappingRuleFromTenantAsync(
     ///         tenantId,
-    ///         &quot;rule-123&quot;);
+    ///         mappingRuleId);
     /// }
     /// </code>
     /// </example>
@@ -7685,22 +7602,22 @@ public partial class CamundaClient
     /// Operation: unassignRoleFromClient
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignRoleFromClientExample()
+    /// public static async Task UnassignRoleFromClientExample(RoleId roleId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignRoleFromClientAsync(&quot;developer&quot;, &quot;my-service-account&quot;);
+    ///     await client.UnassignRoleFromClientAsync(roleId, clientId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignRoleFromClientExample()
+    /// public static async Task UnassignRoleFromClientExample(RoleId roleId, ClientId clientId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignRoleFromClientAsync(&quot;developer&quot;, &quot;my-service-account&quot;);
+    ///     await client.UnassignRoleFromClientAsync(roleId, clientId);
     /// }
     /// </code>
     /// </example>
@@ -7718,22 +7635,22 @@ public partial class CamundaClient
     /// Operation: unassignRoleFromGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignRoleFromGroupExample()
+    /// public static async Task UnassignRoleFromGroupExample(RoleId roleId, GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignRoleFromGroupAsync(&quot;developer&quot;, &quot;engineering&quot;);
+    ///     await client.UnassignRoleFromGroupAsync(roleId, groupId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignRoleFromGroupExample()
+    /// public static async Task UnassignRoleFromGroupExample(RoleId roleId, GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignRoleFromGroupAsync(&quot;developer&quot;, &quot;engineering&quot;);
+    ///     await client.UnassignRoleFromGroupAsync(roleId, groupId);
     /// }
     /// </code>
     /// </example>
@@ -7751,22 +7668,22 @@ public partial class CamundaClient
     /// Operation: unassignRoleFromMappingRule
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignRoleFromMappingRuleExample()
+    /// public static async Task UnassignRoleFromMappingRuleExample(RoleId roleId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignRoleFromMappingRuleAsync(&quot;developer&quot;, &quot;rule-123&quot;);
+    ///     await client.UnassignRoleFromMappingRuleAsync(roleId, mappingRuleId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignRoleFromMappingRuleExample()
+    /// public static async Task UnassignRoleFromMappingRuleExample(RoleId roleId, MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignRoleFromMappingRuleAsync(&quot;developer&quot;, &quot;rule-123&quot;);
+    ///     await client.UnassignRoleFromMappingRuleAsync(roleId, mappingRuleId);
     /// }
     /// </code>
     /// </example>
@@ -7787,26 +7704,26 @@ public partial class CamundaClient
     /// Operation: unassignRoleFromTenant
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignRoleFromTenantExample(TenantId tenantId)
+    /// public static async Task UnassignRoleFromTenantExample(TenantId tenantId, RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.UnassignRoleFromTenantAsync(
     ///         tenantId,
-    ///         &quot;developer&quot;);
+    ///         roleId);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignRoleFromTenantExample(TenantId tenantId)
+    /// public static async Task UnassignRoleFromTenantExample(TenantId tenantId, RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     await client.UnassignRoleFromTenantAsync(
     ///         tenantId,
-    ///         &quot;developer&quot;);
+    ///         roleId);
     /// }
     /// </code>
     /// </example>
@@ -7824,22 +7741,22 @@ public partial class CamundaClient
     /// Operation: unassignRoleFromUser
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignRoleFromUserExample(Username username)
+    /// public static async Task UnassignRoleFromUserExample(RoleId roleId, Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignRoleFromUserAsync(&quot;developer&quot;, username);
+    ///     await client.UnassignRoleFromUserAsync(roleId, username);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignRoleFromUserExample(Username username)
+    /// public static async Task UnassignRoleFromUserExample(RoleId roleId, Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignRoleFromUserAsync(&quot;developer&quot;, username);
+    ///     await client.UnassignRoleFromUserAsync(roleId, username);
     /// }
     /// </code>
     /// </example>
@@ -7859,22 +7776,22 @@ public partial class CamundaClient
     /// Operation: unassignUserFromGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignUserFromGroupExample(Username username)
+    /// public static async Task UnassignUserFromGroupExample(GroupId groupId, Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignUserFromGroupAsync(&quot;engineering&quot;, username);
+    ///     await client.UnassignUserFromGroupAsync(groupId, username);
     /// }
     /// </code>
     /// </remarks>
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UnassignUserFromGroupExample(Username username)
+    /// public static async Task UnassignUserFromGroupExample(GroupId groupId, Username username)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UnassignUserFromGroupAsync(&quot;engineering&quot;, username);
+    ///     await client.UnassignUserFromGroupAsync(groupId, username);
     /// }
     /// </code>
     /// </example>
@@ -8018,12 +7935,12 @@ public partial class CamundaClient
     /// Operation: updateGlobalClusterVariable
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateGlobalClusterVariableExample()
+    /// public static async Task UpdateGlobalClusterVariableExample(ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.UpdateGlobalClusterVariableAsync(
-    ///         &quot;my-variable&quot;,
+    ///         name,
     ///         new UpdateClusterVariableRequest
     ///         {
     ///             Value = &quot;updated-value&quot;,
@@ -8036,12 +7953,12 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateGlobalClusterVariableExample()
+    /// public static async Task UpdateGlobalClusterVariableExample(ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.UpdateGlobalClusterVariableAsync(
-    ///         &quot;my-variable&quot;,
+    ///         name,
     ///         new UpdateClusterVariableRequest
     ///         {
     ///             Value = &quot;updated-value&quot;,
@@ -8114,11 +8031,11 @@ public partial class CamundaClient
     /// Operation: updateGroup
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateGroupExample()
+    /// public static async Task UpdateGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UpdateGroupAsync(&quot;engineering&quot;, new GroupUpdateRequest
+    ///     await client.UpdateGroupAsync(groupId, new GroupUpdateRequest
     ///     {
     ///         Name = &quot;engineering-team&quot;,
     ///     });
@@ -8128,11 +8045,11 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateGroupExample()
+    /// public static async Task UpdateGroupExample(GroupId groupId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UpdateGroupAsync(&quot;engineering&quot;, new GroupUpdateRequest
+    ///     await client.UpdateGroupAsync(groupId, new GroupUpdateRequest
     ///     {
     ///         Name = &quot;engineering-team&quot;,
     ///     });
@@ -8197,11 +8114,11 @@ public partial class CamundaClient
     /// Operation: updateMappingRule
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateMappingRuleExample()
+    /// public static async Task UpdateMappingRuleExample(MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UpdateMappingRuleAsync(&quot;rule-123&quot;, new MappingRuleUpdateRequest
+    ///     await client.UpdateMappingRuleAsync(mappingRuleId, new MappingRuleUpdateRequest
     ///     {
     ///         ClaimName = &quot;groups&quot;,
     ///         ClaimValue = &quot;senior-engineering&quot;,
@@ -8213,11 +8130,11 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateMappingRuleExample()
+    /// public static async Task UpdateMappingRuleExample(MappingRuleId mappingRuleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UpdateMappingRuleAsync(&quot;rule-123&quot;, new MappingRuleUpdateRequest
+    ///     await client.UpdateMappingRuleAsync(mappingRuleId, new MappingRuleUpdateRequest
     ///     {
     ///         ClaimName = &quot;groups&quot;,
     ///         ClaimValue = &quot;senior-engineering&quot;,
@@ -8240,11 +8157,11 @@ public partial class CamundaClient
     /// Operation: updateRole
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateRoleExample()
+    /// public static async Task UpdateRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UpdateRoleAsync(&quot;developer&quot;, new RoleUpdateRequest
+    ///     await client.UpdateRoleAsync(roleId, new RoleUpdateRequest
     ///     {
     ///         Name = &quot;senior-developer&quot;,
     ///     });
@@ -8254,11 +8171,11 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateRoleExample()
+    /// public static async Task UpdateRoleExample(RoleId roleId)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
-    ///     await client.UpdateRoleAsync(&quot;developer&quot;, new RoleUpdateRequest
+    ///     await client.UpdateRoleAsync(roleId, new RoleUpdateRequest
     ///     {
     ///         Name = &quot;senior-developer&quot;,
     ///     });
@@ -8324,13 +8241,13 @@ public partial class CamundaClient
     /// Operation: updateTenantClusterVariable
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateTenantClusterVariableExample(TenantId tenantId)
+    /// public static async Task UpdateTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.UpdateTenantClusterVariableAsync(
     ///         tenantId,
-    ///         &quot;my-variable&quot;,
+    ///         name,
     ///         new UpdateClusterVariableRequest
     ///         {
     ///             Value = &quot;updated-tenant-value&quot;,
@@ -8343,13 +8260,13 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateTenantClusterVariableExample(TenantId tenantId)
+    /// public static async Task UpdateTenantClusterVariableExample(TenantId tenantId, ClusterVariableName name)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
     ///     var result = await client.UpdateTenantClusterVariableAsync(
     ///         tenantId,
-    ///         &quot;my-variable&quot;,
+    ///         name,
     ///         new UpdateClusterVariableRequest
     ///         {
     ///             Value = &quot;updated-tenant-value&quot;,

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -807,57 +807,6 @@ public sealed class AdvancedDeploymentKeyFilter
 }
 
 /// <summary>
-/// Advanced ElementId filter.
-/// </summary>
-public sealed class AdvancedElementIdFilter
-{
-    /// <summary>
-    /// Checks for equality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$eq")]
-    public ElementId? Eq { get; set; }
-
-    /// <summary>
-    /// Checks for inequality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$neq")]
-    public ElementId? Neq { get; set; }
-
-    /// <summary>
-    /// Checks if the current property exists.
-    /// </summary>
-    [JsonPropertyName("$exists")]
-    public bool? Exists { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches any of the provided values.
-    /// </summary>
-    [JsonPropertyName("$in")]
-    public List<ElementId>? In { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches none of the provided values.
-    /// </summary>
-    [JsonPropertyName("$notIn")]
-    public List<ElementId>? NotIn { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches the provided like value.
-    /// 
-    /// Supported wildcard characters are:
-    /// 
-    /// * `*`: matches zero, one, or multiple characters.
-    /// * `?`: matches one, single character.
-    /// 
-    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
-    /// 
-    /// </summary>
-    [JsonPropertyName("$like")]
-    public LikeFilter? Like { get; set; }
-
-}
-
-/// <summary>
 /// Advanced ElementInstanceKey filter.
 /// </summary>
 public sealed class AdvancedElementInstanceKeyFilter
@@ -1523,51 +1472,6 @@ public sealed class AdvancedMessageSubscriptionStateFilter
 }
 
 /// <summary>
-/// Advanced MessageSubscriptionTypeEnum filter
-/// </summary>
-public sealed class AdvancedMessageSubscriptionTypeFilter
-{
-    /// <summary>
-    /// Checks for equality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$eq")]
-    public MessageSubscriptionTypeEnum? Eq { get; set; }
-
-    /// <summary>
-    /// Checks for inequality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$neq")]
-    public MessageSubscriptionTypeEnum? Neq { get; set; }
-
-    /// <summary>
-    /// Checks if the current property exists.
-    /// </summary>
-    [JsonPropertyName("$exists")]
-    public bool? Exists { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches any of the provided values.
-    /// </summary>
-    [JsonPropertyName("$in")]
-    public List<MessageSubscriptionTypeEnum>? In { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches the provided like value.
-    /// 
-    /// Supported wildcard characters are:
-    /// 
-    /// * `*`: matches zero, one, or multiple characters.
-    /// * `?`: matches one, single character.
-    /// 
-    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
-    /// 
-    /// </summary>
-    [JsonPropertyName("$like")]
-    public LikeFilter? Like { get; set; }
-
-}
-
-/// <summary>
 /// Advanced AuditLogOperationTypeEnum filter.
 /// </summary>
 public sealed class AdvancedOperationTypeFilter
@@ -1595,57 +1499,6 @@ public sealed class AdvancedOperationTypeFilter
     /// </summary>
     [JsonPropertyName("$in")]
     public List<AuditLogOperationTypeEnum>? In { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches the provided like value.
-    /// 
-    /// Supported wildcard characters are:
-    /// 
-    /// * `*`: matches zero, one, or multiple characters.
-    /// * `?`: matches one, single character.
-    /// 
-    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
-    /// 
-    /// </summary>
-    [JsonPropertyName("$like")]
-    public LikeFilter? Like { get; set; }
-
-}
-
-/// <summary>
-/// Advanced ProcessDefinitionId filter.
-/// </summary>
-public sealed class AdvancedProcessDefinitionIdFilter
-{
-    /// <summary>
-    /// Checks for equality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$eq")]
-    public ProcessDefinitionId? Eq { get; set; }
-
-    /// <summary>
-    /// Checks for inequality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$neq")]
-    public ProcessDefinitionId? Neq { get; set; }
-
-    /// <summary>
-    /// Checks if the current property exists.
-    /// </summary>
-    [JsonPropertyName("$exists")]
-    public bool? Exists { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches any of the provided values.
-    /// </summary>
-    [JsonPropertyName("$in")]
-    public List<ProcessDefinitionId>? In { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches none of the provided values.
-    /// </summary>
-    [JsonPropertyName("$notIn")]
-    public List<ProcessDefinitionId>? NotIn { get; set; }
 
     /// <summary>
     /// Checks if the property matches the provided like value.
@@ -3571,13 +3424,10 @@ public sealed class BatchOperationItemResponse
     public string ItemKey { get; set; } = null!;
 
     /// <summary>
-    /// The process instance key of the processed item. Null for batch-op types whose targets
-    /// are not process instances (e.g. DELETE_DECISION_INSTANCE, DELETE_DECISION_DEFINITION,
-    /// DELETE_PROCESS_DEFINITION).
-    /// 
+    /// the process instance key of the processed item.
     /// </summary>
     [JsonPropertyName("processInstanceKey")]
-    public ProcessInstanceKey? ProcessInstanceKey { get; set; }
+    public ProcessInstanceKey ProcessInstanceKey { get; set; }
 
     /// <summary>
     /// The key of the root process instance. The root process instance is the top-level
@@ -7319,85 +7169,6 @@ public readonly record struct ElementId : global::Camunda.Orchestration.Sdk.ICam
 }
 
 /// <summary>
-/// Matches the value exactly.
-/// </summary>
-public readonly record struct ElementIdExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
-{
-    /// <summary>The underlying string value.</summary>
-    public string Value { get; }
-
-    private ElementIdExactMatch(string value) => Value = value;
-
-    /// <summary>
-    /// Creates a <see cref="ElementIdExactMatch"/> from a raw string value.
-    /// Use this when side-loading values not received from an API call.
-    /// </summary>
-    public static ElementIdExactMatch AssumeExists(string value)
-    {
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "ElementIdExactMatch");
-        return new ElementIdExactMatch(value);
-    }
-
-    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
-    public static bool IsValid(string value) =>
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
-
-    /// <inheritdoc />
-    public override string ToString() => Value.ToString()!;
-}
-
-/// <summary>
-/// ElementId property with full advanced search capabilities.
-/// </summary>
-public sealed class ElementIdFilterProperty
-{
-    /// <summary>
-    /// Checks for equality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$eq")]
-    public ElementId? Eq { get; set; }
-
-    /// <summary>
-    /// Checks for inequality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$neq")]
-    public ElementId? Neq { get; set; }
-
-    /// <summary>
-    /// Checks if the current property exists.
-    /// </summary>
-    [JsonPropertyName("$exists")]
-    public bool? Exists { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches any of the provided values.
-    /// </summary>
-    [JsonPropertyName("$in")]
-    public List<ElementId>? In { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches none of the provided values.
-    /// </summary>
-    [JsonPropertyName("$notIn")]
-    public List<ElementId>? NotIn { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches the provided like value.
-    /// 
-    /// Supported wildcard characters are:
-    /// 
-    /// * `*`: matches zero, one, or multiple characters.
-    /// * `?`: matches one, single character.
-    /// 
-    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
-    /// 
-    /// </summary>
-    [JsonPropertyName("$like")]
-    public LikeFilter? Like { get; set; }
-
-}
-
-/// <summary>
 /// Element instance filter.
 /// </summary>
 public sealed class ElementInstanceFilter
@@ -7424,14 +7195,14 @@ public sealed class ElementInstanceFilter
     /// The element ID for this element instance.
     /// </summary>
     [JsonPropertyName("elementId")]
-    public ElementIdFilterProperty? ElementId { get; set; }
+    public ElementId? ElementId { get; set; }
 
     /// <summary>
     /// The element name. This only works for data created with 8.8 and onwards. Instances from prior versions don&apos;t contain this data and cannot be found.
     /// 
     /// </summary>
     [JsonPropertyName("elementName")]
-    public StringFilterProperty? ElementName { get; set; }
+    public string? ElementName { get; set; }
 
     /// <summary>
     /// Shows whether this element instance has an incident related to.
@@ -10607,8 +10378,6 @@ public enum JobListenerEventTypeEnum
 {
     [JsonPropertyName("ASSIGNING")]
     ASSIGNING,
-    [JsonPropertyName("BEFORE_ALL")]
-    BEFOREALL,
     [JsonPropertyName("CANCELING")]
     CANCELING,
     [JsonPropertyName("COMPLETING")]
@@ -12201,39 +11970,6 @@ public sealed class MessageSubscriptionFilter
     [JsonPropertyName("tenantId")]
     public StringFilterProperty? TenantId { get; set; }
 
-    /// <summary>
-    /// The type of message subscription to filter by. When omitted, both
-    /// `START_EVENT` and `PROCESS_EVENT` are returned. Only available for data
-    /// created with Camunda 8.10 or later.
-    /// 
-    /// </summary>
-    [JsonPropertyName("messageSubscriptionType")]
-    public MessageSubscriptionTypeFilterProperty? MessageSubscriptionType { get; set; }
-
-    /// <summary>
-    /// The name of the process definition associated with this message subscription.
-    /// </summary>
-    [JsonPropertyName("processDefinitionName")]
-    public StringFilterProperty? ProcessDefinitionName { get; set; }
-
-    /// <summary>
-    /// The version of the process definition associated with this message subscription.
-    /// </summary>
-    [JsonPropertyName("processDefinitionVersion")]
-    public IntegerFilterProperty? ProcessDefinitionVersion { get; set; }
-
-    /// <summary>
-    /// Filter by tool name extracted from the `io.camunda.tool:name` zeebe:property.
-    /// </summary>
-    [JsonPropertyName("toolName")]
-    public StringFilterProperty? ToolName { get; set; }
-
-    /// <summary>
-    /// Filter by inbound connector type extracted from the `inbound.type` zeebe:property.
-    /// </summary>
-    [JsonPropertyName("inboundConnectorType")]
-    public StringFilterProperty? InboundConnectorType { get; set; }
-
 }
 
 /// <summary>
@@ -12354,8 +12090,6 @@ public sealed class MessageSubscriptionResult
 
     /// <summary>
     /// The process instance key associated with this message subscription.
-    /// Only populated for intermediate event entities.
-    /// 
     /// </summary>
     [JsonPropertyName("processInstanceKey")]
     public ProcessInstanceKey? ProcessInstanceKey { get; set; }
@@ -12377,8 +12111,6 @@ public sealed class MessageSubscriptionResult
 
     /// <summary>
     /// The element instance key associated with this message subscription.
-    /// Only populated for intermediate event entities.
-    /// 
     /// </summary>
     [JsonPropertyName("elementInstanceKey")]
     public ElementInstanceKey? ElementInstanceKey { get; set; }
@@ -12406,53 +12138,6 @@ public sealed class MessageSubscriptionResult
     /// </summary>
     [JsonPropertyName("correlationKey")]
     public string? CorrelationKey { get; set; }
-
-    /// <summary>
-    /// The type of message subscription.
-    /// `START_EVENT` is definition-scoped (process start events). Always has a value; only
-    /// captured from Camunda 8.10 onwards.
-    /// `PROCESS_EVENT` is instance-scoped (intermediate catch events). Pre-8.10 entries have
-    /// no value stored; the API returns `PROCESS_EVENT` as a default for those entries.
-    /// 
-    /// </summary>
-    [JsonPropertyName("messageSubscriptionType")]
-    public MessageSubscriptionTypeEnum MessageSubscriptionType { get; set; }
-
-    /// <summary>
-    /// The `zeebe:properties` extension properties extracted from the BPMN element associated
-    /// with this subscription. Empty object when no properties are defined.
-    /// 
-    /// </summary>
-    [JsonPropertyName("extensionProperties")]
-    public Dictionary<string, string> ExtensionProperties { get; set; } = null!;
-
-    /// <summary>
-    /// The name of the process definition associated with this message subscription.
-    /// </summary>
-    [JsonPropertyName("processDefinitionName")]
-    public string? ProcessDefinitionName { get; set; }
-
-    /// <summary>
-    /// The version of the process definition associated with this message subscription.
-    /// </summary>
-    [JsonPropertyName("processDefinitionVersion")]
-    public int? ProcessDefinitionVersion { get; set; }
-
-    /// <summary>
-    /// Tool name extracted from the `io.camunda.tool:name` zeebe:property.
-    /// Null when the property is absent.
-    /// 
-    /// </summary>
-    [JsonPropertyName("toolName")]
-    public string? ToolName { get; set; }
-
-    /// <summary>
-    /// Inbound connector type extracted from the `inbound.type` zeebe:property.
-    /// Null when the property is absent.
-    /// 
-    /// </summary>
-    [JsonPropertyName("inboundConnectorType")]
-    public string? InboundConnectorType { get; set; }
 
     /// <summary>
     /// The unique identifier of the tenant.
@@ -12597,96 +12282,6 @@ public sealed class MessageSubscriptionStateFilterProperty
     /// </summary>
     [JsonPropertyName("$in")]
     public List<MessageSubscriptionStateEnum>? In { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches the provided like value.
-    /// 
-    /// Supported wildcard characters are:
-    /// 
-    /// * `*`: matches zero, one, or multiple characters.
-    /// * `?`: matches one, single character.
-    /// 
-    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
-    /// 
-    /// </summary>
-    [JsonPropertyName("$like")]
-    public LikeFilter? Like { get; set; }
-
-}
-
-/// <summary>
-/// The type of message subscription.
-/// `START_EVENT` is definition-scoped (process start events). Always has a value; only
-/// captured from Camunda 8.10 onwards.
-/// `PROCESS_EVENT` is instance-scoped (intermediate catch events). Pre-8.10 entries have
-/// no value stored; the API returns `PROCESS_EVENT` as a default for those entries.
-/// 
-/// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
-public enum MessageSubscriptionTypeEnum
-{
-    [JsonPropertyName("START_EVENT")]
-    STARTEVENT,
-    [JsonPropertyName("PROCESS_EVENT")]
-    PROCESSEVENT,
-}
-
-/// <summary>
-/// Matches the value exactly.
-/// </summary>
-public readonly record struct MessageSubscriptionTypeExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
-{
-    /// <summary>The underlying string value.</summary>
-    public string Value { get; }
-
-    private MessageSubscriptionTypeExactMatch(string value) => Value = value;
-
-    /// <summary>
-    /// Creates a <see cref="MessageSubscriptionTypeExactMatch"/> from a raw string value.
-    /// Use this when side-loading values not received from an API call.
-    /// </summary>
-    public static MessageSubscriptionTypeExactMatch AssumeExists(string value)
-    {
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "MessageSubscriptionTypeExactMatch");
-        return new MessageSubscriptionTypeExactMatch(value);
-    }
-
-    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
-    public static bool IsValid(string value) =>
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
-
-    /// <inheritdoc />
-    public override string ToString() => Value.ToString()!;
-}
-
-/// <summary>
-/// MessageSubscriptionTypeEnum with full advanced search capabilities.
-/// </summary>
-public sealed class MessageSubscriptionTypeFilterProperty
-{
-    /// <summary>
-    /// Checks for equality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$eq")]
-    public MessageSubscriptionTypeEnum? Eq { get; set; }
-
-    /// <summary>
-    /// Checks for inequality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$neq")]
-    public MessageSubscriptionTypeEnum? Neq { get; set; }
-
-    /// <summary>
-    /// Checks if the current property exists.
-    /// </summary>
-    [JsonPropertyName("$exists")]
-    public bool? Exists { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches any of the provided values.
-    /// </summary>
-    [JsonPropertyName("$in")]
-    public List<MessageSubscriptionTypeEnum>? In { get; set; }
 
     /// <summary>
     /// Checks if the property matches the provided like value.
@@ -13154,85 +12749,6 @@ public readonly record struct ProcessDefinitionId : global::Camunda.Orchestratio
 
     /// <inheritdoc />
     public override string ToString() => Value.ToString()!;
-}
-
-/// <summary>
-/// Matches the value exactly.
-/// </summary>
-public readonly record struct ProcessDefinitionIdExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
-{
-    /// <summary>The underlying string value.</summary>
-    public string Value { get; }
-
-    private ProcessDefinitionIdExactMatch(string value) => Value = value;
-
-    /// <summary>
-    /// Creates a <see cref="ProcessDefinitionIdExactMatch"/> from a raw string value.
-    /// Use this when side-loading values not received from an API call.
-    /// </summary>
-    public static ProcessDefinitionIdExactMatch AssumeExists(string value)
-    {
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "ProcessDefinitionIdExactMatch", pattern: @"^[\p{L}_][\p{L}\p{N}_\-\.]*$", minLength: 1);
-        return new ProcessDefinitionIdExactMatch(value);
-    }
-
-    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
-    public static bool IsValid(string value) =>
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^[\p{L}_][\p{L}\p{N}_\-\.]*$", minLength: 1);
-
-    /// <inheritdoc />
-    public override string ToString() => Value.ToString()!;
-}
-
-/// <summary>
-/// ProcessDefinitionId property with full advanced search capabilities.
-/// </summary>
-public sealed class ProcessDefinitionIdFilterProperty
-{
-    /// <summary>
-    /// Checks for equality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$eq")]
-    public ProcessDefinitionId? Eq { get; set; }
-
-    /// <summary>
-    /// Checks for inequality with the provided value.
-    /// </summary>
-    [JsonPropertyName("$neq")]
-    public ProcessDefinitionId? Neq { get; set; }
-
-    /// <summary>
-    /// Checks if the current property exists.
-    /// </summary>
-    [JsonPropertyName("$exists")]
-    public bool? Exists { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches any of the provided values.
-    /// </summary>
-    [JsonPropertyName("$in")]
-    public List<ProcessDefinitionId>? In { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches none of the provided values.
-    /// </summary>
-    [JsonPropertyName("$notIn")]
-    public List<ProcessDefinitionId>? NotIn { get; set; }
-
-    /// <summary>
-    /// Checks if the property matches the provided like value.
-    /// 
-    /// Supported wildcard characters are:
-    /// 
-    /// * `*`: matches zero, one, or multiple characters.
-    /// * `?`: matches one, single character.
-    /// 
-    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
-    /// 
-    /// </summary>
-    [JsonPropertyName("$like")]
-    public LikeFilter? Like { get; set; }
-
 }
 
 /// <summary>
@@ -15271,55 +14787,6 @@ public sealed class ProcessInstanceStateFilterProperty
 }
 
 /// <summary>
-/// Resource search filter.
-/// </summary>
-public sealed class ResourceFilter
-{
-    /// <summary>
-    /// The key for this resource.
-    /// </summary>
-    [JsonPropertyName("resourceKey")]
-    public ResourceKeyFilterProperty? ResourceKey { get; set; }
-
-    /// <summary>
-    /// Resource name of this resource.
-    /// </summary>
-    [JsonPropertyName("resourceName")]
-    public StringFilterProperty? ResourceName { get; set; }
-
-    /// <summary>
-    /// Resource ID of this resource.
-    /// </summary>
-    [JsonPropertyName("resourceId")]
-    public StringFilterProperty? ResourceId { get; set; }
-
-    /// <summary>
-    /// Version of this resource.
-    /// </summary>
-    [JsonPropertyName("version")]
-    public IntegerFilterProperty? Version { get; set; }
-
-    /// <summary>
-    /// Version tag of this resource.
-    /// </summary>
-    [JsonPropertyName("versionTag")]
-    public StringFilterProperty? VersionTag { get; set; }
-
-    /// <summary>
-    /// Deployment key of this resource.
-    /// </summary>
-    [JsonPropertyName("deploymentKey")]
-    public DeploymentKeyFilterProperty? DeploymentKey { get; set; }
-
-    /// <summary>
-    /// Tenant ID of this resource.
-    /// </summary>
-    [JsonPropertyName("tenantId")]
-    public TenantId? TenantId { get; set; }
-
-}
-
-/// <summary>
 /// The system-assigned key for this resource.
 /// </summary>
 public readonly record struct ResourceKey : global::Camunda.Orchestration.Sdk.ICamundaKey
@@ -15484,69 +14951,6 @@ public sealed class ResourceResult
     /// </summary>
     [JsonPropertyName("resourceKey")]
     public ResourceKey ResourceKey { get; set; }
-
-}
-
-/// <summary>
-/// ResourceSearchQuery
-/// </summary>
-public sealed class ResourceSearchQuery
-{
-    /// <summary>
-    /// Sort field criteria.
-    /// </summary>
-    [JsonPropertyName("sort")]
-    public List<ResourceSearchQuerySortRequest>? Sort { get; set; }
-
-    /// <summary>
-    /// The resource search filters.
-    /// </summary>
-    [JsonPropertyName("filter")]
-    public ResourceFilter? Filter { get; set; }
-
-    /// <summary>
-    /// Pagination criteria.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageRequest? Page { get; set; }
-
-}
-
-/// <summary>
-/// ResourceSearchQueryResult
-/// </summary>
-public sealed class ResourceSearchQueryResult
-{
-    /// <summary>
-    /// The matching resources.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<ResourceResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// ResourceSearchQuerySortRequest
-/// </summary>
-public sealed class ResourceSearchQuerySortRequest
-{
-    /// <summary>
-    /// The field to sort by.
-    /// </summary>
-    [JsonPropertyName("field")]
-    public string Field { get; set; } = null!;
-
-    /// <summary>
-    /// The order in which to sort the related field.
-    /// </summary>
-    [JsonPropertyName("order")]
-    public SortOrderEnum? Order { get; set; }
 
 }
 
@@ -17581,7 +16985,7 @@ public sealed class UserTaskFilter
     /// The ID of the process definition.
     /// </summary>
     [JsonPropertyName("processDefinitionId")]
-    public ProcessDefinitionIdFilterProperty? ProcessDefinitionId { get; set; }
+    public ProcessDefinitionId? ProcessDefinitionId { get; set; }
 
     /// <summary>
     /// The user task creation date.
@@ -17629,13 +17033,13 @@ public sealed class UserTaskFilter
     /// The key of the process definition.
     /// </summary>
     [JsonPropertyName("processDefinitionKey")]
-    public ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; }
+    public ProcessDefinitionKey? ProcessDefinitionKey { get; set; }
 
     /// <summary>
     /// The key of the process instance.
     /// </summary>
     [JsonPropertyName("processInstanceKey")]
-    public ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; }
+    public ProcessInstanceKey? ProcessInstanceKey { get; set; }
 
     /// <summary>
     /// The key of the element instance.

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -217,6 +217,88 @@ public sealed class AdvancedActorTypeFilter
 }
 
 /// <summary>
+/// Advanced AgentInstanceKey filter.
+/// </summary>
+public sealed class AdvancedAgentInstanceKeyFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public AgentInstanceKey? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public AgentInstanceKey? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<AgentInstanceKey>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches none of the provided values.
+    /// </summary>
+    [JsonPropertyName("$notIn")]
+    public List<AgentInstanceKey>? NotIn { get; set; }
+
+}
+
+/// <summary>
+/// Advanced AgentInstanceStatusEnum filter.
+/// </summary>
+public sealed class AdvancedAgentInstanceStatusFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public AgentInstanceStatusEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public AgentInstanceStatusEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<AgentInstanceStatusEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
 /// Advanced entityKey filter.
 /// </summary>
 public sealed class AdvancedAuditLogEntityKeyFilter
@@ -803,6 +885,57 @@ public sealed class AdvancedDeploymentKeyFilter
     /// </summary>
     [JsonPropertyName("$notIn")]
     public List<DeploymentKey>? NotIn { get; set; }
+
+}
+
+/// <summary>
+/// Advanced ElementId filter.
+/// </summary>
+public sealed class AdvancedElementIdFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public ElementId? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public ElementId? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<ElementId>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches none of the provided values.
+    /// </summary>
+    [JsonPropertyName("$notIn")]
+    public List<ElementId>? NotIn { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
 
 }
 
@@ -1472,6 +1605,51 @@ public sealed class AdvancedMessageSubscriptionStateFilter
 }
 
 /// <summary>
+/// Advanced MessageSubscriptionTypeEnum filter
+/// </summary>
+public sealed class AdvancedMessageSubscriptionTypeFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public MessageSubscriptionTypeEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public MessageSubscriptionTypeEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<MessageSubscriptionTypeEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
 /// Advanced AuditLogOperationTypeEnum filter.
 /// </summary>
 public sealed class AdvancedOperationTypeFilter
@@ -1499,6 +1677,57 @@ public sealed class AdvancedOperationTypeFilter
     /// </summary>
     [JsonPropertyName("$in")]
     public List<AuditLogOperationTypeEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
+/// Advanced ProcessDefinitionId filter.
+/// </summary>
+public sealed class AdvancedProcessDefinitionIdFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public ProcessDefinitionId? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public ProcessDefinitionId? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<ProcessDefinitionId>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches none of the provided values.
+    /// </summary>
+    [JsonPropertyName("$notIn")]
+    public List<ProcessDefinitionId>? NotIn { get; set; }
 
     /// <summary>
     /// Checks if the property matches the provided like value.
@@ -1884,6 +2113,476 @@ public sealed class AdvancedVariableKeyFilter
     /// </summary>
     [JsonPropertyName("$notIn")]
     public List<VariableKey>? NotIn { get; set; }
+
+}
+
+/// <summary>
+/// The static definition of an agent instance, set once at creation.
+/// </summary>
+public sealed class AgentInstanceDefinition
+{
+    /// <summary>
+    /// The LLM model identifier (for example, gpt-4o).
+    /// </summary>
+    [JsonPropertyName("model")]
+    public string Model { get; set; } = null!;
+
+    /// <summary>
+    /// The LLM provider (for example, openai or anthropic).
+    /// </summary>
+    [JsonPropertyName("provider")]
+    public string Provider { get; set; } = null!;
+
+    /// <summary>
+    /// The system prompt configured for this agent instance.
+    /// </summary>
+    [JsonPropertyName("systemPrompt")]
+    public string SystemPrompt { get; set; } = null!;
+
+}
+
+/// <summary>
+/// Agent instance search filter.
+/// </summary>
+public sealed class AgentInstanceFilter
+{
+    /// <summary>
+    /// The unique key of the agent instance.
+    /// </summary>
+    [JsonPropertyName("agentInstanceKey")]
+    public AgentInstanceKeyFilterProperty? AgentInstanceKey { get; set; }
+
+    /// <summary>
+    /// The current status of the agent instance.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public AgentInstanceStatusFilterProperty? Status { get; set; }
+
+    /// <summary>
+    /// The BPMN element ID of the agent task.
+    /// </summary>
+    [JsonPropertyName("elementId")]
+    public ElementIdFilterProperty? ElementId { get; set; }
+
+    /// <summary>
+    /// The key of the process instance that owns this agent instance.
+    /// </summary>
+    [JsonPropertyName("processInstanceKey")]
+    public ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The key of the process definition associated with this agent instance.
+    /// </summary>
+    [JsonPropertyName("processDefinitionKey")]
+    public ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; }
+
+    /// <summary>
+    /// The tenant ID of the agent instance.
+    /// </summary>
+    [JsonPropertyName("tenantId")]
+    public StringFilterProperty? TenantId { get; set; }
+
+    /// <summary>
+    /// The creation date of the agent instance.
+    /// </summary>
+    [JsonPropertyName("creationDate")]
+    public DateTimeFilterProperty? CreationDate { get; set; }
+
+    /// <summary>
+    /// The date the agent instance was last updated.
+    /// </summary>
+    [JsonPropertyName("lastUpdatedDate")]
+    public DateTimeFilterProperty? LastUpdatedDate { get; set; }
+
+    /// <summary>
+    /// The completion date of the agent instance.
+    /// </summary>
+    [JsonPropertyName("completionDate")]
+    public DateTimeFilterProperty? CompletionDate { get; set; }
+
+}
+
+/// <summary>
+/// System-generated key for an agent instance.
+/// </summary>
+public readonly record struct AgentInstanceKey : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private AgentInstanceKey(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="AgentInstanceKey"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static AgentInstanceKey AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "AgentInstanceKey", pattern: @"^-?[0-9]+$", minLength: 1, maxLength: 25);
+        return new AgentInstanceKey(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^-?[0-9]+$", minLength: 1, maxLength: 25);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct AgentInstanceKeyExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private AgentInstanceKeyExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="AgentInstanceKeyExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static AgentInstanceKeyExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "AgentInstanceKeyExactMatch");
+        return new AgentInstanceKeyExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// AgentInstanceKey property with full advanced search capabilities.
+/// </summary>
+public sealed class AgentInstanceKeyFilterProperty
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public AgentInstanceKey? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public AgentInstanceKey? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<AgentInstanceKey>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches none of the provided values.
+    /// </summary>
+    [JsonPropertyName("$notIn")]
+    public List<AgentInstanceKey>? NotIn { get; set; }
+
+}
+
+/// <summary>
+/// The configured limits for an agent instance, set once at creation.
+/// </summary>
+public sealed class AgentInstanceLimits
+{
+    /// <summary>
+    /// Maximum LLM calls allowed. -1 if no limit is configured.
+    /// </summary>
+    [JsonPropertyName("maxModelCalls")]
+    public long MaxModelCalls { get; set; }
+
+    /// <summary>
+    /// Maximum tool calls allowed. -1 if no limit is configured.
+    /// </summary>
+    [JsonPropertyName("maxToolCalls")]
+    public long MaxToolCalls { get; set; }
+
+    /// <summary>
+    /// Maximum total tokens allowed. -1 if no limit is configured.
+    /// </summary>
+    [JsonPropertyName("maxTokens")]
+    public long MaxTokens { get; set; }
+
+}
+
+/// <summary>
+/// Aggregated metrics for an agent instance across all model calls.
+/// </summary>
+public sealed class AgentInstanceMetrics
+{
+    /// <summary>
+    /// Total input tokens consumed across all model calls.
+    /// </summary>
+    [JsonPropertyName("inputTokens")]
+    public long InputTokens { get; set; }
+
+    /// <summary>
+    /// Total output tokens produced across all model calls.
+    /// </summary>
+    [JsonPropertyName("outputTokens")]
+    public long OutputTokens { get; set; }
+
+    /// <summary>
+    /// Total number of LLM calls made.
+    /// </summary>
+    [JsonPropertyName("modelCalls")]
+    public long ModelCalls { get; set; }
+
+    /// <summary>
+    /// Total number of tool calls made.
+    /// </summary>
+    [JsonPropertyName("toolCalls")]
+    public long ToolCalls { get; set; }
+
+}
+
+/// <summary>
+/// AgentInstanceResult
+/// </summary>
+public sealed class AgentInstanceResult
+{
+    /// <summary>
+    /// The unique key for this agent instance.
+    /// </summary>
+    [JsonPropertyName("agentInstanceKey")]
+    public AgentInstanceKey AgentInstanceKey { get; set; }
+
+    /// <summary>
+    /// The current status of an agent instance.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public AgentInstanceStatusEnum Status { get; set; }
+
+    /// <summary>
+    /// The static definition of the agent, including model, provider, and system prompt.
+    /// </summary>
+    [JsonPropertyName("definition")]
+    public AgentInstanceDefinition Definition { get; set; } = null!;
+
+    /// <summary>
+    /// Aggregated metrics across all iterations of this agent instance.
+    /// </summary>
+    [JsonPropertyName("metrics")]
+    public AgentInstanceMetrics Metrics { get; set; } = null!;
+
+    /// <summary>
+    /// The configured limits for this agent instance, set once at creation.
+    /// </summary>
+    [JsonPropertyName("limits")]
+    public AgentInstanceLimits Limits { get; set; } = null!;
+
+    /// <summary>
+    /// The BPMN element ID of the ad-hoc sub-process or AI agent task that owns this agent instance.
+    /// </summary>
+    [JsonPropertyName("elementId")]
+    public ElementId ElementId { get; set; }
+
+    /// <summary>
+    /// The key of the process instance that owns this agent instance.
+    /// </summary>
+    [JsonPropertyName("processInstanceKey")]
+    public ProcessInstanceKey ProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The key of the process definition associated with this agent instance.
+    /// </summary>
+    [JsonPropertyName("processDefinitionKey")]
+    public ProcessDefinitionKey ProcessDefinitionKey { get; set; }
+
+    /// <summary>
+    /// The tenant ID of this agent instance.
+    /// </summary>
+    [JsonPropertyName("tenantId")]
+    public TenantId TenantId { get; set; }
+
+    /// <summary>
+    /// The date when this agent instance was created.
+    /// </summary>
+    [JsonPropertyName("creationDate")]
+    public DateTimeOffset CreationDate { get; set; }
+
+    /// <summary>
+    /// The date when this agent instance was last updated.
+    /// </summary>
+    [JsonPropertyName("lastUpdatedDate")]
+    public DateTimeOffset LastUpdatedDate { get; set; }
+
+    /// <summary>
+    /// The date when this agent instance completed. Null while the agent is still running.
+    /// </summary>
+    [JsonPropertyName("completionDate")]
+    public DateTimeOffset? CompletionDate { get; set; }
+
+}
+
+/// <summary>
+/// Agent instance search request.
+/// </summary>
+public sealed class AgentInstanceSearchQuery
+{
+    /// <summary>
+    /// Sort field criteria.
+    /// </summary>
+    [JsonPropertyName("sort")]
+    public List<AgentInstanceSearchQuerySortRequest>? Sort { get; set; }
+
+    /// <summary>
+    /// The agent instance search filters.
+    /// </summary>
+    [JsonPropertyName("filter")]
+    public AgentInstanceFilter? Filter { get; set; }
+
+    /// <summary>
+    /// Pagination criteria.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public SearchQueryPageRequest? Page { get; set; }
+
+}
+
+/// <summary>
+/// Agent instance search response.
+/// </summary>
+public sealed class AgentInstanceSearchQueryResult
+{
+    /// <summary>
+    /// The matching agent instances.
+    /// </summary>
+    [JsonPropertyName("items")]
+    public List<AgentInstanceResult> Items { get; set; } = null!;
+
+    /// <summary>
+    /// Pagination information about the search results.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public SearchQueryPageResponse Page { get; set; } = null!;
+
+}
+
+/// <summary>
+/// AgentInstanceSearchQuerySortRequest
+/// </summary>
+public sealed class AgentInstanceSearchQuerySortRequest
+{
+    /// <summary>
+    /// The field to sort by.
+    /// </summary>
+    [JsonPropertyName("field")]
+    public string Field { get; set; } = null!;
+
+    /// <summary>
+    /// The order in which to sort the related field.
+    /// </summary>
+    [JsonPropertyName("order")]
+    public SortOrderEnum? Order { get; set; }
+
+}
+
+/// <summary>
+/// The current status of an agent instance.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AgentInstanceStatusEnum
+{
+    [JsonPropertyName("COMPLETED")]
+    COMPLETED,
+    [JsonPropertyName("IDLE")]
+    IDLE,
+    [JsonPropertyName("INITIALIZING")]
+    INITIALIZING,
+    [JsonPropertyName("THINKING")]
+    THINKING,
+    [JsonPropertyName("TOOL_CALLING")]
+    TOOLCALLING,
+    [JsonPropertyName("TOOL_DISCOVERY")]
+    TOOLDISCOVERY,
+}
+
+/// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct AgentInstanceStatusExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private AgentInstanceStatusExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="AgentInstanceStatusExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static AgentInstanceStatusExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "AgentInstanceStatusExactMatch");
+        return new AgentInstanceStatusExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// AgentInstanceStatusEnum property with full advanced search capabilities.
+/// </summary>
+public sealed class AgentInstanceStatusFilterProperty
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public AgentInstanceStatusEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public AgentInstanceStatusEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<AgentInstanceStatusEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
 
 }
 
@@ -3424,10 +4123,13 @@ public sealed class BatchOperationItemResponse
     public string ItemKey { get; set; } = null!;
 
     /// <summary>
-    /// the process instance key of the processed item.
+    /// The process instance key of the processed item. Null for batch-op types whose targets
+    /// are not process instances (e.g. DELETE_DECISION_INSTANCE, DELETE_DECISION_DEFINITION,
+    /// DELETE_PROCESS_DEFINITION).
+    /// 
     /// </summary>
     [JsonPropertyName("processInstanceKey")]
-    public ProcessInstanceKey ProcessInstanceKey { get; set; }
+    public ProcessInstanceKey? ProcessInstanceKey { get; set; }
 
     /// <summary>
     /// The key of the root process instance. The root process instance is the top-level
@@ -4258,6 +4960,39 @@ public sealed class Changeset
 }
 
 /// <summary>
+/// The unique identifier of an OAuth client.
+/// Minted outside the Camunda REST API: in SaaS by Console, in Self-Managed
+/// with OIDC by the external identity provider (e.g. EntraID, Keycloak,
+/// Okta). In Self-Managed with Basic authentication, machine-to-machine
+/// applications are modelled as users instead — see the user identifier.
+/// 
+/// </summary>
+public readonly record struct ClientId : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private ClientId(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="ClientId"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static ClientId AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "ClientId", pattern: @"^[a-zA-Z0-9_~@.+-]+$", minLength: 1, maxLength: 256);
+        return new ClientId(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^[a-zA-Z0-9_~@.+-]+$", minLength: 1, maxLength: 256);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
 /// ClockPinRequest
 /// </summary>
 public sealed class ClockPinRequest
@@ -4268,6 +5003,34 @@ public sealed class ClockPinRequest
     [JsonPropertyName("timestamp")]
     public long Timestamp { get; set; }
 
+}
+
+/// <summary>
+/// The name of a cluster variable. Unique within its scope (global or tenant-specific).
+/// </summary>
+public readonly record struct ClusterVariableName : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private ClusterVariableName(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="ClusterVariableName"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static ClusterVariableName AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "ClusterVariableName", pattern: @"^[a-zA-Z0-9_~@.+-]+$", minLength: 1, maxLength: 256);
+        return new ClusterVariableName(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^[a-zA-Z0-9_~@.+-]+$", minLength: 1, maxLength: 256);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
 }
 
 /// <summary>
@@ -4285,7 +5048,7 @@ public sealed class ClusterVariableResult
     /// The name of the cluster variable. Unique within its scope (global or tenant-specific).
     /// </summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; } = null!;
+    public ClusterVariableName Name { get; set; }
 
     /// <summary>
     /// The scope of a cluster variable.
@@ -4310,7 +5073,7 @@ public sealed class ClusterVariableResultBase
     /// The name of the cluster variable. Unique within its scope (global or tenant-specific).
     /// </summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; } = null!;
+    public ClusterVariableName Name { get; set; }
 
     /// <summary>
     /// The scope of a cluster variable.
@@ -4533,7 +5296,7 @@ public sealed class ClusterVariableSearchResult
     /// The name of the cluster variable. Unique within its scope (global or tenant-specific).
     /// </summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; } = null!;
+    public ClusterVariableName Name { get; set; }
 
     /// <summary>
     /// The scope of a cluster variable.
@@ -4850,7 +5613,7 @@ public sealed class CreateClusterVariableRequest
     /// The name of the cluster variable. Must be unique within its scope (global or tenant-specific).
     /// </summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; } = null!;
+    public ClusterVariableName Name { get; set; }
 
     /// <summary>
     /// The value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses.
@@ -7169,6 +7932,85 @@ public readonly record struct ElementId : global::Camunda.Orchestration.Sdk.ICam
 }
 
 /// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct ElementIdExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private ElementIdExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="ElementIdExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static ElementIdExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "ElementIdExactMatch");
+        return new ElementIdExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// ElementId property with full advanced search capabilities.
+/// </summary>
+public sealed class ElementIdFilterProperty
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public ElementId? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public ElementId? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<ElementId>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches none of the provided values.
+    /// </summary>
+    [JsonPropertyName("$notIn")]
+    public List<ElementId>? NotIn { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
 /// Element instance filter.
 /// </summary>
 public sealed class ElementInstanceFilter
@@ -7195,14 +8037,14 @@ public sealed class ElementInstanceFilter
     /// The element ID for this element instance.
     /// </summary>
     [JsonPropertyName("elementId")]
-    public ElementId? ElementId { get; set; }
+    public ElementIdFilterProperty? ElementId { get; set; }
 
     /// <summary>
     /// The element name. This only works for data created with 8.8 and onwards. Instances from prior versions don&apos;t contain this data and cannot be found.
     /// 
     /// </summary>
     [JsonPropertyName("elementName")]
-    public string? ElementName { get; set; }
+    public StringFilterProperty? ElementName { get; set; }
 
     /// <summary>
     /// Shows whether this element instance has an incident related to.
@@ -8242,13 +9084,13 @@ public readonly record struct GlobalListenerId : global::Camunda.Orchestration.S
     /// </summary>
     public static GlobalListenerId AssumeExists(string value)
     {
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "GlobalListenerId");
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "GlobalListenerId", pattern: @"^[a-zA-Z0-9_~@.+\-]+$", minLength: 1, maxLength: 256);
         return new GlobalListenerId(value);
     }
 
     /// <summary>Returns true if the value satisfies this type's constraints.</summary>
     public static bool IsValid(string value) =>
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^[a-zA-Z0-9_~@.+\-]+$", minLength: 1, maxLength: 256);
 
     /// <inheritdoc />
     public override string ToString() => Value.ToString()!;
@@ -8639,7 +9481,7 @@ public sealed class GroupClientResult
     /// The ID of the client.
     /// </summary>
     [JsonPropertyName("clientId")]
-    public string ClientId { get; set; } = null!;
+    public ClientId ClientId { get; set; }
 
 }
 
@@ -8709,7 +9551,7 @@ public sealed class GroupCreateRequest
     /// The ID of the new group.
     /// </summary>
     [JsonPropertyName("groupId")]
-    public string GroupId { get; set; } = null!;
+    public GroupId GroupId { get; set; }
 
     /// <summary>
     /// The display name of the new group.
@@ -8734,7 +9576,7 @@ public sealed class GroupCreateResult
     /// The ID of the created group.
     /// </summary>
     [JsonPropertyName("groupId")]
-    public string GroupId { get; set; } = null!;
+    public GroupId GroupId { get; set; }
 
     /// <summary>
     /// The display name of the created group.
@@ -8767,6 +9609,34 @@ public sealed class GroupFilter
     [JsonPropertyName("name")]
     public string? Name { get; set; }
 
+}
+
+/// <summary>
+/// The unique identifier of a group.
+/// </summary>
+public readonly record struct GroupId : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private GroupId(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="GroupId"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static GroupId AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "GroupId", minLength: 1, maxLength: 256);
+        return new GroupId(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, minLength: 1, maxLength: 256);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
 }
 
 /// <summary>
@@ -8803,7 +9673,7 @@ public sealed class GroupResult
     /// The group ID.
     /// </summary>
     [JsonPropertyName("groupId")]
-    public string GroupId { get; set; } = null!;
+    public GroupId GroupId { get; set; }
 
     /// <summary>
     /// The group description.
@@ -8920,10 +9790,10 @@ public sealed class GroupUpdateRequest
 public sealed class GroupUpdateResult
 {
     /// <summary>
-    /// The unique external group ID.
+    /// The unique group ID.
     /// </summary>
     [JsonPropertyName("groupId")]
-    public string GroupId { get; set; } = null!;
+    public GroupId GroupId { get; set; }
 
     /// <summary>
     /// The name of the group.
@@ -10378,6 +11248,8 @@ public enum JobListenerEventTypeEnum
 {
     [JsonPropertyName("ASSIGNING")]
     ASSIGNING,
+    [JsonPropertyName("BEFORE_ALL")]
+    BEFOREALL,
     [JsonPropertyName("CANCELING")]
     CANCELING,
     [JsonPropertyName("COMPLETING")]
@@ -11427,7 +12299,7 @@ public sealed class MappingRuleCreateRequest
     /// The unique ID of the mapping rule.
     /// </summary>
     [JsonPropertyName("mappingRuleId")]
-    public string MappingRuleId { get; set; } = null!;
+    public MappingRuleId MappingRuleId { get; set; }
 
     /// <summary>
     /// The name of the claim to map.
@@ -11476,7 +12348,7 @@ public sealed class MappingRuleCreateResult
     /// The unique ID of the mapping rule.
     /// </summary>
     [JsonPropertyName("mappingRuleId")]
-    public string MappingRuleId { get; set; } = null!;
+    public MappingRuleId MappingRuleId { get; set; }
 
 }
 
@@ -11532,7 +12404,7 @@ public sealed class MappingRuleCreateUpdateResult
     /// The unique ID of the mapping rule.
     /// </summary>
     [JsonPropertyName("mappingRuleId")]
-    public string MappingRuleId { get; set; } = null!;
+    public MappingRuleId MappingRuleId { get; set; }
 
 }
 
@@ -11563,8 +12435,36 @@ public sealed class MappingRuleFilter
     /// The ID of the mapping rule.
     /// </summary>
     [JsonPropertyName("mappingRuleId")]
-    public string? MappingRuleId { get; set; }
+    public MappingRuleId? MappingRuleId { get; set; }
 
+}
+
+/// <summary>
+/// The unique identifier of a mapping rule.
+/// </summary>
+public readonly record struct MappingRuleId : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private MappingRuleId(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="MappingRuleId"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static MappingRuleId AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "MappingRuleId", pattern: @"^[a-zA-Z0-9_~@.+-]+$", minLength: 1, maxLength: 256);
+        return new MappingRuleId(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^[a-zA-Z0-9_~@.+-]+$", minLength: 1, maxLength: 256);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
 }
 
 /// <summary>
@@ -11594,7 +12494,7 @@ public sealed class MappingRuleResult
     /// The ID of the mapping rule.
     /// </summary>
     [JsonPropertyName("mappingRuleId")]
-    public string MappingRuleId { get; set; } = null!;
+    public MappingRuleId MappingRuleId { get; set; }
 
 }
 
@@ -11713,7 +12613,7 @@ public sealed class MappingRuleUpdateResult
     /// The unique ID of the mapping rule.
     /// </summary>
     [JsonPropertyName("mappingRuleId")]
-    public string MappingRuleId { get; set; } = null!;
+    public MappingRuleId MappingRuleId { get; set; }
 
 }
 
@@ -11970,6 +12870,39 @@ public sealed class MessageSubscriptionFilter
     [JsonPropertyName("tenantId")]
     public StringFilterProperty? TenantId { get; set; }
 
+    /// <summary>
+    /// The type of message subscription to filter by. When omitted, both
+    /// `START_EVENT` and `PROCESS_EVENT` are returned. Only available for data
+    /// created with Camunda 8.10 or later.
+    /// 
+    /// </summary>
+    [JsonPropertyName("messageSubscriptionType")]
+    public MessageSubscriptionTypeFilterProperty? MessageSubscriptionType { get; set; }
+
+    /// <summary>
+    /// The name of the process definition associated with this message subscription.
+    /// </summary>
+    [JsonPropertyName("processDefinitionName")]
+    public StringFilterProperty? ProcessDefinitionName { get; set; }
+
+    /// <summary>
+    /// The version of the process definition associated with this message subscription.
+    /// </summary>
+    [JsonPropertyName("processDefinitionVersion")]
+    public IntegerFilterProperty? ProcessDefinitionVersion { get; set; }
+
+    /// <summary>
+    /// Filter by tool name extracted from the `io.camunda.tool:name` zeebe:property.
+    /// </summary>
+    [JsonPropertyName("toolName")]
+    public StringFilterProperty? ToolName { get; set; }
+
+    /// <summary>
+    /// Filter by inbound connector type extracted from the `inbound.type` zeebe:property.
+    /// </summary>
+    [JsonPropertyName("inboundConnectorType")]
+    public StringFilterProperty? InboundConnectorType { get; set; }
+
 }
 
 /// <summary>
@@ -12090,6 +13023,8 @@ public sealed class MessageSubscriptionResult
 
     /// <summary>
     /// The process instance key associated with this message subscription.
+    /// Only populated for intermediate event entities.
+    /// 
     /// </summary>
     [JsonPropertyName("processInstanceKey")]
     public ProcessInstanceKey? ProcessInstanceKey { get; set; }
@@ -12111,6 +13046,8 @@ public sealed class MessageSubscriptionResult
 
     /// <summary>
     /// The element instance key associated with this message subscription.
+    /// Only populated for intermediate event entities.
+    /// 
     /// </summary>
     [JsonPropertyName("elementInstanceKey")]
     public ElementInstanceKey? ElementInstanceKey { get; set; }
@@ -12138,6 +13075,53 @@ public sealed class MessageSubscriptionResult
     /// </summary>
     [JsonPropertyName("correlationKey")]
     public string? CorrelationKey { get; set; }
+
+    /// <summary>
+    /// The type of message subscription.
+    /// `START_EVENT` is definition-scoped (process start events). Always has a value; only
+    /// captured from Camunda 8.10 onwards.
+    /// `PROCESS_EVENT` is instance-scoped (intermediate catch events). Pre-8.10 entries have
+    /// no value stored; the API returns `PROCESS_EVENT` as a default for those entries.
+    /// 
+    /// </summary>
+    [JsonPropertyName("messageSubscriptionType")]
+    public MessageSubscriptionTypeEnum MessageSubscriptionType { get; set; }
+
+    /// <summary>
+    /// The `zeebe:properties` extension properties extracted from the BPMN element associated
+    /// with this subscription. Empty object when no properties are defined.
+    /// 
+    /// </summary>
+    [JsonPropertyName("extensionProperties")]
+    public Dictionary<string, string> ExtensionProperties { get; set; } = null!;
+
+    /// <summary>
+    /// The name of the process definition associated with this message subscription.
+    /// </summary>
+    [JsonPropertyName("processDefinitionName")]
+    public string? ProcessDefinitionName { get; set; }
+
+    /// <summary>
+    /// The version of the process definition associated with this message subscription.
+    /// </summary>
+    [JsonPropertyName("processDefinitionVersion")]
+    public int? ProcessDefinitionVersion { get; set; }
+
+    /// <summary>
+    /// Tool name extracted from the `io.camunda.tool:name` zeebe:property.
+    /// Null when the property is absent.
+    /// 
+    /// </summary>
+    [JsonPropertyName("toolName")]
+    public string? ToolName { get; set; }
+
+    /// <summary>
+    /// Inbound connector type extracted from the `inbound.type` zeebe:property.
+    /// Null when the property is absent.
+    /// 
+    /// </summary>
+    [JsonPropertyName("inboundConnectorType")]
+    public string? InboundConnectorType { get; set; }
 
     /// <summary>
     /// The unique identifier of the tenant.
@@ -12282,6 +13266,96 @@ public sealed class MessageSubscriptionStateFilterProperty
     /// </summary>
     [JsonPropertyName("$in")]
     public List<MessageSubscriptionStateEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
+/// The type of message subscription.
+/// `START_EVENT` is definition-scoped (process start events). Always has a value; only
+/// captured from Camunda 8.10 onwards.
+/// `PROCESS_EVENT` is instance-scoped (intermediate catch events). Pre-8.10 entries have
+/// no value stored; the API returns `PROCESS_EVENT` as a default for those entries.
+/// 
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MessageSubscriptionTypeEnum
+{
+    [JsonPropertyName("START_EVENT")]
+    STARTEVENT,
+    [JsonPropertyName("PROCESS_EVENT")]
+    PROCESSEVENT,
+}
+
+/// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct MessageSubscriptionTypeExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private MessageSubscriptionTypeExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="MessageSubscriptionTypeExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static MessageSubscriptionTypeExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "MessageSubscriptionTypeExactMatch");
+        return new MessageSubscriptionTypeExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// MessageSubscriptionTypeEnum with full advanced search capabilities.
+/// </summary>
+public sealed class MessageSubscriptionTypeFilterProperty
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public MessageSubscriptionTypeEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public MessageSubscriptionTypeEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<MessageSubscriptionTypeEnum>? In { get; set; }
 
     /// <summary>
     /// Checks if the property matches the provided like value.
@@ -12749,6 +13823,85 @@ public readonly record struct ProcessDefinitionId : global::Camunda.Orchestratio
 
     /// <inheritdoc />
     public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct ProcessDefinitionIdExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private ProcessDefinitionIdExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="ProcessDefinitionIdExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static ProcessDefinitionIdExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "ProcessDefinitionIdExactMatch", pattern: @"^[\p{L}_][\p{L}\p{N}_\-\.]*$", minLength: 1);
+        return new ProcessDefinitionIdExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^[\p{L}_][\p{L}\p{N}_\-\.]*$", minLength: 1);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// ProcessDefinitionId property with full advanced search capabilities.
+/// </summary>
+public sealed class ProcessDefinitionIdFilterProperty
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public ProcessDefinitionId? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public ProcessDefinitionId? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<ProcessDefinitionId>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches none of the provided values.
+    /// </summary>
+    [JsonPropertyName("$notIn")]
+    public List<ProcessDefinitionId>? NotIn { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
 }
 
 /// <summary>
@@ -14787,6 +15940,55 @@ public sealed class ProcessInstanceStateFilterProperty
 }
 
 /// <summary>
+/// Resource search filter.
+/// </summary>
+public sealed class ResourceFilter
+{
+    /// <summary>
+    /// The key for this resource.
+    /// </summary>
+    [JsonPropertyName("resourceKey")]
+    public ResourceKeyFilterProperty? ResourceKey { get; set; }
+
+    /// <summary>
+    /// Resource name of this resource.
+    /// </summary>
+    [JsonPropertyName("resourceName")]
+    public StringFilterProperty? ResourceName { get; set; }
+
+    /// <summary>
+    /// Resource ID of this resource.
+    /// </summary>
+    [JsonPropertyName("resourceId")]
+    public StringFilterProperty? ResourceId { get; set; }
+
+    /// <summary>
+    /// Version of this resource.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public IntegerFilterProperty? Version { get; set; }
+
+    /// <summary>
+    /// Version tag of this resource.
+    /// </summary>
+    [JsonPropertyName("versionTag")]
+    public StringFilterProperty? VersionTag { get; set; }
+
+    /// <summary>
+    /// Deployment key of this resource.
+    /// </summary>
+    [JsonPropertyName("deploymentKey")]
+    public DeploymentKeyFilterProperty? DeploymentKey { get; set; }
+
+    /// <summary>
+    /// Tenant ID of this resource.
+    /// </summary>
+    [JsonPropertyName("tenantId")]
+    public TenantId? TenantId { get; set; }
+
+}
+
+/// <summary>
 /// The system-assigned key for this resource.
 /// </summary>
 public readonly record struct ResourceKey : global::Camunda.Orchestration.Sdk.ICamundaKey
@@ -14955,6 +16157,69 @@ public sealed class ResourceResult
 }
 
 /// <summary>
+/// ResourceSearchQuery
+/// </summary>
+public sealed class ResourceSearchQuery
+{
+    /// <summary>
+    /// Sort field criteria.
+    /// </summary>
+    [JsonPropertyName("sort")]
+    public List<ResourceSearchQuerySortRequest>? Sort { get; set; }
+
+    /// <summary>
+    /// The resource search filters.
+    /// </summary>
+    [JsonPropertyName("filter")]
+    public ResourceFilter? Filter { get; set; }
+
+    /// <summary>
+    /// Pagination criteria.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public SearchQueryPageRequest? Page { get; set; }
+
+}
+
+/// <summary>
+/// ResourceSearchQueryResult
+/// </summary>
+public sealed class ResourceSearchQueryResult
+{
+    /// <summary>
+    /// The matching resources.
+    /// </summary>
+    [JsonPropertyName("items")]
+    public List<ResourceResult> Items { get; set; } = null!;
+
+    /// <summary>
+    /// Pagination information about the search results.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public SearchQueryPageResponse Page { get; set; } = null!;
+
+}
+
+/// <summary>
+/// ResourceSearchQuerySortRequest
+/// </summary>
+public sealed class ResourceSearchQuerySortRequest
+{
+    /// <summary>
+    /// The field to sort by.
+    /// </summary>
+    [JsonPropertyName("field")]
+    public string Field { get; set; } = null!;
+
+    /// <summary>
+    /// The order in which to sort the related field.
+    /// </summary>
+    [JsonPropertyName("order")]
+    public SortOrderEnum? Order { get; set; }
+
+}
+
+/// <summary>
 /// The type of resource to add/remove permissions to/from.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -15011,7 +16276,7 @@ public sealed class RoleClientResult
     /// The ID of the client.
     /// </summary>
     [JsonPropertyName("clientId")]
-    public string ClientId { get; set; } = null!;
+    public ClientId ClientId { get; set; }
 
 }
 
@@ -15081,7 +16346,7 @@ public sealed class RoleCreateRequest
     /// The ID of the new role.
     /// </summary>
     [JsonPropertyName("roleId")]
-    public string RoleId { get; set; } = null!;
+    public RoleId RoleId { get; set; }
 
     /// <summary>
     /// The display name of the new role.
@@ -15106,7 +16371,7 @@ public sealed class RoleCreateResult
     /// The ID of the created role.
     /// </summary>
     [JsonPropertyName("roleId")]
-    public string RoleId { get; set; } = null!;
+    public RoleId RoleId { get; set; }
 
     /// <summary>
     /// The display name of the created role.
@@ -15131,7 +16396,7 @@ public sealed class RoleFilter
     /// The role ID search filters.
     /// </summary>
     [JsonPropertyName("roleId")]
-    public string? RoleId { get; set; }
+    public RoleId? RoleId { get; set; }
 
     /// <summary>
     /// The role name search filters.
@@ -15150,7 +16415,7 @@ public sealed class RoleGroupResult
     /// The id of the group.
     /// </summary>
     [JsonPropertyName("groupId")]
-    public string GroupId { get; set; } = null!;
+    public GroupId GroupId { get; set; }
 
 }
 
@@ -15212,6 +16477,34 @@ public sealed class RoleGroupSearchResult
 }
 
 /// <summary>
+/// The unique identifier of a role.
+/// </summary>
+public readonly record struct RoleId : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private RoleId(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="RoleId"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static RoleId AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "RoleId", pattern: @"^[a-zA-Z0-9_~@.+-]+$", minLength: 1, maxLength: 256);
+        return new RoleId(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^[a-zA-Z0-9_~@.+-]+$", minLength: 1, maxLength: 256);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
 /// RoleMappingRuleSearchResult
 /// </summary>
 public sealed class RoleMappingRuleSearchResult
@@ -15245,7 +16538,7 @@ public sealed class RoleResult
     /// The role id.
     /// </summary>
     [JsonPropertyName("roleId")]
-    public string RoleId { get; set; } = null!;
+    public RoleId RoleId { get; set; }
 
     /// <summary>
     /// The description of the role.
@@ -15358,7 +16651,7 @@ public sealed class RoleUpdateResult
     /// The ID of the updated role.
     /// </summary>
     [JsonPropertyName("roleId")]
-    public string RoleId { get; set; } = null!;
+    public RoleId RoleId { get; set; }
 
 }
 
@@ -15953,7 +17246,7 @@ public sealed class TenantClientResult
     /// The ID of the client.
     /// </summary>
     [JsonPropertyName("clientId")]
-    public string ClientId { get; set; } = null!;
+    public ClientId ClientId { get; set; }
 
 }
 
@@ -16020,10 +17313,13 @@ public sealed class TenantClientSearchResult
 public sealed class TenantCreateRequest
 {
     /// <summary>
-    /// The unique ID for the tenant. Must be 255 characters or less. Can contain letters, numbers, [`_`, `-`, `+`, `.`, `@`].
+    /// The unique ID for the tenant. Must be 31 characters or less and match
+    /// `^[\w.-]{1,31}$` (word characters, `.`, `-`). The literal
+    /// `&lt;default&gt;` is also accepted as the default-tenant alias.
+    /// 
     /// </summary>
     [JsonPropertyName("tenantId")]
-    public string TenantId { get; set; } = null!;
+    public TenantId TenantId { get; set; }
 
     /// <summary>
     /// The name of the tenant.
@@ -16045,7 +17341,7 @@ public sealed class TenantCreateRequest
 public sealed class TenantCreateResult
 {
     /// <summary>
-    /// The unique identifier of the tenant.
+    /// The unique identifier of the created tenant.
     /// </summary>
     [JsonPropertyName("tenantId")]
     public TenantId TenantId { get; set; }
@@ -16102,10 +17398,10 @@ public enum TenantFilterEnum
 public sealed class TenantGroupResult
 {
     /// <summary>
-    /// The groupId of the group.
+    /// The group ID.
     /// </summary>
     [JsonPropertyName("groupId")]
-    public string GroupId { get; set; } = null!;
+    public GroupId GroupId { get; set; }
 
 }
 
@@ -16182,13 +17478,13 @@ public readonly record struct TenantId : global::Camunda.Orchestration.Sdk.ICamu
     /// </summary>
     public static TenantId AssumeExists(string value)
     {
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "TenantId", pattern: @"^(<default>|[A-Za-z0-9_@.+-]+)$", minLength: 1, maxLength: 256);
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "TenantId", pattern: @"^(<default>|[\w\.\-]{1,31})$", minLength: 1, maxLength: 31);
         return new TenantId(value);
     }
 
     /// <summary>Returns true if the value satisfies this type's constraints.</summary>
     public static bool IsValid(string value) =>
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^(<default>|[A-Za-z0-9_@.+-]+)$", minLength: 1, maxLength: 256);
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^(<default>|[\w\.\-]{1,31})$", minLength: 1, maxLength: 31);
 
     /// <inheritdoc />
     public override string ToString() => Value.ToString()!;
@@ -16345,7 +17641,7 @@ public sealed class TenantUpdateRequest
 public sealed class TenantUpdateResult
 {
     /// <summary>
-    /// The unique identifier of the tenant.
+    /// The unique identifier of the updated tenant.
     /// </summary>
     [JsonPropertyName("tenantId")]
     public TenantId TenantId { get; set; }
@@ -16601,7 +17897,7 @@ public sealed class UsageMetricsResponseItem
 public sealed class UserCreateResult
 {
     /// <summary>
-    /// The unique name of a user.
+    /// The username of the created user.
     /// </summary>
     [JsonPropertyName("username")]
     public Username Username { get; set; }
@@ -16661,13 +17957,13 @@ public readonly record struct Username : global::Camunda.Orchestration.Sdk.ICamu
     /// </summary>
     public static Username AssumeExists(string value)
     {
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "Username", pattern: @"^(<default>|[A-Za-z0-9_@.+-]+)$", minLength: 1, maxLength: 256);
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "Username", pattern: @"^[a-zA-Z0-9_~@.+-]+$", minLength: 1, maxLength: 256);
         return new Username(value);
     }
 
     /// <summary>Returns true if the value satisfies this type's constraints.</summary>
     public static bool IsValid(string value) =>
-        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^(<default>|[A-Za-z0-9_@.+-]+)$", minLength: 1, maxLength: 256);
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: @"^[a-zA-Z0-9_~@.+-]+$", minLength: 1, maxLength: 256);
 
     /// <inheritdoc />
     public override string ToString() => Value.ToString()!;
@@ -16685,10 +17981,10 @@ public sealed class UserRequest
     public string Password { get; set; } = null!;
 
     /// <summary>
-    /// The username of the user.
+    /// The username of the new user.
     /// </summary>
     [JsonPropertyName("username")]
-    public string Username { get; set; } = null!;
+    public Username Username { get; set; }
 
     /// <summary>
     /// The name of the user.
@@ -16710,7 +18006,7 @@ public sealed class UserRequest
 public sealed class UserResult
 {
     /// <summary>
-    /// The unique name of a user.
+    /// The username of the user.
     /// </summary>
     [JsonPropertyName("username")]
     public Username Username { get; set; }
@@ -16985,7 +18281,7 @@ public sealed class UserTaskFilter
     /// The ID of the process definition.
     /// </summary>
     [JsonPropertyName("processDefinitionId")]
-    public ProcessDefinitionId? ProcessDefinitionId { get; set; }
+    public ProcessDefinitionIdFilterProperty? ProcessDefinitionId { get; set; }
 
     /// <summary>
     /// The user task creation date.
@@ -17033,13 +18329,13 @@ public sealed class UserTaskFilter
     /// The key of the process definition.
     /// </summary>
     [JsonPropertyName("processDefinitionKey")]
-    public ProcessDefinitionKey? ProcessDefinitionKey { get; set; }
+    public ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; }
 
     /// <summary>
     /// The key of the process instance.
     /// </summary>
     [JsonPropertyName("processInstanceKey")]
-    public ProcessInstanceKey? ProcessInstanceKey { get; set; }
+    public ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; }
 
     /// <summary>
     /// The key of the element instance.
@@ -17596,7 +18892,7 @@ public sealed class UserUpdateRequest
 public sealed class UserUpdateResult
 {
     /// <summary>
-    /// The unique name of a user.
+    /// The username of the updated user.
     /// </summary>
     [JsonPropertyName("username")]
     public Username Username { get; set; }
@@ -18025,555 +19321,6 @@ public sealed class VariableValueFilterProperty
     /// </summary>
     [JsonPropertyName("value")]
     public StringFilterProperty Value { get; set; } = null!;
-
-}
-
-/// <summary>
-/// CreateMappingRuleResponse
-/// </summary>
-public sealed class CreateMappingRuleResponse
-{
-    /// <summary>
-    /// The name of the claim to map.
-    /// </summary>
-    [JsonPropertyName("claimName")]
-    public string ClaimName { get; set; } = null!;
-
-    /// <summary>
-    /// The value of the claim to map.
-    /// </summary>
-    [JsonPropertyName("claimValue")]
-    public string ClaimValue { get; set; } = null!;
-
-    /// <summary>
-    /// The name of the mapping rule.
-    /// </summary>
-    [JsonPropertyName("name")]
-    public string Name { get; set; } = null!;
-
-    /// <summary>
-    /// The unique ID of the mapping rule.
-    /// </summary>
-    [JsonPropertyName("mappingRuleId")]
-    public string MappingRuleId { get; set; } = null!;
-
-}
-
-/// <summary>
-/// GetUserResponse
-/// </summary>
-public sealed class GetUserResponse
-{
-    /// <summary>
-    /// The unique name of a user.
-    /// </summary>
-    [JsonPropertyName("username")]
-    public Username Username { get; set; }
-
-    /// <summary>
-    /// The name of the user.
-    /// </summary>
-    [JsonPropertyName("name")]
-    public string? Name { get; set; }
-
-    /// <summary>
-    /// The email of the user.
-    /// </summary>
-    [JsonPropertyName("email")]
-    public string? Email { get; set; }
-
-}
-
-/// <summary>
-/// SearchClientsForGroupRequest
-/// </summary>
-public sealed class SearchClientsForGroupRequest
-{
-    /// <summary>
-    /// Sort field criteria.
-    /// </summary>
-    [JsonPropertyName("sort")]
-    public List<AuditLogSearchQuerySortRequest>? Sort { get; set; }
-
-    /// <summary>
-    /// Pagination criteria.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageRequest? Page { get; set; }
-
-}
-
-/// <summary>
-/// SearchClientsForGroupResponse
-/// </summary>
-public sealed class SearchClientsForGroupResponse
-{
-    /// <summary>
-    /// The matching client IDs.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<GroupClientResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchClientsForRoleRequest
-/// </summary>
-public sealed class SearchClientsForRoleRequest
-{
-    /// <summary>
-    /// Sort field criteria.
-    /// </summary>
-    [JsonPropertyName("sort")]
-    public List<AuditLogSearchQuerySortRequest>? Sort { get; set; }
-
-    /// <summary>
-    /// Pagination criteria.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageRequest? Page { get; set; }
-
-}
-
-/// <summary>
-/// SearchClientsForRoleResponse
-/// </summary>
-public sealed class SearchClientsForRoleResponse
-{
-    /// <summary>
-    /// The matching clients.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<GroupClientResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchClientsForTenantRequest
-/// </summary>
-public sealed class SearchClientsForTenantRequest
-{
-    /// <summary>
-    /// Sort field criteria.
-    /// </summary>
-    [JsonPropertyName("sort")]
-    public List<AuditLogSearchQuerySortRequest>? Sort { get; set; }
-
-    /// <summary>
-    /// Pagination criteria.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageRequest? Page { get; set; }
-
-}
-
-/// <summary>
-/// SearchClientsForTenantResponse
-/// </summary>
-public sealed class SearchClientsForTenantResponse
-{
-    /// <summary>
-    /// The matching clients.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<GroupClientResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchMappingRuleResponse
-/// </summary>
-public sealed class SearchMappingRuleResponse
-{
-    /// <summary>
-    /// The matching mapping rules.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<MappingRuleResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchMappingRulesForGroupResponse
-/// </summary>
-public sealed class SearchMappingRulesForGroupResponse
-{
-    /// <summary>
-    /// The matching mapping rules.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<MappingRuleResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchMappingRulesForRoleResponse
-/// </summary>
-public sealed class SearchMappingRulesForRoleResponse
-{
-    /// <summary>
-    /// The matching mapping rules.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<MappingRuleResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchMappingRulesForTenantResponse
-/// </summary>
-public sealed class SearchMappingRulesForTenantResponse
-{
-    /// <summary>
-    /// The matching mapping rules.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<MappingRuleResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchRolesForGroupResponse
-/// </summary>
-public sealed class SearchRolesForGroupResponse
-{
-    /// <summary>
-    /// The matching roles.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<RoleResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchRolesForTenantResponse
-/// </summary>
-public sealed class SearchRolesForTenantResponse
-{
-    /// <summary>
-    /// The matching roles.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<RoleResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchUsersForGroupRequest
-/// </summary>
-public sealed class SearchUsersForGroupRequest
-{
-    /// <summary>
-    /// Sort field criteria.
-    /// </summary>
-    [JsonPropertyName("sort")]
-    public List<AuditLogSearchQuerySortRequest>? Sort { get; set; }
-
-    /// <summary>
-    /// Pagination criteria.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageRequest? Page { get; set; }
-
-}
-
-/// <summary>
-/// SearchUsersForGroupResponse
-/// </summary>
-public sealed class SearchUsersForGroupResponse
-{
-    /// <summary>
-    /// The matching members.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<GroupUserResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchUsersForRoleRequest
-/// </summary>
-public sealed class SearchUsersForRoleRequest
-{
-    /// <summary>
-    /// Sort field criteria.
-    /// </summary>
-    [JsonPropertyName("sort")]
-    public List<AuditLogSearchQuerySortRequest>? Sort { get; set; }
-
-    /// <summary>
-    /// Pagination criteria.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageRequest? Page { get; set; }
-
-}
-
-/// <summary>
-/// SearchUsersForRoleResponse
-/// </summary>
-public sealed class SearchUsersForRoleResponse
-{
-    /// <summary>
-    /// The matching users.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<GroupUserResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchUsersForTenantRequest
-/// </summary>
-public sealed class SearchUsersForTenantRequest
-{
-    /// <summary>
-    /// Sort field criteria.
-    /// </summary>
-    [JsonPropertyName("sort")]
-    public List<AuditLogSearchQuerySortRequest>? Sort { get; set; }
-
-    /// <summary>
-    /// Pagination criteria.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageRequest? Page { get; set; }
-
-}
-
-/// <summary>
-/// SearchUsersForTenantResponse
-/// </summary>
-public sealed class SearchUsersForTenantResponse
-{
-    /// <summary>
-    /// The matching users.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<GroupUserResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// SearchUsersResponse
-/// </summary>
-public sealed class SearchUsersResponse
-{
-    /// <summary>
-    /// The matching users.
-    /// </summary>
-    [JsonPropertyName("items")]
-    public List<UserCreateResult> Items { get; set; } = null!;
-
-    /// <summary>
-    /// Pagination information about the search results.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageResponse Page { get; set; } = null!;
-
-}
-
-/// <summary>
-/// User task effective variable search query request. Uses offset-based pagination only.
-/// 
-/// </summary>
-public sealed class SearchUserTaskEffectiveVariablesRequest
-{
-    /// <summary>
-    /// Pagination parameters.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public OffsetPagination? Page { get; set; }
-
-    /// <summary>
-    /// Sort field criteria.
-    /// </summary>
-    [JsonPropertyName("sort")]
-    public List<AuditLogSearchQuerySortRequest>? Sort { get; set; }
-
-    /// <summary>
-    /// The user task variable search filters.
-    /// </summary>
-    [JsonPropertyName("filter")]
-    public UserTaskVariableFilter? Filter { get; set; }
-
-}
-
-/// <summary>
-/// User task search query request.
-/// </summary>
-public sealed class SearchUserTaskVariablesRequest
-{
-    /// <summary>
-    /// Sort field criteria.
-    /// </summary>
-    [JsonPropertyName("sort")]
-    public List<AuditLogSearchQuerySortRequest>? Sort { get; set; }
-
-    /// <summary>
-    /// The user task variable search filters.
-    /// </summary>
-    [JsonPropertyName("filter")]
-    public UserTaskVariableFilter? Filter { get; set; }
-
-    /// <summary>
-    /// Pagination criteria.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageRequest? Page { get; set; }
-
-}
-
-/// <summary>
-/// Variable search query request.
-/// </summary>
-public sealed class SearchVariablesRequest
-{
-    /// <summary>
-    /// Sort field criteria.
-    /// </summary>
-    [JsonPropertyName("sort")]
-    public List<AuditLogSearchQuerySortRequest>? Sort { get; set; }
-
-    /// <summary>
-    /// The variable search filters.
-    /// </summary>
-    [JsonPropertyName("filter")]
-    public VariableFilter? Filter { get; set; }
-
-    /// <summary>
-    /// Pagination criteria.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public SearchQueryPageRequest? Page { get; set; }
-
-}
-
-/// <summary>
-/// UpdateMappingRuleResponse
-/// </summary>
-public sealed class UpdateMappingRuleResponse
-{
-    /// <summary>
-    /// The name of the claim to map.
-    /// </summary>
-    [JsonPropertyName("claimName")]
-    public string ClaimName { get; set; } = null!;
-
-    /// <summary>
-    /// The value of the claim to map.
-    /// </summary>
-    [JsonPropertyName("claimValue")]
-    public string ClaimValue { get; set; } = null!;
-
-    /// <summary>
-    /// The name of the mapping rule.
-    /// </summary>
-    [JsonPropertyName("name")]
-    public string Name { get; set; } = null!;
-
-    /// <summary>
-    /// The unique ID of the mapping rule.
-    /// </summary>
-    [JsonPropertyName("mappingRuleId")]
-    public string MappingRuleId { get; set; } = null!;
-
-}
-
-/// <summary>
-/// UpdateUserResponse
-/// </summary>
-public sealed class UpdateUserResponse
-{
-    /// <summary>
-    /// The unique name of a user.
-    /// </summary>
-    [JsonPropertyName("username")]
-    public Username Username { get; set; }
-
-    /// <summary>
-    /// The name of the user.
-    /// </summary>
-    [JsonPropertyName("name")]
-    public string? Name { get; set; }
-
-    /// <summary>
-    /// The email of the user.
-    /// </summary>
-    [JsonPropertyName("email")]
-    public string? Email { get; set; }
 
 }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:fe524536c89d236f85a390f5877becc6d497fe83c039dcb2f58f8805269bcd44";
+    public const string SpecHash = "sha256:4a17a26d4a0129c6bbcf4e9e207902cefc08f33f1a040d01ab9a3cb18781e9ff";
 }

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:de88b7688514b7feee8ed5a59c68f2858a9bf488fe3dbd1a27757291039bfcd1";
+    public const string SpecHash = "sha256:fe524536c89d236f85a390f5877becc6d497fe83c039dcb2f58f8805269bcd44";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -180,15 +180,6 @@ TYPE Camunda.Orchestration.Sdk.AdvancedDeploymentKeyFilter : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.DeploymentKey>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.DeploymentKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
-TYPE Camunda.Orchestration.Sdk.AdvancedElementIdFilter : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.ElementId? Eq { get; set; } [JsonPropertyName("$eq")]
-  PROP Camunda.Orchestration.Sdk.ElementId? Neq { get; set; } [JsonPropertyName("$neq")]
-  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
-  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementId>? In { get; set; } [JsonPropertyName("$in")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementId>? NotIn { get; set; } [JsonPropertyName("$notIn")]
-
 TYPE Camunda.Orchestration.Sdk.AdvancedElementInstanceKeyFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey? Eq { get; set; } [JsonPropertyName("$eq")]
@@ -314,14 +305,6 @@ TYPE Camunda.Orchestration.Sdk.AdvancedMessageSubscriptionStateFilter : sealed c
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum>? In { get; set; } [JsonPropertyName("$in")]
 
-TYPE Camunda.Orchestration.Sdk.AdvancedMessageSubscriptionTypeFilter : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
-  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
-  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
-  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
-
 TYPE Camunda.Orchestration.Sdk.AdvancedOperationTypeFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuditLogOperationTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
@@ -329,15 +312,6 @@ TYPE Camunda.Orchestration.Sdk.AdvancedOperationTypeFilter : sealed class
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogOperationTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
-
-TYPE Camunda.Orchestration.Sdk.AdvancedProcessDefinitionIdFilter : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
-  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? Eq { get; set; } [JsonPropertyName("$eq")]
-  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? Neq { get; set; } [JsonPropertyName("$neq")]
-  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionId>? In { get; set; } [JsonPropertyName("$in")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionId>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
 TYPE Camunda.Orchestration.Sdk.AdvancedProcessDefinitionKeyFilter : sealed class
   CTOR ()
@@ -816,7 +790,7 @@ TYPE Camunda.Orchestration.Sdk.BatchOperationItemResponse : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.BatchOperationKey BatchOperationKey { get; set; } [JsonPropertyName("batchOperationKey")]
   PROP Camunda.Orchestration.Sdk.BatchOperationTypeEnum OperationType { get; set; } [JsonPropertyName("operationType")]
-  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? RootProcessInstanceKey { get; set; } [JsonPropertyName("rootProcessInstanceKey")]
   PROP System.DateTimeOffset? ProcessedDate { get; set; } [JsonPropertyName("processedDate")]
   PROP System.String ItemKey { get; set; } [JsonPropertyName("itemKey")]
@@ -1151,8 +1125,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessInstanceResult> GetProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessInstanceResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessInstanceSearchQueryResult> SearchProcessInstancesAsync(Camunda.Orchestration.Sdk.ProcessInstanceSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessInstanceSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessInstanceSequenceFlowsQueryResult> GetProcessInstanceSequenceFlowsAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessInstanceSequenceFlowsQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ResourceResult> GetResourceAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ResourceResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ResourceSearchQueryResult> SearchResourcesAsync(Camunda.Orchestration.Sdk.ResourceSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ResourceSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ResourceResult> GetResourceAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleCreateResult> CreateRoleAsync(Camunda.Orchestration.Sdk.RoleCreateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleGroupSearchResult> SearchGroupsForRoleAsync(System.String roleId, Camunda.Orchestration.Sdk.RoleGroupSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleGroupSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleResult> GetRoleAsync(System.String roleId, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1195,7 +1168,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<System.Object> GetDocumentAsync(Camunda.Orchestration.Sdk.DocumentId documentId, System.String? storeId = null, System.String? contentHash = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetProcessDefinitionXmlAsync(Camunda.Orchestration.Sdk.ProcessDefinitionKey processDefinitionKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetProcessInstanceCallHierarchyAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<System.Object> GetResourceContentAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<System.Object> GetResourceContentAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.ValueTask DisposeAsync()
   METHOD System.Void Dispose()
   METHOD static Camunda.Orchestration.Sdk.CamundaClient Create(Camunda.Orchestration.Sdk.CamundaOptions? options = null)
@@ -2008,39 +1981,21 @@ TYPE Camunda.Orchestration.Sdk.ElementId : struct interfaces=[Camunda.Orchestrat
   METHOD virtual System.Int32 GetHashCode()
   METHOD virtual System.String ToString()
 
-TYPE Camunda.Orchestration.Sdk.ElementIdExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ElementIdExactMatch>]
-  PROP System.String Value { get; }
-  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.ElementIdExactMatch other)
-  METHOD static Camunda.Orchestration.Sdk.ElementIdExactMatch AssumeExists(System.String value)
-  METHOD static System.Boolean IsValid(System.String value)
-  METHOD virtual System.Boolean Equals(System.Object obj)
-  METHOD virtual System.Int32 GetHashCode()
-  METHOD virtual System.String ToString()
-
-TYPE Camunda.Orchestration.Sdk.ElementIdFilterProperty : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.ElementId? Eq { get; set; } [JsonPropertyName("$eq")]
-  PROP Camunda.Orchestration.Sdk.ElementId? Neq { get; set; } [JsonPropertyName("$neq")]
-  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
-  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementId>? In { get; set; } [JsonPropertyName("$in")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementId>? NotIn { get; set; } [JsonPropertyName("$notIn")]
-
 TYPE Camunda.Orchestration.Sdk.ElementInstanceFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? EndDate { get; set; } [JsonPropertyName("endDate")]
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? StartDate { get; set; } [JsonPropertyName("startDate")]
-  PROP Camunda.Orchestration.Sdk.ElementIdFilterProperty? ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.ElementId? ElementId { get; set; } [JsonPropertyName("elementId")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceStateFilterProperty? State { get; set; } [JsonPropertyName("state")]
   PROP Camunda.Orchestration.Sdk.IncidentKey? IncidentKey { get; set; } [JsonPropertyName("incidentKey")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
-  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ElementName { get; set; } [JsonPropertyName("elementName")]
   PROP Camunda.Orchestration.Sdk.TenantId? TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Boolean? HasIncident { get; set; } [JsonPropertyName("hasIncident")]
   PROP System.String? ElementInstanceScopeKey { get; set; } [JsonPropertyName("elementInstanceScopeKey")]
+  PROP System.String? ElementName { get; set; } [JsonPropertyName("elementName")]
   PROP System.String? Type { get; set; } [JsonPropertyName("type")]
 
 TYPE Camunda.Orchestration.Sdk.ElementInstanceKey : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ElementInstanceKey>]
@@ -2871,14 +2826,13 @@ TYPE Camunda.Orchestration.Sdk.JobListenerEventTypeEnum : enum interfaces=[Syste
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
   underlying=System.Int32
   MEMBER ASSIGNING = 0 json="ASSIGNING"
-  MEMBER BEFOREALL = 1 json="BEFORE_ALL"
-  MEMBER CANCELING = 2 json="CANCELING"
-  MEMBER COMPLETING = 3 json="COMPLETING"
-  MEMBER CREATING = 4 json="CREATING"
-  MEMBER END = 5 json="END"
-  MEMBER START = 6 json="START"
-  MEMBER UNSPECIFIED = 7 json="UNSPECIFIED"
-  MEMBER UPDATING = 8 json="UPDATING"
+  MEMBER CANCELING = 1 json="CANCELING"
+  MEMBER COMPLETING = 2 json="COMPLETING"
+  MEMBER CREATING = 3 json="CREATING"
+  MEMBER END = 4 json="END"
+  MEMBER START = 5 json="START"
+  MEMBER UNSPECIFIED = 6 json="UNSPECIFIED"
+  MEMBER UPDATING = 7 json="UPDATING"
 
 TYPE Camunda.Orchestration.Sdk.JobListenerEventTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.JobListenerEventTypeExactMatch>]
   PROP System.String Value { get; }
@@ -3255,20 +3209,15 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? LastUpdatedDate { get; set; } [JsonPropertyName("lastUpdatedDate")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
-  PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? ProcessDefinitionVersion { get; set; } [JsonPropertyName("processDefinitionVersion")]
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionKeyFilterProperty? MessageSubscriptionKey { get; set; } [JsonPropertyName("messageSubscriptionKey")]
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionStateFilterProperty? MessageSubscriptionState { get; set; } [JsonPropertyName("messageSubscriptionState")]
-  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeFilterProperty? MessageSubscriptionType { get; set; } [JsonPropertyName("messageSubscriptionType")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? CorrelationKey { get; set; } [JsonPropertyName("correlationKey")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ElementId { get; set; } [JsonPropertyName("elementId")]
-  PROP Camunda.Orchestration.Sdk.StringFilterProperty? InboundConnectorType { get; set; } [JsonPropertyName("inboundConnectorType")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? MessageName { get; set; } [JsonPropertyName("messageName")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
-  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionName { get; set; } [JsonPropertyName("processDefinitionName")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? TenantId { get; set; } [JsonPropertyName("tenantId")]
-  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ToolName { get; set; } [JsonPropertyName("toolName")]
 
 TYPE Camunda.Orchestration.Sdk.MessageSubscriptionKey : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.MessageSubscriptionKey>]
   PROP System.String Value { get; }
@@ -3302,20 +3251,14 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionResult : sealed class
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionKey MessageSubscriptionKey { get; set; } [JsonPropertyName("messageSubscriptionKey")]
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum MessageSubscriptionState { get; set; } [JsonPropertyName("messageSubscriptionState")]
-  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum MessageSubscriptionType { get; set; } [JsonPropertyName("messageSubscriptionType")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionId ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? RootProcessInstanceKey { get; set; } [JsonPropertyName("rootProcessInstanceKey")]
   PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
-  PROP System.Collections.Generic.Dictionary<System.String,System.String> ExtensionProperties { get; set; } [JsonPropertyName("extensionProperties")]
   PROP System.DateTimeOffset LastUpdatedDate { get; set; } [JsonPropertyName("lastUpdatedDate")]
-  PROP System.Int32? ProcessDefinitionVersion { get; set; } [JsonPropertyName("processDefinitionVersion")]
   PROP System.String MessageName { get; set; } [JsonPropertyName("messageName")]
   PROP System.String? CorrelationKey { get; set; } [JsonPropertyName("correlationKey")]
-  PROP System.String? InboundConnectorType { get; set; } [JsonPropertyName("inboundConnectorType")]
-  PROP System.String? ProcessDefinitionName { get; set; } [JsonPropertyName("processDefinitionName")]
-  PROP System.String? ToolName { get; set; } [JsonPropertyName("toolName")]
 
 TYPE Camunda.Orchestration.Sdk.MessageSubscriptionSearchQuery : sealed class
   CTOR ()
@@ -3357,29 +3300,6 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionStateFilterProperty : sealed c
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum>? In { get; set; } [JsonPropertyName("$in")]
-
-TYPE Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
-  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
-  underlying=System.Int32
-  MEMBER STARTEVENT = 0 json="START_EVENT"
-  MEMBER PROCESSEVENT = 1 json="PROCESS_EVENT"
-
-TYPE Camunda.Orchestration.Sdk.MessageSubscriptionTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.MessageSubscriptionTypeExactMatch>]
-  PROP System.String Value { get; }
-  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.MessageSubscriptionTypeExactMatch other)
-  METHOD static Camunda.Orchestration.Sdk.MessageSubscriptionTypeExactMatch AssumeExists(System.String value)
-  METHOD static System.Boolean IsValid(System.String value)
-  METHOD virtual System.Boolean Equals(System.Object obj)
-  METHOD virtual System.Int32 GetHashCode()
-  METHOD virtual System.String ToString()
-
-TYPE Camunda.Orchestration.Sdk.MessageSubscriptionTypeFilterProperty : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
-  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
-  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
-  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
 
 TYPE Camunda.Orchestration.Sdk.MigrateProcessInstanceMappingInstruction : sealed class
   CTOR ()
@@ -3533,24 +3453,6 @@ TYPE Camunda.Orchestration.Sdk.ProcessDefinitionId : struct interfaces=[Camunda.
   METHOD virtual System.Boolean Equals(System.Object obj)
   METHOD virtual System.Int32 GetHashCode()
   METHOD virtual System.String ToString()
-
-TYPE Camunda.Orchestration.Sdk.ProcessDefinitionIdExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ProcessDefinitionIdExactMatch>]
-  PROP System.String Value { get; }
-  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.ProcessDefinitionIdExactMatch other)
-  METHOD static Camunda.Orchestration.Sdk.ProcessDefinitionIdExactMatch AssumeExists(System.String value)
-  METHOD static System.Boolean IsValid(System.String value)
-  METHOD virtual System.Boolean Equals(System.Object obj)
-  METHOD virtual System.Int32 GetHashCode()
-  METHOD virtual System.String ToString()
-
-TYPE Camunda.Orchestration.Sdk.ProcessDefinitionIdFilterProperty : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
-  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? Eq { get; set; } [JsonPropertyName("$eq")]
-  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? Neq { get; set; } [JsonPropertyName("$neq")]
-  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionId>? In { get; set; } [JsonPropertyName("$in")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionId>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
 TYPE Camunda.Orchestration.Sdk.ProcessDefinitionInstanceStatisticsQuery : sealed class
   CTOR ()
@@ -3982,16 +3884,6 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceStateFilterProperty : sealed class
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessInstanceStateEnum>? In { get; set; } [JsonPropertyName("$in")]
 
-TYPE Camunda.Orchestration.Sdk.ResourceFilter : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.DeploymentKeyFilterProperty? DeploymentKey { get; set; } [JsonPropertyName("deploymentKey")]
-  PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? Version { get; set; } [JsonPropertyName("version")]
-  PROP Camunda.Orchestration.Sdk.ResourceKeyFilterProperty? ResourceKey { get; set; } [JsonPropertyName("resourceKey")]
-  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ResourceId { get; set; } [JsonPropertyName("resourceId")]
-  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ResourceName { get; set; } [JsonPropertyName("resourceName")]
-  PROP Camunda.Orchestration.Sdk.StringFilterProperty? VersionTag { get; set; } [JsonPropertyName("versionTag")]
-  PROP Camunda.Orchestration.Sdk.TenantId? TenantId { get; set; } [JsonPropertyName("tenantId")]
-
 TYPE Camunda.Orchestration.Sdk.ResourceKey : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ResourceKey>]
   PROP System.String Value { get; }
   METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.ResourceKey other)
@@ -4026,22 +3918,6 @@ TYPE Camunda.Orchestration.Sdk.ResourceResult : sealed class
   PROP System.String ResourceId { get; set; } [JsonPropertyName("resourceId")]
   PROP System.String ResourceName { get; set; } [JsonPropertyName("resourceName")]
   PROP System.String? VersionTag { get; set; } [JsonPropertyName("versionTag")]
-
-TYPE Camunda.Orchestration.Sdk.ResourceSearchQuery : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.ResourceFilter? Filter { get; set; } [JsonPropertyName("filter")]
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ResourceSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
-
-TYPE Camunda.Orchestration.Sdk.ResourceSearchQueryResult : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ResourceResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.ResourceSearchQuerySortRequest : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SortOrderEnum? Order { get; set; } [JsonPropertyName("order")]
-  PROP System.String Field { get; set; } [JsonPropertyName("field")]
 
 TYPE Camunda.Orchestration.Sdk.ResourceTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
@@ -4719,9 +4595,9 @@ TYPE Camunda.Orchestration.Sdk.UserTaskFilter : sealed class
   PROP Camunda.Orchestration.Sdk.ElementId? ElementId { get; set; } [JsonPropertyName("elementId")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? Priority { get; set; } [JsonPropertyName("priority")]
-  PROP Camunda.Orchestration.Sdk.ProcessDefinitionIdFilterProperty? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
-  PROP Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
-  PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? Assignee { get; set; } [JsonPropertyName("assignee")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? CandidateGroup { get; set; } [JsonPropertyName("candidateGroup")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? CandidateUser { get; set; } [JsonPropertyName("candidateUser")]

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -64,6 +64,22 @@ TYPE Camunda.Orchestration.Sdk.AdvancedActorTypeFilter : sealed class
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogActorTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
 
+TYPE Camunda.Orchestration.Sdk.AdvancedAgentInstanceKeyFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceKey? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceKey>? In { get; set; } [JsonPropertyName("$in")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
+
+TYPE Camunda.Orchestration.Sdk.AdvancedAgentInstanceStatusFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceStatusEnum>? In { get; set; } [JsonPropertyName("$in")]
+
 TYPE Camunda.Orchestration.Sdk.AdvancedAuditLogEntityKeyFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuditLogEntityKey? Eq { get; set; } [JsonPropertyName("$eq")]
@@ -179,6 +195,15 @@ TYPE Camunda.Orchestration.Sdk.AdvancedDeploymentKeyFilter : sealed class
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.DeploymentKey>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.DeploymentKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
+
+TYPE Camunda.Orchestration.Sdk.AdvancedElementIdFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.ElementId? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ElementId? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementId>? In { get; set; } [JsonPropertyName("$in")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementId>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
 TYPE Camunda.Orchestration.Sdk.AdvancedElementInstanceKeyFilter : sealed class
   CTOR ()
@@ -305,6 +330,14 @@ TYPE Camunda.Orchestration.Sdk.AdvancedMessageSubscriptionStateFilter : sealed c
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum>? In { get; set; } [JsonPropertyName("$in")]
 
+TYPE Camunda.Orchestration.Sdk.AdvancedMessageSubscriptionTypeFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
+
 TYPE Camunda.Orchestration.Sdk.AdvancedOperationTypeFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuditLogOperationTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
@@ -312,6 +345,15 @@ TYPE Camunda.Orchestration.Sdk.AdvancedOperationTypeFilter : sealed class
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogOperationTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.AdvancedProcessDefinitionIdFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionId>? In { get; set; } [JsonPropertyName("$in")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionId>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
 TYPE Camunda.Orchestration.Sdk.AdvancedProcessDefinitionKeyFilter : sealed class
   CTOR ()
@@ -385,6 +427,121 @@ TYPE Camunda.Orchestration.Sdk.AdvancedVariableKeyFilter : sealed class
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableKey>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceDefinition : sealed class
+  CTOR ()
+  PROP System.String Model { get; set; } [JsonPropertyName("model")]
+  PROP System.String Provider { get; set; } [JsonPropertyName("provider")]
+  PROP System.String SystemPrompt { get; set; } [JsonPropertyName("systemPrompt")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceKeyFilterProperty? AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceStatusFilterProperty? Status { get; set; } [JsonPropertyName("status")]
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? CompletionDate { get; set; } [JsonPropertyName("completionDate")]
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? CreationDate { get; set; } [JsonPropertyName("creationDate")]
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? LastUpdatedDate { get; set; } [JsonPropertyName("lastUpdatedDate")]
+  PROP Camunda.Orchestration.Sdk.ElementIdFilterProperty? ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? TenantId { get; set; } [JsonPropertyName("tenantId")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceKey : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentInstanceKey>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.AgentInstanceKey other)
+  METHOD static Camunda.Orchestration.Sdk.AgentInstanceKey AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceKeyExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentInstanceKeyExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.AgentInstanceKeyExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.AgentInstanceKeyExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceKeyFilterProperty : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceKey? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceKey>? In { get; set; } [JsonPropertyName("$in")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceLimits : sealed class
+  CTOR ()
+  PROP System.Int64 MaxModelCalls { get; set; } [JsonPropertyName("maxModelCalls")]
+  PROP System.Int64 MaxTokens { get; set; } [JsonPropertyName("maxTokens")]
+  PROP System.Int64 MaxToolCalls { get; set; } [JsonPropertyName("maxToolCalls")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceMetrics : sealed class
+  CTOR ()
+  PROP System.Int64 InputTokens { get; set; } [JsonPropertyName("inputTokens")]
+  PROP System.Int64 ModelCalls { get; set; } [JsonPropertyName("modelCalls")]
+  PROP System.Int64 OutputTokens { get; set; } [JsonPropertyName("outputTokens")]
+  PROP System.Int64 ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceResult : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceDefinition Definition { get; set; } [JsonPropertyName("definition")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceKey AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceLimits Limits { get; set; } [JsonPropertyName("limits")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceMetrics Metrics { get; set; } [JsonPropertyName("metrics")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum Status { get; set; } [JsonPropertyName("status")]
+  PROP Camunda.Orchestration.Sdk.ElementId ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
+  PROP System.DateTimeOffset CreationDate { get; set; } [JsonPropertyName("creationDate")]
+  PROP System.DateTimeOffset LastUpdatedDate { get; set; } [JsonPropertyName("lastUpdatedDate")]
+  PROP System.DateTimeOffset? CompletionDate { get; set; } [JsonPropertyName("completionDate")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceSearchQuery : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceFilter? Filter { get; set; } [JsonPropertyName("filter")]
+  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceSearchQueryResult : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceResult> Items { get; set; } [JsonPropertyName("items")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceSearchQuerySortRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.SortOrderEnum? Order { get; set; } [JsonPropertyName("order")]
+  PROP System.String Field { get; set; } [JsonPropertyName("field")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER COMPLETED = 0 json="COMPLETED"
+  MEMBER IDLE = 1 json="IDLE"
+  MEMBER INITIALIZING = 2 json="INITIALIZING"
+  MEMBER THINKING = 3 json="THINKING"
+  MEMBER TOOLCALLING = 4 json="TOOL_CALLING"
+  MEMBER TOOLDISCOVERY = 5 json="TOOL_DISCOVERY"
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentInstanceStatusExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.AgentInstanceStatusExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.AgentInstanceStatusExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusFilterProperty : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceStatusEnum>? In { get; set; } [JsonPropertyName("$in")]
 
 TYPE Camunda.Orchestration.Sdk.AncestorScopeInstruction : abstract class
   ATTR JsonPolymorphic discriminator=ancestorScopeType
@@ -790,7 +947,7 @@ TYPE Camunda.Orchestration.Sdk.BatchOperationItemResponse : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.BatchOperationKey BatchOperationKey { get; set; } [JsonPropertyName("batchOperationKey")]
   PROP Camunda.Orchestration.Sdk.BatchOperationTypeEnum OperationType { get; set; } [JsonPropertyName("operationType")]
-  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? RootProcessInstanceKey { get; set; } [JsonPropertyName("rootProcessInstanceKey")]
   PROP System.DateTimeOffset? ProcessedDate { get; set; } [JsonPropertyName("processedDate")]
   PROP System.String ItemKey { get; set; } [JsonPropertyName("itemKey")]
@@ -984,18 +1141,18 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD Camunda.Orchestration.Sdk.JobWorker CreateJobWorker(Camunda.Orchestration.Sdk.JobWorkerConfig config, System.Func<Camunda.Orchestration.Sdk.ActivatedJob,System.Threading.CancellationToken,System.Threading.Tasks.Task> handler)
   METHOD System.Collections.Generic.IReadOnlyList<Camunda.Orchestration.Sdk.JobWorker> GetWorkers()
   METHOD System.Threading.Tasks.Task ActivateAdHocSubProcessActivitiesAsync(Camunda.Orchestration.Sdk.ElementInstanceKey adHocSubProcessInstanceKey, Camunda.Orchestration.Sdk.AdHocSubProcessActivateActivitiesInstruction body, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignClientToGroupAsync(System.String groupId, System.String clientId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignClientToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String clientId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignGroupToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String groupId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignMappingRuleToGroupAsync(System.String groupId, System.String mappingRuleId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignMappingRuleToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String mappingRuleId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignRoleToClientAsync(System.String roleId, System.String clientId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignRoleToGroupAsync(System.String roleId, System.String groupId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignRoleToMappingRuleAsync(System.String roleId, System.String mappingRuleId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignRoleToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String roleId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignRoleToUserAsync(System.String roleId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignClientToGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.ClientId clientId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignClientToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.ClientId clientId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignGroupToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.GroupId groupId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignMappingRuleToGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignMappingRuleToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignRoleToClientAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.ClientId clientId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignRoleToGroupAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.GroupId groupId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignRoleToMappingRuleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignRoleToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.RoleId roleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignRoleToUserAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task AssignUserTaskAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskAssignmentRequest body, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task AssignUserToGroupAsync(System.String groupId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignUserToGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task AssignUserToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task CancelBatchOperationAsync(Camunda.Orchestration.Sdk.BatchOperationKey batchOperationKey, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task CancelProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.CancelProcessInstanceRequest body, System.Threading.CancellationToken ct = null)
@@ -1005,14 +1162,14 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task DeleteAuthorizationAsync(Camunda.Orchestration.Sdk.AuthorizationKey authorizationKey, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteDecisionInstanceAsync(Camunda.Orchestration.Sdk.DecisionEvaluationKey decisionEvaluationKey, Camunda.Orchestration.Sdk.DeleteDecisionInstanceRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteDocumentAsync(Camunda.Orchestration.Sdk.DocumentId documentId, System.String? storeId = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task DeleteGlobalClusterVariableAsync(System.String name, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task DeleteGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.ClusterVariableName name, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteGlobalTaskListenerAsync(Camunda.Orchestration.Sdk.GlobalListenerId id, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task DeleteGroupAsync(System.String groupId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task DeleteMappingRuleAsync(System.String mappingRuleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task DeleteGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task DeleteMappingRuleAsync(Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.DeleteProcessInstanceRequest body, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task DeleteRoleAsync(System.String roleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task DeleteRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task DeleteTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String name, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task DeleteTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.ClusterVariableName name, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteUserAsync(Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task FailJobAsync(Camunda.Orchestration.Sdk.JobKey jobKey, Camunda.Orchestration.Sdk.JobFailRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task GetStatusAsync(System.Threading.CancellationToken ct = null)
@@ -1026,22 +1183,24 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task StopAllWorkersAsync(System.TimeSpan? gracePeriod = null)
   METHOD System.Threading.Tasks.Task SuspendBatchOperationAsync(Camunda.Orchestration.Sdk.BatchOperationKey batchOperationKey, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task ThrowJobErrorAsync(Camunda.Orchestration.Sdk.JobKey jobKey, Camunda.Orchestration.Sdk.JobErrorRequest body, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignClientFromGroupAsync(System.String groupId, System.String clientId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignClientFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String clientId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignGroupFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String groupId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignMappingRuleFromGroupAsync(System.String groupId, System.String mappingRuleId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignMappingRuleFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String mappingRuleId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignRoleFromClientAsync(System.String roleId, System.String clientId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignRoleFromGroupAsync(System.String roleId, System.String groupId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignRoleFromMappingRuleAsync(System.String roleId, System.String mappingRuleId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignRoleFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String roleId, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignRoleFromUserAsync(System.String roleId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UnassignUserFromGroupAsync(System.String groupId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignClientFromGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.ClientId clientId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignClientFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.ClientId clientId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignGroupFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.GroupId groupId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignMappingRuleFromGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignMappingRuleFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignRoleFromClientAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.ClientId clientId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignRoleFromGroupAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.GroupId groupId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignRoleFromMappingRuleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignRoleFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.RoleId roleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignRoleFromUserAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UnassignUserFromGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UnassignUserFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UnassignUserTaskAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UpdateAuthorizationAsync(Camunda.Orchestration.Sdk.AuthorizationKey authorizationKey, Camunda.Orchestration.Sdk.AuthorizationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UpdateJobAsync(Camunda.Orchestration.Sdk.JobKey jobKey, Camunda.Orchestration.Sdk.JobUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UpdateUserTaskAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskUpdateRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceResult> GetAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceKey agentInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AgentInstanceResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceSearchQueryResult> SearchAgentInstancesAsync(Camunda.Orchestration.Sdk.AgentInstanceSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AgentInstanceSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AuditLogResult> GetAuditLogAsync(Camunda.Orchestration.Sdk.AuditLogKey auditLogKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AuditLogResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AuditLogSearchQueryResult> SearchAuditLogsAsync(Camunda.Orchestration.Sdk.AuditLogSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AuditLogSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AuditLogSearchQueryResult> SearchUserTaskAuditLogsAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskAuditLogSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AuditLogSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1061,13 +1220,12 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.CamundaUserResult> GetAuthenticationAsync(System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> CreateGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.CreateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> CreateTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.CreateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> GetGlobalClusterVariableAsync(System.String name, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ClusterVariableResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> GetTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String name, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ClusterVariableResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> UpdateGlobalClusterVariableAsync(System.String name, Camunda.Orchestration.Sdk.UpdateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> UpdateTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, System.String name, Camunda.Orchestration.Sdk.UpdateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> GetGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.ClusterVariableName name, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ClusterVariableResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> GetTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.ClusterVariableName name, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ClusterVariableResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> UpdateGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.ClusterVariableName name, Camunda.Orchestration.Sdk.UpdateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> UpdateTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.ClusterVariableName name, Camunda.Orchestration.Sdk.UpdateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableSearchQueryResult> SearchClusterVariablesAsync(Camunda.Orchestration.Sdk.ClusterVariableSearchQueryRequest body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ClusterVariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.CorrelatedMessageSubscriptionSearchQueryResult> SearchCorrelatedMessageSubscriptionsAsync(Camunda.Orchestration.Sdk.CorrelatedMessageSubscriptionSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.CorrelatedMessageSubscriptionSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.CreateMappingRuleResponse> CreateMappingRuleAsync(Camunda.Orchestration.Sdk.MappingRuleCreateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.CreateProcessInstanceResult> CreateProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceCreationInstruction body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.DecisionDefinitionResult> GetDecisionDefinitionAsync(Camunda.Orchestration.Sdk.DecisionDefinitionKey decisionDefinitionKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.DecisionDefinitionResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.DecisionDefinitionSearchQueryResult> SearchDecisionDefinitionsAsync(Camunda.Orchestration.Sdk.DecisionDefinitionSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.DecisionDefinitionSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1088,16 +1246,19 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ExtendedDeploymentResponse> DeployResourcesFromFilesAsync(System.String[] resourceFilePaths, System.String? tenantId = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.FormResult> GetStartProcessFormAsync(Camunda.Orchestration.Sdk.ProcessDefinitionKey processDefinitionKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.FormResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.FormResult> GetUserTaskFormAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.FormResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GetUserResponse> GetUserAsync(Camunda.Orchestration.Sdk.Username username, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GetUserResponse>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GlobalJobStatisticsQueryResult> GetGlobalJobStatisticsAsync(System.DateTimeOffset from, System.DateTimeOffset to, System.String? jobType = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GlobalJobStatisticsQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GlobalTaskListenerResult> CreateGlobalTaskListenerAsync(Camunda.Orchestration.Sdk.CreateGlobalTaskListenerRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GlobalTaskListenerResult> GetGlobalTaskListenerAsync(Camunda.Orchestration.Sdk.GlobalListenerId id, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GlobalTaskListenerResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GlobalTaskListenerResult> UpdateGlobalTaskListenerAsync(Camunda.Orchestration.Sdk.GlobalListenerId id, Camunda.Orchestration.Sdk.UpdateGlobalTaskListenerRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GlobalTaskListenerSearchQueryResult> SearchGlobalTaskListenersAsync(Camunda.Orchestration.Sdk.GlobalTaskListenerSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GlobalTaskListenerSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupClientSearchResult> SearchClientsForGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.GroupClientSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GroupClientSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupCreateResult> CreateGroupAsync(Camunda.Orchestration.Sdk.GroupCreateRequest body, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupResult> GetGroupAsync(System.String groupId, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GroupResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupMappingRuleSearchResult> SearchMappingRulesForGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.MappingRuleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GroupMappingRuleSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupResult> GetGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GroupResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupRoleSearchResult> SearchRolesForGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.RoleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GroupRoleSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupSearchQueryResult> SearchGroupsAsync(Camunda.Orchestration.Sdk.GroupSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GroupSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupUpdateResult> UpdateGroupAsync(System.String groupId, Camunda.Orchestration.Sdk.GroupUpdateRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupUpdateResult> UpdateGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.GroupUpdateRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupUserSearchResult> SearchUsersForGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.GroupUserSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GroupUserSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByDefinitionQueryResult> GetProcessInstanceStatisticsByDefinitionAsync(Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByDefinitionQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByDefinitionQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByErrorQueryResult> GetProcessInstanceStatisticsByErrorAsync(Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByErrorQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByErrorQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.IncidentResult> GetIncidentAsync(Camunda.Orchestration.Sdk.IncidentKey incidentKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.IncidentResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1111,7 +1272,10 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.JobTypeStatisticsQueryResult> GetJobTypeStatisticsAsync(Camunda.Orchestration.Sdk.JobTypeStatisticsQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.JobTypeStatisticsQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.JobWorkerStatisticsQueryResult> GetJobWorkerStatisticsAsync(Camunda.Orchestration.Sdk.JobWorkerStatisticsQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.JobWorkerStatisticsQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.LicenseResponse> GetLicenseAsync(System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.MappingRuleResult> GetMappingRuleAsync(System.String mappingRuleId, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.MappingRuleResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.MappingRuleCreateResult> CreateMappingRuleAsync(Camunda.Orchestration.Sdk.MappingRuleCreateRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.MappingRuleResult> GetMappingRuleAsync(Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.MappingRuleResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.MappingRuleSearchQueryResult> SearchMappingRuleAsync(Camunda.Orchestration.Sdk.MappingRuleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.MappingRuleSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.MappingRuleUpdateResult> UpdateMappingRuleAsync(Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, Camunda.Orchestration.Sdk.MappingRuleUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.MessageCorrelationResult> CorrelateMessageAsync(Camunda.Orchestration.Sdk.MessageCorrelationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.MessagePublicationResult> PublishMessageAsync(Camunda.Orchestration.Sdk.MessagePublicationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.MessageSubscriptionSearchQueryResult> SearchMessageSubscriptionsAsync(Camunda.Orchestration.Sdk.MessageSubscriptionSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.MessageSubscriptionSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1125,50 +1289,46 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessInstanceResult> GetProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessInstanceResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessInstanceSearchQueryResult> SearchProcessInstancesAsync(Camunda.Orchestration.Sdk.ProcessInstanceSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessInstanceSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessInstanceSequenceFlowsQueryResult> GetProcessInstanceSequenceFlowsAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessInstanceSequenceFlowsQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ResourceResult> GetResourceAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ResourceResult> GetResourceAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ResourceResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ResourceSearchQueryResult> SearchResourcesAsync(Camunda.Orchestration.Sdk.ResourceSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ResourceSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleClientSearchResult> SearchClientsForRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.RoleClientSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleClientSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleCreateResult> CreateRoleAsync(Camunda.Orchestration.Sdk.RoleCreateRequest body, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleGroupSearchResult> SearchGroupsForRoleAsync(System.String roleId, Camunda.Orchestration.Sdk.RoleGroupSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleGroupSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleResult> GetRoleAsync(System.String roleId, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleGroupSearchResult> SearchGroupsForRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.RoleGroupSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleGroupSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleMappingRuleSearchResult> SearchMappingRulesForRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.MappingRuleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleMappingRuleSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleResult> GetRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleSearchQueryResult> SearchRolesAsync(Camunda.Orchestration.Sdk.RoleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleUpdateResult> UpdateRoleAsync(System.String roleId, Camunda.Orchestration.Sdk.RoleUpdateRequest body, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchClientsForGroupResponse> SearchClientsForGroupAsync(System.String groupId, Camunda.Orchestration.Sdk.SearchClientsForGroupRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchClientsForGroupResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchClientsForRoleResponse> SearchClientsForRoleAsync(System.String roleId, Camunda.Orchestration.Sdk.SearchClientsForRoleRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchClientsForRoleResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchClientsForTenantResponse> SearchClientsForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.SearchClientsForTenantRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchClientsForTenantResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchMappingRuleResponse> SearchMappingRuleAsync(Camunda.Orchestration.Sdk.MappingRuleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchMappingRuleResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchMappingRulesForGroupResponse> SearchMappingRulesForGroupAsync(System.String groupId, Camunda.Orchestration.Sdk.MappingRuleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchMappingRulesForGroupResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchMappingRulesForRoleResponse> SearchMappingRulesForRoleAsync(System.String roleId, Camunda.Orchestration.Sdk.MappingRuleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchMappingRulesForRoleResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchMappingRulesForTenantResponse> SearchMappingRulesForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.MappingRuleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchMappingRulesForTenantResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchRolesForGroupResponse> SearchRolesForGroupAsync(System.String groupId, Camunda.Orchestration.Sdk.RoleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchRolesForGroupResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchRolesForTenantResponse> SearchRolesForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.RoleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchRolesForTenantResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchUsersForGroupResponse> SearchUsersForGroupAsync(System.String groupId, Camunda.Orchestration.Sdk.SearchUsersForGroupRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchUsersForGroupResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchUsersForRoleResponse> SearchUsersForRoleAsync(System.String roleId, Camunda.Orchestration.Sdk.SearchUsersForRoleRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchUsersForRoleResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchUsersForTenantResponse> SearchUsersForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.SearchUsersForTenantRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchUsersForTenantResponse>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SearchUsersResponse> SearchUsersAsync(Camunda.Orchestration.Sdk.UserSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.SearchUsersResponse>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleUpdateResult> UpdateRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.RoleUpdateRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleUserSearchResult> SearchUsersForRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.RoleUserSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleUserSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SignalBroadcastResult> BroadcastSignalAsync(Camunda.Orchestration.Sdk.SignalBroadcastRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SystemConfigurationResponse> GetSystemConfigurationAsync(System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantClientSearchResult> SearchClientsForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.TenantClientSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.TenantClientSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantCreateResult> CreateTenantAsync(Camunda.Orchestration.Sdk.TenantCreateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantGroupSearchResult> SearchGroupIdsForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.TenantGroupSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.TenantGroupSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantMappingRuleSearchResult> SearchMappingRulesForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.MappingRuleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.TenantMappingRuleSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantResult> GetTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.TenantResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantRoleSearchResult> SearchRolesForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.RoleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.TenantRoleSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantSearchQueryResult> SearchTenantsAsync(Camunda.Orchestration.Sdk.TenantSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.TenantSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantUpdateResult> UpdateTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.TenantUpdateRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantUserSearchResult> SearchUsersForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.TenantUserSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.TenantUserSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TopologyResponse> GetTopologyAsync(System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UpdateMappingRuleResponse> UpdateMappingRuleAsync(System.String mappingRuleId, Camunda.Orchestration.Sdk.MappingRuleUpdateRequest body, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UpdateUserResponse> UpdateUserAsync(Camunda.Orchestration.Sdk.Username username, Camunda.Orchestration.Sdk.UserUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UsageMetricsResponse> GetUsageMetricsAsync(System.DateTimeOffset startTime, System.DateTimeOffset endTime, Camunda.Orchestration.Sdk.TenantId? tenantId = null, System.Boolean? withTenants = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.UsageMetricsResponse>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UserCreateResult> CreateAdminUserAsync(Camunda.Orchestration.Sdk.UserRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UserCreateResult> CreateUserAsync(Camunda.Orchestration.Sdk.UserRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UserResult> GetUserAsync(Camunda.Orchestration.Sdk.Username username, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.UserResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UserSearchResult> SearchUsersAsync(Camunda.Orchestration.Sdk.UserSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.UserSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UserTaskResult> GetUserTaskAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.UserTaskResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UserTaskSearchQueryResult> SearchUserTasksAsync(Camunda.Orchestration.Sdk.UserTaskSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.UserTaskSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UserUpdateResult> UpdateUserAsync(Camunda.Orchestration.Sdk.Username username, Camunda.Orchestration.Sdk.UserUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableResult> GetVariableAsync(Camunda.Orchestration.Sdk.VariableKey variableKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchUserTaskEffectiveVariablesAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.SearchUserTaskEffectiveVariablesRequest body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchUserTaskVariablesAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.SearchUserTaskVariablesRequest body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchVariablesAsync(Camunda.Orchestration.Sdk.SearchVariablesRequest body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchUserTaskEffectiveVariablesAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskEffectiveVariableSearchQueryRequest body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchUserTaskVariablesAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskVariableSearchQueryRequest body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchVariablesAsync(Camunda.Orchestration.Sdk.VariableSearchQuery body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetDecisionDefinitionXmlAsync(Camunda.Orchestration.Sdk.DecisionDefinitionKey decisionDefinitionKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetDecisionRequirementsXmlAsync(Camunda.Orchestration.Sdk.DecisionRequirementsKey decisionRequirementsKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetDocumentAsync(Camunda.Orchestration.Sdk.DocumentId documentId, System.String? storeId = null, System.String? contentHash = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetProcessDefinitionXmlAsync(Camunda.Orchestration.Sdk.ProcessDefinitionKey processDefinitionKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetProcessInstanceCallHierarchyAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<System.Object> GetResourceContentAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<System.Object> GetResourceContentAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.ValueTask DisposeAsync()
   METHOD System.Void Dispose()
   METHOD static Camunda.Orchestration.Sdk.CamundaClient Create(Camunda.Orchestration.Sdk.CamundaOptions? options = null)
@@ -1270,21 +1430,39 @@ TYPE Camunda.Orchestration.Sdk.Changeset : sealed class
   PROP System.DateTimeOffset? FollowUpDate { get; set; } [JsonPropertyName("followUpDate")]
   PROP System.Int32? Priority { get; set; } [JsonPropertyName("priority")]
 
+TYPE Camunda.Orchestration.Sdk.ClientId : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ClientId>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.ClientId other)
+  METHOD static Camunda.Orchestration.Sdk.ClientId AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
 TYPE Camunda.Orchestration.Sdk.ClockPinRequest : sealed class
   CTOR ()
   PROP System.Int64 Timestamp { get; set; } [JsonPropertyName("timestamp")]
 
+TYPE Camunda.Orchestration.Sdk.ClusterVariableName : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ClusterVariableName>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.ClusterVariableName other)
+  METHOD static Camunda.Orchestration.Sdk.ClusterVariableName AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
 TYPE Camunda.Orchestration.Sdk.ClusterVariableResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum Scope { get; set; } [JsonPropertyName("scope")]
-  PROP System.String Name { get; set; } [JsonPropertyName("name")]
   PROP System.String Value { get; set; } [JsonPropertyName("value")]
   PROP System.String? TenantId { get; set; } [JsonPropertyName("tenantId")]
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableResultBase : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum Scope { get; set; } [JsonPropertyName("scope")]
-  PROP System.String Name { get; set; } [JsonPropertyName("name")]
   PROP System.String? TenantId { get; set; } [JsonPropertyName("tenantId")]
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableScopeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
@@ -1336,9 +1514,9 @@ TYPE Camunda.Orchestration.Sdk.ClusterVariableSearchQuerySortRequest : sealed cl
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableSearchResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum Scope { get; set; } [JsonPropertyName("scope")]
   PROP System.Boolean IsTruncated { get; set; } [JsonPropertyName("isTruncated")]
-  PROP System.String Name { get; set; } [JsonPropertyName("name")]
   PROP System.String Value { get; set; } [JsonPropertyName("value")]
   PROP System.String? TenantId { get; set; } [JsonPropertyName("tenantId")]
 
@@ -1431,20 +1609,13 @@ TYPE Camunda.Orchestration.Sdk.CorrelatedMessageSubscriptionSearchQuerySortReque
 
 TYPE Camunda.Orchestration.Sdk.CreateClusterVariableRequest : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP System.Object Value { get; set; } [JsonPropertyName("value")]
-  PROP System.String Name { get; set; } [JsonPropertyName("name")]
 
 TYPE Camunda.Orchestration.Sdk.CreateGlobalTaskListenerRequest : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.GlobalListenerId Id { get; set; } [JsonPropertyName("id")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.GlobalTaskListenerEventTypeEnum> EventTypes { get; set; } [JsonPropertyName("eventTypes")]
-
-TYPE Camunda.Orchestration.Sdk.CreateMappingRuleResponse : sealed class
-  CTOR ()
-  PROP System.String ClaimName { get; set; } [JsonPropertyName("claimName")]
-  PROP System.String ClaimValue { get; set; } [JsonPropertyName("claimValue")]
-  PROP System.String MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
-  PROP System.String Name { get; set; } [JsonPropertyName("name")]
 
 TYPE Camunda.Orchestration.Sdk.CreateProcessInstanceResult : sealed class
   CTOR ()
@@ -1981,21 +2152,39 @@ TYPE Camunda.Orchestration.Sdk.ElementId : struct interfaces=[Camunda.Orchestrat
   METHOD virtual System.Int32 GetHashCode()
   METHOD virtual System.String ToString()
 
+TYPE Camunda.Orchestration.Sdk.ElementIdExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ElementIdExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.ElementIdExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.ElementIdExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.ElementIdFilterProperty : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.ElementId? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ElementId? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementId>? In { get; set; } [JsonPropertyName("$in")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementId>? NotIn { get; set; } [JsonPropertyName("$notIn")]
+
 TYPE Camunda.Orchestration.Sdk.ElementInstanceFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? EndDate { get; set; } [JsonPropertyName("endDate")]
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? StartDate { get; set; } [JsonPropertyName("startDate")]
-  PROP Camunda.Orchestration.Sdk.ElementId? ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.ElementIdFilterProperty? ElementId { get; set; } [JsonPropertyName("elementId")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceStateFilterProperty? State { get; set; } [JsonPropertyName("state")]
   PROP Camunda.Orchestration.Sdk.IncidentKey? IncidentKey { get; set; } [JsonPropertyName("incidentKey")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ElementName { get; set; } [JsonPropertyName("elementName")]
   PROP Camunda.Orchestration.Sdk.TenantId? TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Boolean? HasIncident { get; set; } [JsonPropertyName("hasIncident")]
   PROP System.String? ElementInstanceScopeKey { get; set; } [JsonPropertyName("elementInstanceScopeKey")]
-  PROP System.String? ElementName { get; set; } [JsonPropertyName("elementName")]
   PROP System.String? Type { get; set; } [JsonPropertyName("type")]
 
 TYPE Camunda.Orchestration.Sdk.ElementInstanceKey : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ElementInstanceKey>]
@@ -2236,12 +2425,6 @@ TYPE Camunda.Orchestration.Sdk.FormResult : sealed class
   PROP System.Int64 Version { get; set; } [JsonPropertyName("version")]
   PROP System.String Schema { get; set; } [JsonPropertyName("schema")]
 
-TYPE Camunda.Orchestration.Sdk.GetUserResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.Username Username { get; set; } [JsonPropertyName("username")]
-  PROP System.String? Email { get; set; } [JsonPropertyName("email")]
-  PROP System.String? Name { get; set; } [JsonPropertyName("name")]
-
 TYPE Camunda.Orchestration.Sdk.GlobalJobStatisticsQueryResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.StatusMetric Completed { get; set; } [JsonPropertyName("completed")]
@@ -2361,7 +2544,7 @@ TYPE Camunda.Orchestration.Sdk.GlobalTaskListenerSearchQuerySortRequest : sealed
 
 TYPE Camunda.Orchestration.Sdk.GroupClientResult : sealed class
   CTOR ()
-  PROP System.String ClientId { get; set; } [JsonPropertyName("clientId")]
+  PROP Camunda.Orchestration.Sdk.ClientId ClientId { get; set; } [JsonPropertyName("clientId")]
 
 TYPE Camunda.Orchestration.Sdk.GroupClientSearchQueryRequest : sealed class
   CTOR ()
@@ -2380,13 +2563,13 @@ TYPE Camunda.Orchestration.Sdk.GroupClientSearchResult : sealed class
 
 TYPE Camunda.Orchestration.Sdk.GroupCreateRequest : sealed class
   CTOR ()
-  PROP System.String GroupId { get; set; } [JsonPropertyName("groupId")]
+  PROP Camunda.Orchestration.Sdk.GroupId GroupId { get; set; } [JsonPropertyName("groupId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
   PROP System.String? Description { get; set; } [JsonPropertyName("description")]
 
 TYPE Camunda.Orchestration.Sdk.GroupCreateResult : sealed class
   CTOR ()
-  PROP System.String GroupId { get; set; } [JsonPropertyName("groupId")]
+  PROP Camunda.Orchestration.Sdk.GroupId GroupId { get; set; } [JsonPropertyName("groupId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
   PROP System.String? Description { get; set; } [JsonPropertyName("description")]
 
@@ -2395,6 +2578,15 @@ TYPE Camunda.Orchestration.Sdk.GroupFilter : sealed class
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? GroupId { get; set; } [JsonPropertyName("groupId")]
   PROP System.String? Name { get; set; } [JsonPropertyName("name")]
 
+TYPE Camunda.Orchestration.Sdk.GroupId : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.GroupId>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.GroupId other)
+  METHOD static Camunda.Orchestration.Sdk.GroupId AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
 TYPE Camunda.Orchestration.Sdk.GroupMappingRuleSearchResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
@@ -2402,7 +2594,7 @@ TYPE Camunda.Orchestration.Sdk.GroupMappingRuleSearchResult : sealed class
 
 TYPE Camunda.Orchestration.Sdk.GroupResult : sealed class
   CTOR ()
-  PROP System.String GroupId { get; set; } [JsonPropertyName("groupId")]
+  PROP Camunda.Orchestration.Sdk.GroupId GroupId { get; set; } [JsonPropertyName("groupId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
   PROP System.String? Description { get; set; } [JsonPropertyName("description")]
 
@@ -2434,7 +2626,7 @@ TYPE Camunda.Orchestration.Sdk.GroupUpdateRequest : sealed class
 
 TYPE Camunda.Orchestration.Sdk.GroupUpdateResult : sealed class
   CTOR ()
-  PROP System.String GroupId { get; set; } [JsonPropertyName("groupId")]
+  PROP Camunda.Orchestration.Sdk.GroupId GroupId { get; set; } [JsonPropertyName("groupId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
   PROP System.String? Description { get; set; } [JsonPropertyName("description")]
 
@@ -2826,13 +3018,14 @@ TYPE Camunda.Orchestration.Sdk.JobListenerEventTypeEnum : enum interfaces=[Syste
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
   underlying=System.Int32
   MEMBER ASSIGNING = 0 json="ASSIGNING"
-  MEMBER CANCELING = 1 json="CANCELING"
-  MEMBER COMPLETING = 2 json="COMPLETING"
-  MEMBER CREATING = 3 json="CREATING"
-  MEMBER END = 4 json="END"
-  MEMBER START = 5 json="START"
-  MEMBER UNSPECIFIED = 6 json="UNSPECIFIED"
-  MEMBER UPDATING = 7 json="UPDATING"
+  MEMBER BEFOREALL = 1 json="BEFORE_ALL"
+  MEMBER CANCELING = 2 json="CANCELING"
+  MEMBER COMPLETING = 3 json="COMPLETING"
+  MEMBER CREATING = 4 json="CREATING"
+  MEMBER END = 5 json="END"
+  MEMBER START = 6 json="START"
+  MEMBER UNSPECIFIED = 7 json="UNSPECIFIED"
+  MEMBER UPDATING = 8 json="UPDATING"
 
 TYPE Camunda.Orchestration.Sdk.JobListenerEventTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.JobListenerEventTypeExactMatch>]
   PROP System.String Value { get; }
@@ -3093,16 +3286,16 @@ TYPE Camunda.Orchestration.Sdk.LongKey : struct interfaces=[Camunda.Orchestratio
 
 TYPE Camunda.Orchestration.Sdk.MappingRuleCreateRequest : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.MappingRuleId MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String ClaimName { get; set; } [JsonPropertyName("claimName")]
   PROP System.String ClaimValue { get; set; } [JsonPropertyName("claimValue")]
-  PROP System.String MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
 
 TYPE Camunda.Orchestration.Sdk.MappingRuleCreateResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.MappingRuleId MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String ClaimName { get; set; } [JsonPropertyName("claimName")]
   PROP System.String ClaimValue { get; set; } [JsonPropertyName("claimValue")]
-  PROP System.String MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
 
 TYPE Camunda.Orchestration.Sdk.MappingRuleCreateUpdateRequest : sealed class
@@ -3113,23 +3306,32 @@ TYPE Camunda.Orchestration.Sdk.MappingRuleCreateUpdateRequest : sealed class
 
 TYPE Camunda.Orchestration.Sdk.MappingRuleCreateUpdateResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.MappingRuleId MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String ClaimName { get; set; } [JsonPropertyName("claimName")]
   PROP System.String ClaimValue { get; set; } [JsonPropertyName("claimValue")]
-  PROP System.String MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
 
 TYPE Camunda.Orchestration.Sdk.MappingRuleFilter : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.MappingRuleId? MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String? ClaimName { get; set; } [JsonPropertyName("claimName")]
   PROP System.String? ClaimValue { get; set; } [JsonPropertyName("claimValue")]
-  PROP System.String? MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String? Name { get; set; } [JsonPropertyName("name")]
+
+TYPE Camunda.Orchestration.Sdk.MappingRuleId : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.MappingRuleId>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.MappingRuleId other)
+  METHOD static Camunda.Orchestration.Sdk.MappingRuleId AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.MappingRuleResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.MappingRuleId MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String ClaimName { get; set; } [JsonPropertyName("claimName")]
   PROP System.String ClaimValue { get; set; } [JsonPropertyName("claimValue")]
-  PROP System.String MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
 
 TYPE Camunda.Orchestration.Sdk.MappingRuleSearchQueryRequest : sealed class
@@ -3156,9 +3358,9 @@ TYPE Camunda.Orchestration.Sdk.MappingRuleUpdateRequest : sealed class
 
 TYPE Camunda.Orchestration.Sdk.MappingRuleUpdateResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.MappingRuleId MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String ClaimName { get; set; } [JsonPropertyName("claimName")]
   PROP System.String ClaimValue { get; set; } [JsonPropertyName("claimValue")]
-  PROP System.String MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
 
 TYPE Camunda.Orchestration.Sdk.MatchedDecisionRuleItem : sealed class
@@ -3209,15 +3411,20 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? LastUpdatedDate { get; set; } [JsonPropertyName("lastUpdatedDate")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? ProcessDefinitionVersion { get; set; } [JsonPropertyName("processDefinitionVersion")]
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionKeyFilterProperty? MessageSubscriptionKey { get; set; } [JsonPropertyName("messageSubscriptionKey")]
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionStateFilterProperty? MessageSubscriptionState { get; set; } [JsonPropertyName("messageSubscriptionState")]
+  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeFilterProperty? MessageSubscriptionType { get; set; } [JsonPropertyName("messageSubscriptionType")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? CorrelationKey { get; set; } [JsonPropertyName("correlationKey")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? InboundConnectorType { get; set; } [JsonPropertyName("inboundConnectorType")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? MessageName { get; set; } [JsonPropertyName("messageName")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionName { get; set; } [JsonPropertyName("processDefinitionName")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? TenantId { get; set; } [JsonPropertyName("tenantId")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ToolName { get; set; } [JsonPropertyName("toolName")]
 
 TYPE Camunda.Orchestration.Sdk.MessageSubscriptionKey : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.MessageSubscriptionKey>]
   PROP System.String Value { get; }
@@ -3251,14 +3458,20 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionResult : sealed class
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionKey MessageSubscriptionKey { get; set; } [JsonPropertyName("messageSubscriptionKey")]
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum MessageSubscriptionState { get; set; } [JsonPropertyName("messageSubscriptionState")]
+  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum MessageSubscriptionType { get; set; } [JsonPropertyName("messageSubscriptionType")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionId ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? RootProcessInstanceKey { get; set; } [JsonPropertyName("rootProcessInstanceKey")]
   PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
+  PROP System.Collections.Generic.Dictionary<System.String,System.String> ExtensionProperties { get; set; } [JsonPropertyName("extensionProperties")]
   PROP System.DateTimeOffset LastUpdatedDate { get; set; } [JsonPropertyName("lastUpdatedDate")]
+  PROP System.Int32? ProcessDefinitionVersion { get; set; } [JsonPropertyName("processDefinitionVersion")]
   PROP System.String MessageName { get; set; } [JsonPropertyName("messageName")]
   PROP System.String? CorrelationKey { get; set; } [JsonPropertyName("correlationKey")]
+  PROP System.String? InboundConnectorType { get; set; } [JsonPropertyName("inboundConnectorType")]
+  PROP System.String? ProcessDefinitionName { get; set; } [JsonPropertyName("processDefinitionName")]
+  PROP System.String? ToolName { get; set; } [JsonPropertyName("toolName")]
 
 TYPE Camunda.Orchestration.Sdk.MessageSubscriptionSearchQuery : sealed class
   CTOR ()
@@ -3300,6 +3513,29 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionStateFilterProperty : sealed c
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER STARTEVENT = 0 json="START_EVENT"
+  MEMBER PROCESSEVENT = 1 json="PROCESS_EVENT"
+
+TYPE Camunda.Orchestration.Sdk.MessageSubscriptionTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.MessageSubscriptionTypeExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.MessageSubscriptionTypeExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.MessageSubscriptionTypeExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.MessageSubscriptionTypeFilterProperty : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
 
 TYPE Camunda.Orchestration.Sdk.MigrateProcessInstanceMappingInstruction : sealed class
   CTOR ()
@@ -3453,6 +3689,24 @@ TYPE Camunda.Orchestration.Sdk.ProcessDefinitionId : struct interfaces=[Camunda.
   METHOD virtual System.Boolean Equals(System.Object obj)
   METHOD virtual System.Int32 GetHashCode()
   METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.ProcessDefinitionIdExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ProcessDefinitionIdExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.ProcessDefinitionIdExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.ProcessDefinitionIdExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.ProcessDefinitionIdFilterProperty : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionId>? In { get; set; } [JsonPropertyName("$in")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionId>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
 TYPE Camunda.Orchestration.Sdk.ProcessDefinitionInstanceStatisticsQuery : sealed class
   CTOR ()
@@ -3884,6 +4138,16 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceStateFilterProperty : sealed class
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessInstanceStateEnum>? In { get; set; } [JsonPropertyName("$in")]
 
+TYPE Camunda.Orchestration.Sdk.ResourceFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.DeploymentKeyFilterProperty? DeploymentKey { get; set; } [JsonPropertyName("deploymentKey")]
+  PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? Version { get; set; } [JsonPropertyName("version")]
+  PROP Camunda.Orchestration.Sdk.ResourceKeyFilterProperty? ResourceKey { get; set; } [JsonPropertyName("resourceKey")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ResourceId { get; set; } [JsonPropertyName("resourceId")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ResourceName { get; set; } [JsonPropertyName("resourceName")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? VersionTag { get; set; } [JsonPropertyName("versionTag")]
+  PROP Camunda.Orchestration.Sdk.TenantId? TenantId { get; set; } [JsonPropertyName("tenantId")]
+
 TYPE Camunda.Orchestration.Sdk.ResourceKey : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ResourceKey>]
   PROP System.String Value { get; }
   METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.ResourceKey other)
@@ -3918,6 +4182,22 @@ TYPE Camunda.Orchestration.Sdk.ResourceResult : sealed class
   PROP System.String ResourceId { get; set; } [JsonPropertyName("resourceId")]
   PROP System.String ResourceName { get; set; } [JsonPropertyName("resourceName")]
   PROP System.String? VersionTag { get; set; } [JsonPropertyName("versionTag")]
+
+TYPE Camunda.Orchestration.Sdk.ResourceSearchQuery : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.ResourceFilter? Filter { get; set; } [JsonPropertyName("filter")]
+  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ResourceSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
+
+TYPE Camunda.Orchestration.Sdk.ResourceSearchQueryResult : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ResourceResult> Items { get; set; } [JsonPropertyName("items")]
+
+TYPE Camunda.Orchestration.Sdk.ResourceSearchQuerySortRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.SortOrderEnum? Order { get; set; } [JsonPropertyName("order")]
+  PROP System.String Field { get; set; } [JsonPropertyName("field")]
 
 TYPE Camunda.Orchestration.Sdk.ResourceTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
@@ -3955,7 +4235,7 @@ TYPE Camunda.Orchestration.Sdk.RetryDecision : struct interfaces=[System.IEquata
 
 TYPE Camunda.Orchestration.Sdk.RoleClientResult : sealed class
   CTOR ()
-  PROP System.String ClientId { get; set; } [JsonPropertyName("clientId")]
+  PROP Camunda.Orchestration.Sdk.ClientId ClientId { get; set; } [JsonPropertyName("clientId")]
 
 TYPE Camunda.Orchestration.Sdk.RoleClientSearchQueryRequest : sealed class
   CTOR ()
@@ -3974,24 +4254,24 @@ TYPE Camunda.Orchestration.Sdk.RoleClientSearchResult : sealed class
 
 TYPE Camunda.Orchestration.Sdk.RoleCreateRequest : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.RoleId RoleId { get; set; } [JsonPropertyName("roleId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
-  PROP System.String RoleId { get; set; } [JsonPropertyName("roleId")]
   PROP System.String? Description { get; set; } [JsonPropertyName("description")]
 
 TYPE Camunda.Orchestration.Sdk.RoleCreateResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.RoleId RoleId { get; set; } [JsonPropertyName("roleId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
-  PROP System.String RoleId { get; set; } [JsonPropertyName("roleId")]
   PROP System.String? Description { get; set; } [JsonPropertyName("description")]
 
 TYPE Camunda.Orchestration.Sdk.RoleFilter : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.RoleId? RoleId { get; set; } [JsonPropertyName("roleId")]
   PROP System.String? Name { get; set; } [JsonPropertyName("name")]
-  PROP System.String? RoleId { get; set; } [JsonPropertyName("roleId")]
 
 TYPE Camunda.Orchestration.Sdk.RoleGroupResult : sealed class
   CTOR ()
-  PROP System.String GroupId { get; set; } [JsonPropertyName("groupId")]
+  PROP Camunda.Orchestration.Sdk.GroupId GroupId { get; set; } [JsonPropertyName("groupId")]
 
 TYPE Camunda.Orchestration.Sdk.RoleGroupSearchQueryRequest : sealed class
   CTOR ()
@@ -4008,6 +4288,15 @@ TYPE Camunda.Orchestration.Sdk.RoleGroupSearchResult : sealed class
   PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.RoleGroupResult> Items { get; set; } [JsonPropertyName("items")]
 
+TYPE Camunda.Orchestration.Sdk.RoleId : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.RoleId>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.RoleId other)
+  METHOD static Camunda.Orchestration.Sdk.RoleId AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
 TYPE Camunda.Orchestration.Sdk.RoleMappingRuleSearchResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
@@ -4015,8 +4304,8 @@ TYPE Camunda.Orchestration.Sdk.RoleMappingRuleSearchResult : sealed class
 
 TYPE Camunda.Orchestration.Sdk.RoleResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.RoleId RoleId { get; set; } [JsonPropertyName("roleId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
-  PROP System.String RoleId { get; set; } [JsonPropertyName("roleId")]
   PROP System.String? Description { get; set; } [JsonPropertyName("description")]
 
 TYPE Camunda.Orchestration.Sdk.RoleSearchQueryRequest : sealed class
@@ -4042,8 +4331,8 @@ TYPE Camunda.Orchestration.Sdk.RoleUpdateRequest : sealed class
 
 TYPE Camunda.Orchestration.Sdk.RoleUpdateResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.RoleId RoleId { get; set; } [JsonPropertyName("roleId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
-  PROP System.String RoleId { get; set; } [JsonPropertyName("roleId")]
   PROP System.String? Description { get; set; } [JsonPropertyName("description")]
 
 TYPE Camunda.Orchestration.Sdk.RoleUserResult : sealed class
@@ -4091,56 +4380,6 @@ TYPE Camunda.Orchestration.Sdk.ScopeKeyFilterProperty : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ScopeKey>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ScopeKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
-TYPE Camunda.Orchestration.Sdk.SearchClientsForGroupRequest : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
-
-TYPE Camunda.Orchestration.Sdk.SearchClientsForGroupResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.GroupClientResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchClientsForRoleRequest : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
-
-TYPE Camunda.Orchestration.Sdk.SearchClientsForRoleResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.GroupClientResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchClientsForTenantRequest : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
-
-TYPE Camunda.Orchestration.Sdk.SearchClientsForTenantResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.GroupClientResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchMappingRuleResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MappingRuleResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchMappingRulesForGroupResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MappingRuleResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchMappingRulesForRoleResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MappingRuleResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchMappingRulesForTenantResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MappingRuleResult> Items { get; set; } [JsonPropertyName("items")]
-
 TYPE Camunda.Orchestration.Sdk.SearchQueryPageRequest : abstract class
   ATTR JsonDerivedType Camunda.Orchestration.Sdk.CursorBackwardPagination tag=<none>
   ATTR JsonDerivedType Camunda.Orchestration.Sdk.CursorForwardPagination tag=<none>
@@ -4161,69 +4400,6 @@ TYPE Camunda.Orchestration.Sdk.SearchQueryRequest : sealed class
 TYPE Camunda.Orchestration.Sdk.SearchQueryResponse : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-
-TYPE Camunda.Orchestration.Sdk.SearchRolesForGroupResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.RoleResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchRolesForTenantResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.RoleResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchUserTaskEffectiveVariablesRequest : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.OffsetPagination? Page { get; set; } [JsonPropertyName("page")]
-  PROP Camunda.Orchestration.Sdk.UserTaskVariableFilter? Filter { get; set; } [JsonPropertyName("filter")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
-
-TYPE Camunda.Orchestration.Sdk.SearchUserTaskVariablesRequest : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
-  PROP Camunda.Orchestration.Sdk.UserTaskVariableFilter? Filter { get; set; } [JsonPropertyName("filter")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
-
-TYPE Camunda.Orchestration.Sdk.SearchUsersForGroupRequest : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
-
-TYPE Camunda.Orchestration.Sdk.SearchUsersForGroupResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.GroupUserResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchUsersForRoleRequest : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
-
-TYPE Camunda.Orchestration.Sdk.SearchUsersForRoleResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.GroupUserResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchUsersForTenantRequest : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
-
-TYPE Camunda.Orchestration.Sdk.SearchUsersForTenantResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.GroupUserResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchUsersResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.UserCreateResult> Items { get; set; } [JsonPropertyName("items")]
-
-TYPE Camunda.Orchestration.Sdk.SearchVariablesRequest : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
-  PROP Camunda.Orchestration.Sdk.VariableFilter? Filter { get; set; } [JsonPropertyName("filter")]
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogSearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
 
 TYPE Camunda.Orchestration.Sdk.SetVariableRequest : sealed class
   CTOR ()
@@ -4319,7 +4495,7 @@ TYPE Camunda.Orchestration.Sdk.Tag : struct interfaces=[Camunda.Orchestration.Sd
 
 TYPE Camunda.Orchestration.Sdk.TenantClientResult : sealed class
   CTOR ()
-  PROP System.String ClientId { get; set; } [JsonPropertyName("clientId")]
+  PROP Camunda.Orchestration.Sdk.ClientId ClientId { get; set; } [JsonPropertyName("clientId")]
 
 TYPE Camunda.Orchestration.Sdk.TenantClientSearchQueryRequest : sealed class
   CTOR ()
@@ -4338,8 +4514,8 @@ TYPE Camunda.Orchestration.Sdk.TenantClientSearchResult : sealed class
 
 TYPE Camunda.Orchestration.Sdk.TenantCreateRequest : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
-  PROP System.String TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.String? Description { get; set; } [JsonPropertyName("description")]
 
 TYPE Camunda.Orchestration.Sdk.TenantCreateResult : sealed class
@@ -4361,7 +4537,7 @@ TYPE Camunda.Orchestration.Sdk.TenantFilterEnum : enum interfaces=[System.ICompa
 
 TYPE Camunda.Orchestration.Sdk.TenantGroupResult : sealed class
   CTOR ()
-  PROP System.String GroupId { get; set; } [JsonPropertyName("groupId")]
+  PROP Camunda.Orchestration.Sdk.GroupId GroupId { get; set; } [JsonPropertyName("groupId")]
 
 TYPE Camunda.Orchestration.Sdk.TenantGroupSearchQueryRequest : sealed class
   CTOR ()
@@ -4484,19 +4660,6 @@ TYPE Camunda.Orchestration.Sdk.UpdateGlobalTaskListenerRequest : sealed class
   PROP System.Int32? Retries { get; set; } [JsonPropertyName("retries")]
   PROP System.String Type { get; set; } [JsonPropertyName("type")]
 
-TYPE Camunda.Orchestration.Sdk.UpdateMappingRuleResponse : sealed class
-  CTOR ()
-  PROP System.String ClaimName { get; set; } [JsonPropertyName("claimName")]
-  PROP System.String ClaimValue { get; set; } [JsonPropertyName("claimValue")]
-  PROP System.String MappingRuleId { get; set; } [JsonPropertyName("mappingRuleId")]
-  PROP System.String Name { get; set; } [JsonPropertyName("name")]
-
-TYPE Camunda.Orchestration.Sdk.UpdateUserResponse : sealed class
-  CTOR ()
-  PROP Camunda.Orchestration.Sdk.Username Username { get; set; } [JsonPropertyName("username")]
-  PROP System.String? Email { get; set; } [JsonPropertyName("email")]
-  PROP System.String? Name { get; set; } [JsonPropertyName("name")]
-
 TYPE Camunda.Orchestration.Sdk.UsageMetricsResponse : sealed class
   CTOR ()
   PROP System.Collections.Generic.Dictionary<System.String,System.Object> Tenants { get; set; } [JsonPropertyName("tenants")]
@@ -4528,8 +4691,8 @@ TYPE Camunda.Orchestration.Sdk.UserFilter : sealed class
 
 TYPE Camunda.Orchestration.Sdk.UserRequest : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.Username Username { get; set; } [JsonPropertyName("username")]
   PROP System.String Password { get; set; } [JsonPropertyName("password")]
-  PROP System.String Username { get; set; } [JsonPropertyName("username")]
   PROP System.String? Email { get; set; } [JsonPropertyName("email")]
   PROP System.String? Name { get; set; } [JsonPropertyName("name")]
 
@@ -4595,9 +4758,9 @@ TYPE Camunda.Orchestration.Sdk.UserTaskFilter : sealed class
   PROP Camunda.Orchestration.Sdk.ElementId? ElementId { get; set; } [JsonPropertyName("elementId")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? Priority { get; set; } [JsonPropertyName("priority")]
-  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
-  PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
-  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionIdFilterProperty? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? Assignee { get; set; } [JsonPropertyName("assignee")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? CandidateGroup { get; set; } [JsonPropertyName("candidateGroup")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? CandidateUser { get; set; } [JsonPropertyName("candidateUser")]


### PR DESCRIPTION
Combined v10 migration PR that prepares the SDK for the v10 release (Camunda 8.10).

## Changes

### Bundler upgrade
- Upgrade `camunda-schema-bundler` from `^1.6.1` to `^2.4.1`
- v2.4.1 preserves upstream `$ref` names through dedup, eliminating 26 inline type names that diverged from the canonical upstream schemas

### Spec ref
- Change default `SPEC_REF` from `stable/8.9` to `main` in `scripts/bundle-spec.sh`
- The upstream `main` branch defines `x-semantic-type` annotations for `GroupId`, `RoleId`, `ClientId`, `MappingRuleId`, `AgentInstanceKey`, and `ClusterVariableName` — these are now generated as branded `readonly record struct`s

### Type renames (26 types)
The bundler dedup now preserves canonical upstream names. See `MIGRATION.md` for the full table. Examples:
- `SearchClientsForGroupRequest` → `GroupClientSearchQueryRequest`
- `CreateMappingRuleResponse` → `MappingRuleCreateResult`
- `GetUserResponse` → `UserResult`
- `SearchVariablesRequest` → `VariableSearchQuery`

### New branded types (6)
`GroupId`, `RoleId`, `ClientId`, `MappingRuleId`, `AgentInstanceKey`, `ClusterVariableName` — all implement `ICamundaKey`

### New API surface
- `GetAgentInstanceAsync` / `SearchAgentInstancesAsync` methods
- `AgentInstanceKey`, `AgentInstanceResult`, `AgentInstanceSearchQuery`, etc.

### Examples
- Updated all example files to use branded type parameters
- Fixed type renames across 5 example files
- Added `AgentInstance.cs` examples

### Migration guide
- Added `MIGRATION.md` with v9 → v10 migration instructions

## Verification
- SDK builds: 0 warnings, 0 errors
- Examples build: 0 warnings, 0 errors
- Tests: 811 passed (net8.0 + net10.0), public API baseline updated