### PR TITLE
fix: return byte[] for binary (octet-stream) response operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1006,6 +1006,12 @@ The following methods have updated parameter and/or return types to match the ty
 | `GetUserAsync` | Returns `UserResult` (was `GetUserResponse`) |
 | `SearchUsersAsync` | Returns `UserSearchResult` (was `SearchUsersResponse`) |
 | `UpdateUserAsync` | Returns `UserUpdateResult` (was `UpdateUserResponse`) |
+| `GetDocumentAsync` | Returns `byte[]` (was `object`) |
+| `GetResourceContentBinaryAsync` | Returns `byte[]` (new in v10) |
+
+#### Binary response handling
+
+Operations that return `application/octet-stream` content (such as `GetDocumentAsync`) now correctly return `byte[]` instead of `object`. In v9, these methods attempted to JSON-deserialize the binary response body, which threw `JsonException` for non-JSON content and returned an unusable `JsonElement` for JSON content. No migration action is needed unless your code caught the `JsonException` and worked around it.
 
 #### Inline string enums
 

--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -229,6 +229,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.CreateAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceCreationRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/AgentInstance.cs#CreateAgentInstance)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.CreateAuthorizationAsync(Camunda.Orchestration.Sdk.AuthorizationRequest,System.Threading.CancellationToken)
 example:
 - *content
@@ -733,6 +743,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.GetFormByKeyAsync(Camunda.Orchestration.Sdk.FormKey,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.FormResult},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Admin.cs#GetFormByKey)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.GetGlobalClusterVariableAsync(System.String,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.ClusterVariableResult},System.Threading.CancellationToken)
 example:
 - *content
@@ -980,6 +1000,16 @@ example:
 
 
 [!code-csharp[](../../examples/Deployment.cs#GetResourceContent)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.GetResourceContentBinaryAsync(Camunda.Orchestration.Sdk.ResourceKey,Camunda.Orchestration.Sdk.ConsistencyOptions{System.Byte[]},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Admin.cs#GetResourceContentBinary)]
 
 
 ---
@@ -1820,6 +1850,16 @@ example:
 
 
 [!code-csharp[](../../examples/UserTask.cs#UnassignUserTask)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.UpdateAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceKey,Camunda.Orchestration.Sdk.AgentInstanceUpdateRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/AgentInstance.cs#UpdateAgentInstance)]
 
 
 ---

--- a/examples/Admin.cs
+++ b/examples/Admin.cs
@@ -338,6 +338,19 @@ public static class AdminExamples
     // </EvaluateExpression>
     #endregion EvaluateExpression
 
+    #region GetFormByKey
+
+    // <GetFormByKey>
+    public static async Task GetFormByKeyExample(FormKey formKey)
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.GetFormByKeyAsync(formKey);
+        Console.WriteLine($"Form: {result.FormId}, version: {result.Version}");
+    }
+    // </GetFormByKey>
+    #endregion GetFormByKey
+
     #region GetResource
 
     // <GetResource>
@@ -363,6 +376,19 @@ public static class AdminExamples
     }
     // </GetResourceContent>
     #endregion GetResourceContent
+
+    #region GetResourceContentBinary
+
+    // <GetResourceContentBinary>
+    public static async Task GetResourceContentBinaryExample(ResourceKey resourceKey)
+    {
+        using var client = CamundaClient.Create();
+
+        byte[] content = await client.GetResourceContentBinaryAsync(resourceKey);
+        Console.WriteLine($"Binary content length: {content.Length} bytes");
+    }
+    // </GetResourceContentBinary>
+    #endregion GetResourceContentBinary
 
     #region SearchResources
 

--- a/examples/AgentInstance.cs
+++ b/examples/AgentInstance.cs
@@ -32,4 +32,52 @@ public static class AgentInstanceExamples
     }
     // </SearchAgentInstances>
     #endregion SearchAgentInstances
+
+    #region CreateAgentInstance
+
+    // <CreateAgentInstance>
+    public static async Task CreateAgentInstanceExample(ElementInstanceKey elementInstanceKey)
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.CreateAgentInstanceAsync(new AgentInstanceCreationRequest
+        {
+            ElementInstanceKey = elementInstanceKey,
+            Definition = new AgentInstanceDefinition
+            {
+                Model = "gpt-4o",
+                Provider = "openai",
+                SystemPrompt = "You are a helpful assistant.",
+            },
+        });
+
+        Console.WriteLine($"Created agent instance: {result.AgentInstanceKey}");
+    }
+    // </CreateAgentInstance>
+    #endregion CreateAgentInstance
+
+    #region UpdateAgentInstance
+
+    // <UpdateAgentInstance>
+    public static async Task UpdateAgentInstanceExample(AgentInstanceKey agentInstanceKey)
+    {
+        using var client = CamundaClient.Create();
+
+        await client.UpdateAgentInstanceAsync(
+            agentInstanceKey,
+            new AgentInstanceUpdateRequest
+            {
+                Status = AgentInstanceStatusEnum.THINKING,
+                Metrics = new AgentInstanceMetricsDelta
+                {
+                    InputTokens = 150,
+                    OutputTokens = 50,
+                    ModelCalls = 1,
+                },
+            });
+
+        Console.WriteLine($"Updated agent instance: {agentInstanceKey}");
+    }
+    // </UpdateAgentInstance>
+    #endregion UpdateAgentInstance
 }

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -13,6 +13,20 @@
       "label": "Search agent instances"
     }
   ],
+  "createAgentInstance": [
+    {
+      "file": "AgentInstance.cs",
+      "region": "CreateAgentInstance",
+      "label": "Create an agent instance"
+    }
+  ],
+  "updateAgentInstance": [
+    {
+      "file": "AgentInstance.cs",
+      "region": "UpdateAgentInstance",
+      "label": "Update an agent instance"
+    }
+  ],
   "getTopology": [
     {
       "file": "Client.cs",
@@ -165,6 +179,13 @@
       "label": "Get start process form"
     }
   ],
+  "getFormByKey": [
+    {
+      "file": "Admin.cs",
+      "region": "GetFormByKey",
+      "label": "Get a form by key"
+    }
+  ],
   "createDeployment": [
     {
       "file": "Deployment.cs",
@@ -191,6 +212,13 @@
       "file": "Admin.cs",
       "region": "GetResourceContent",
       "label": "Get resource content"
+    }
+  ],
+  "getResourceContentBinary": [
+    {
+      "file": "Admin.cs",
+      "region": "GetResourceContentBinary",
+      "label": "Get resource content as binary"
     }
   ],
   "searchResources": [

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -86,6 +86,9 @@
       "name": "Expression"
     },
     {
+      "name": "Form"
+    },
+    {
       "name": "Global listener"
     },
     {
@@ -147,6 +150,107 @@
     }
   ],
   "paths": {
+    "/agent-instances": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Agent instance"
+        ],
+        "operationId": "createAgentInstance",
+        "summary": "Create agent instance",
+        "description": "Creates a new agent instance. The returned key identifies the instance and must\nbe used in subsequent update and query calls.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstanceCreationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The agent instance was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstanceCreationResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The elementInstanceKey does not correspond to an active element instance.\nMore details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/agent-instances/{agentInstanceKey}": {
       "get": {
         "x-eventually-consistent": true,
@@ -177,6 +281,109 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The agent instance with the given key was not found.\nMore details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      },
+      "patch": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Agent instance"
+        ],
+        "operationId": "updateAgentInstance",
+        "summary": "Update agent instance",
+        "description": "Updates the mutable fields of an agent instance: status, metric counters, and\ntools. Metric values are treated as deltas and applied immediately to the\naggregate counters. Tool updates replace the existing tool list. At least one of\nstatus, metrics, or tools must be provided.\n",
+        "parameters": [
+          {
+            "name": "agentInstanceKey",
+            "in": "path",
+            "required": true,
+            "description": "The key of the agent instance to update.",
+            "schema": {
+              "$ref": "#/components/schemas/AgentInstanceKey"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstanceUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "The agent instance was updated successfully."
           },
           "400": {
             "description": "The provided data is not valid.",
@@ -4609,6 +4816,98 @@
           }
         },
         "x-added-in-version": "8.9"
+      }
+    },
+    "/forms/{formKey}": {
+      "get": {
+        "x-eventually-consistent": true,
+        "tags": [
+          "Form"
+        ],
+        "operationId": "getFormByKey",
+        "summary": "Get form by key",
+        "description": "Get a form by its unique form key.\n",
+        "parameters": [
+          {
+            "name": "formKey",
+            "in": "path",
+            "required": true,
+            "description": "The form key.",
+            "schema": {
+              "$ref": "#/components/schemas/FormKey"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The form is successfully returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The form with the given key was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
       }
     },
     "/global-task-listeners": {
@@ -11080,13 +11379,24 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": true
                 }
               }
             }
           },
           "404": {
-            "description": "An RPA resource with the given key was not found.",
+            "description": "A resource with the given key was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "The resource exists but is not an RPA resource.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -11107,6 +11417,62 @@
           }
         },
         "x-added-in-version": "8.7"
+      }
+    },
+    "/resources/{resourceKey}/content/binary": {
+      "get": {
+        "x-eventually-consistent": true,
+        "tags": [
+          "Resource"
+        ],
+        "operationId": "getResourceContentBinary",
+        "summary": "Get resource content as binary",
+        "description": "Returns the content of a deployed resource in binary format (octet-stream).\n:::info\nThis endpoint does not return BPMN process definitions, DMN decision definitions, or form\nresources. To query BPMN process definitions or DMN decision definitions, use their\nrespective APIs.\n:::\n",
+        "parameters": [
+          {
+            "name": "resourceKey",
+            "in": "path",
+            "required": true,
+            "description": "The unique key identifying the resource.",
+            "schema": {
+              "$ref": "#/components/schemas/ResourceKey"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The resource content is successfully returned.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "A resource with the given key was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.11"
       }
     },
     "/resources/{resourceKey}/deletion": {
@@ -16844,6 +17210,7 @@
           "definition",
           "metrics",
           "limits",
+          "tools",
           "elementId",
           "processInstanceKey",
           "processDefinitionKey",
@@ -16887,6 +17254,13 @@
                 "$ref": "#/components/schemas/AgentInstanceLimits"
               }
             ]
+          },
+          "tools": {
+            "description": "The tools available to the agent.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentTool"
+            }
           },
           "elementId": {
             "description": "The BPMN element ID of the ad-hoc sub-process or AI agent task that owns this agent instance.",
@@ -16961,6 +17335,31 @@
           }
         }
       },
+      "AgentTool": {
+        "description": "A tool available to the agent.",
+        "type": "object",
+        "required": [
+          "name",
+          "description",
+          "elementId"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The tool name as visible to the LLM."
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "A human-readable description of the tool."
+          },
+          "elementId": {
+            "type": "string",
+            "nullable": true,
+            "description": "The BPMN element ID of the tool element within the ad-hoc sub-process."
+          }
+        }
+      },
       "AgentInstanceMetrics": {
         "description": "Aggregated metrics for an agent instance across all model calls.",
         "type": "object",
@@ -17030,6 +17429,119 @@
           "TOOL_CALLING",
           "TOOL_DISCOVERY"
         ]
+      },
+      "AgentInstanceCreationRequest": {
+        "description": "Request to create a new agent instance.",
+        "type": "object",
+        "required": [
+          "elementInstanceKey",
+          "definition"
+        ],
+        "properties": {
+          "elementInstanceKey": {
+            "description": "The key of the AHSP or AI Agent Task element instance.\nThe engine uses this key to infer processInstanceKey, elementId,\nprocessDefinitionKey, and tenantId.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementInstanceKey"
+              }
+            ]
+          },
+          "definition": {
+            "description": "Static definition set once at creation.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceDefinition"
+              }
+            ]
+          },
+          "limits": {
+            "description": "Limits for the agent execution. When omitted, all limits default to -1\n(no limit).\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceLimits"
+              }
+            ]
+          }
+        }
+      },
+      "AgentInstanceCreationResult": {
+        "description": "Response returned after successfully creating an agent instance.",
+        "type": "object",
+        "x-semantic-provider": [
+          "agentInstanceKey"
+        ],
+        "required": [
+          "agentInstanceKey"
+        ],
+        "properties": {
+          "agentInstanceKey": {
+            "description": "The system-generated key for the created agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceKey"
+              }
+            ]
+          }
+        }
+      },
+      "AgentInstanceMetricsDelta": {
+        "description": "Metric increments to apply to the agent instance aggregate counters. The engine\naccumulates these deltas into running totals on each UPDATED event. All fields\nare optional; omit a field to leave the corresponding counter unchanged.\n",
+        "type": "object",
+        "properties": {
+          "inputTokens": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "description": "Increment to apply to the total input token counter."
+          },
+          "outputTokens": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "description": "Increment to apply to the total output token counter."
+          },
+          "modelCalls": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "description": "Increment to apply to the total model call counter."
+          },
+          "toolCalls": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "description": "Increment to apply to the total tool call counter."
+          }
+        }
+      },
+      "AgentInstanceUpdateRequest": {
+        "description": "Request to update the mutable state of an agent instance. At least one of\nstatus, metrics, or tools must be provided.\n",
+        "type": "object",
+        "properties": {
+          "status": {
+            "description": "The new status of the agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceStatusEnum"
+              }
+            ]
+          },
+          "metrics": {
+            "description": "Metric increments to apply to the aggregate counters.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceMetricsDelta"
+              }
+            ]
+          },
+          "tools": {
+            "description": "The complete list of tools available to the agent, replacing any previously\nstored tools. When provided, the engine replaces the existing tool list with\nthis value.\n",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentTool"
+            }
+          }
+        }
       },
       "AgentInstanceStatusFilterProperty": {
         "description": "AgentInstanceStatusEnum property with full advanced search capabilities.",
@@ -22220,7 +22732,8 @@
           "processDefinitionKey",
           "rootProcessInstanceKey",
           "endDate",
-          "incidentKey"
+          "incidentKey",
+          "agentInstanceKey"
         ],
         "properties": {
           "processDefinitionId": {
@@ -22347,6 +22860,15 @@
               }
             ],
             "description": "Incident key associated with this element instance.",
+            "nullable": true
+          },
+          "agentInstanceKey": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceKey"
+              }
+            ],
+            "description": "The agent instance key associated with this element instance.",
             "nullable": true
           }
         }

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -109,7 +109,7 @@ internal static class CSharpClientGenerator
                     c.Key.Contains("multipart", StringComparison.OrdinalIgnoreCase)) == true;
 
                 var bodySchemaRef = hasBody ? GetBodySchemaRef(op) : null;
-                var responseSchemaRef = GetResponseSchemaRef(op);
+                var responseSchemaRef = GetResponseSchemaRef(doc, op);
 
                 // Use pre-computed metadata for behavioral flags
                 var metaEntry = metadata.GetOperation(op.OperationId);
@@ -210,7 +210,7 @@ internal static class CSharpClientGenerator
         return null;
     }
 
-    private static string? GetResponseSchemaRef(OpenApiOperation op)
+    private static string? GetResponseSchemaRef(OpenApiDocument doc, OpenApiOperation op)
     {
         if (op.Responses == null)
             return null;
@@ -224,15 +224,28 @@ internal static class CSharpClientGenerator
             foreach (var (contentType, mediaType) in response.Content)
             {
                 // Binary (octet-stream) responses return byte[]
-                if (contentType.Contains("octet-stream", StringComparison.OrdinalIgnoreCase)
-                    || mediaType.Schema?.Format == "binary")
+                if (contentType.Contains("octet-stream", StringComparison.OrdinalIgnoreCase))
                     return "byte[]";
 
-                if (GetRefId(mediaType.Schema) != null)
-                    return SanitizeTypeName(GetRefId(mediaType.Schema)!);
+                // Resolve $ref before checking format so that referenced
+                // schemas with format: binary are detected correctly.
+                var schema = mediaType.Schema;
+                var refId = GetRefId(schema);
+                if (refId != null
+                    && doc.Components?.Schemas != null
+                    && doc.Components.Schemas.TryGetValue(refId, out var resolved))
+                {
+                    if (resolved.Format == "binary")
+                        return "byte[]";
+                    return SanitizeTypeName(refId);
+                }
+
+                if (schema?.Format == "binary")
+                    return "byte[]";
+
                 // Only create an inline class when the schema has actual properties.
                 // Bare {type: object} with no properties maps to 'object' via MapPrimitiveType.
-                if (mediaType.Schema?.Properties?.Count > 0)
+                if (schema?.Properties?.Count > 0)
                     return SanitizeOperationId(op.OperationId!) + "Response";
             }
         }

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -186,6 +186,7 @@ internal static class CSharpClientGenerator
                     Description = op.Description,
                     Tags = op.Tags?.Select(t => t.Name ?? string.Empty).ToList() ?? [],
                     IsExemptFromBackpressure = IsExempt(opId),
+                    IsBinaryResponse = responseTypeName == "byte[]",
                 });
             }
         }
@@ -220,8 +221,13 @@ internal static class CSharpClientGenerator
             if (response.Content == null || response.Content.Count == 0)
                 return null;
 
-            foreach (var (_, mediaType) in response.Content)
+            foreach (var (contentType, mediaType) in response.Content)
             {
+                // Binary (octet-stream) responses return byte[]
+                if (contentType.Contains("octet-stream", StringComparison.OrdinalIgnoreCase)
+                    || mediaType.Schema?.Format == "binary")
+                    return "byte[]";
+
                 if (GetRefId(mediaType.Schema) != null)
                     return SanitizeTypeName(GetRefId(mediaType.Schema)!);
                 // Only create an inline class when the schema has actual properties.
@@ -1299,6 +1305,12 @@ internal static class CSharpClientGenerator
                     sb.AppendLine($"                () => InvokeWithRetryAsync(() => SendMultipartAsync<{op.ResponseTypeName}>(path, content, ct), \"{op.OriginalOperationId}\", {op.IsExemptFromBackpressure.ToString().ToLowerInvariant()}, ct),");
                     sb.AppendLine($"                consistency!, _logger, ct);");
                 }
+                else if (op.IsBinaryResponse)
+                {
+                    sb.AppendLine($"            return await EventualPoller.PollAsync(\"{op.OriginalOperationId}\", {isGetLiteral},");
+                    sb.AppendLine($"                () => InvokeWithRetryAsync(() => SendBinaryAsync({httpMethod}, path, {bodyArg}, ct), \"{op.OriginalOperationId}\", {op.IsExemptFromBackpressure.ToString().ToLowerInvariant()}, ct),");
+                    sb.AppendLine($"                consistency!, _logger, ct);");
+                }
                 else
                 {
                     sb.AppendLine($"            return await EventualPoller.PollAsync(\"{op.OriginalOperationId}\", {isGetLiteral},");
@@ -1318,6 +1330,10 @@ internal static class CSharpClientGenerator
         else if (op.IsVoidResponse)
         {
             sb.AppendLine($"        await InvokeWithRetryAsync(async () => {{ await SendVoidAsync({httpMethod}, path, {bodyArg}, ct); return 0; }}, \"{op.OriginalOperationId}\", {op.IsExemptFromBackpressure.ToString().ToLowerInvariant()}, ct);");
+        }
+        else if (op.IsBinaryResponse)
+        {
+            sb.AppendLine($"        return await InvokeWithRetryAsync(() => SendBinaryAsync({httpMethod}, path, {bodyArg}, ct), \"{op.OriginalOperationId}\", {op.IsExemptFromBackpressure.ToString().ToLowerInvariant()}, ct);");
         }
         else
         {
@@ -2064,6 +2080,7 @@ internal sealed class OperationMeta
     public required bool IsExemptFromBackpressure { get; init; }
     public required bool HasOptionalTenantIdInBody { get; init; }
     public required bool HasOptionalTenantIdsInBody { get; init; }
+    public required bool IsBinaryResponse { get; init; }
 }
 
 internal readonly record struct ParamMeta(string Name, string Type, bool Required);

--- a/src/Camunda.Orchestration.Sdk/CamundaClient.cs
+++ b/src/Camunda.Orchestration.Sdk/CamundaClient.cs
@@ -223,6 +223,44 @@ public partial class CamundaClient : IDisposable
     }
 
     /// <summary>
+    /// Execute an HTTP request and return the response body as raw bytes.
+    /// Used for operations that return application/octet-stream (binary content).
+    /// </summary>
+    internal async Task<byte[]> SendBinaryAsync(
+        HttpMethod method,
+        string path,
+        object? body = null,
+        CancellationToken ct = default)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+            _logger.LogDebug("HTTP {Method} {Path} (binary)", method, path);
+
+        var relativePath = path.TrimStart('/');
+        using var request = new HttpRequestMessage(method, relativePath);
+
+        if (body != null)
+        {
+            var json = JsonSerializer.Serialize(body, _jsonOptions);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        using var response = await _httpClient.SendAsync(request, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(ct);
+            if (_logger.IsEnabled(LogLevel.Warning))
+                _logger.LogWarning("HTTP {Method} {Path} (binary) failed with {Status}", method, path, (int)response.StatusCode);
+            throw BuildHttpException(response.StatusCode, errorBody, path);
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+            _logger.LogDebug("HTTP {Method} {Path} (binary) -> {Status}", method, path, (int)response.StatusCode);
+
+        return await response.Content.ReadAsByteArrayAsync(ct);
+    }
+
+    /// <summary>
     /// Send a multipart/form-data request (used for deployment).
     /// </summary>
     internal async Task<TResponse> SendMultipartAsync<TResponse>(

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -911,6 +911,63 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Create agent instance
+    /// Creates a new agent instance. The returned key identifies the instance and must
+    /// be used in subsequent update and query calls.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: createAgentInstance
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task CreateAgentInstanceExample(ElementInstanceKey elementInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.CreateAgentInstanceAsync(new AgentInstanceCreationRequest
+    ///     {
+    ///         ElementInstanceKey = elementInstanceKey,
+    ///         Definition = new AgentInstanceDefinition
+    ///         {
+    ///             Model = &quot;gpt-4o&quot;,
+    ///             Provider = &quot;openai&quot;,
+    ///             SystemPrompt = &quot;You are a helpful assistant.&quot;,
+    ///         },
+    ///     });
+    /// 
+    ///     Console.WriteLine($&quot;Created agent instance: {result.AgentInstanceKey}&quot;);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task CreateAgentInstanceExample(ElementInstanceKey elementInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.CreateAgentInstanceAsync(new AgentInstanceCreationRequest
+    ///     {
+    ///         ElementInstanceKey = elementInstanceKey,
+    ///         Definition = new AgentInstanceDefinition
+    ///         {
+    ///             Model = &quot;gpt-4o&quot;,
+    ///             Provider = &quot;openai&quot;,
+    ///             SystemPrompt = &quot;You are a helpful assistant.&quot;,
+    ///         },
+    ///     });
+    /// 
+    ///     Console.WriteLine($&quot;Created agent instance: {result.AgentInstanceKey}&quot;);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<AgentInstanceCreationResult> CreateAgentInstanceAsync(AgentInstanceCreationRequest body, CancellationToken ct = default)
+    {
+        var path = $"/agent-instances";
+        return await InvokeWithRetryAsync(() => SendAsync<AgentInstanceCreationResult>(HttpMethod.Post, path, body, ct), "createAgentInstance", false, ct);
+    }
+
+    /// <summary>
     /// Create authorization
     /// Create the authorization.
     /// </summary>
@@ -2920,13 +2977,13 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<object> GetDocumentAsync(DocumentId documentId, string? storeId = null, string? contentHash = null, CancellationToken ct = default)
+    public async Task<byte[]> GetDocumentAsync(DocumentId documentId, string? storeId = null, string? contentHash = null, CancellationToken ct = default)
     {
         var queryParts = new List<string>();
         if (storeId != null) queryParts.Add($"storeId={Uri.EscapeDataString(storeId.ToString()!)}");
         if (contentHash != null) queryParts.Add($"contentHash={Uri.EscapeDataString(contentHash.ToString()!)}");
         var path = queryParts.Count > 0 ? $"/documents/{Uri.EscapeDataString(documentId.ToString()!)}?{string.Join("&", queryParts)}" : $"/documents/{Uri.EscapeDataString(documentId.ToString()!)}";
-        return await InvokeWithRetryAsync(() => SendAsync<object>(HttpMethod.Get, path, null, ct), "getDocument", false, ct);
+        return await InvokeWithRetryAsync(() => SendBinaryAsync(HttpMethod.Get, path, null, ct), "getDocument", false, ct);
     }
 
     /// <summary>
@@ -2973,6 +3030,49 @@ public partial class CamundaClient
         }
 
         return await InvokeWithRetryAsync(() => SendAsync<ElementInstanceResult>(HttpMethod.Get, path, null, ct), "getElementInstance", false, ct);
+    }
+
+    /// <summary>
+    /// Get form by key
+    /// Get a form by its unique form key.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: getFormByKey
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task GetFormByKeyExample(FormKey formKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.GetFormByKeyAsync(formKey);
+    ///     Console.WriteLine($&quot;Form: {result.FormId}, version: {result.Version}&quot;);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task GetFormByKeyExample(FormKey formKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.GetFormByKeyAsync(formKey);
+    ///     Console.WriteLine($&quot;Form: {result.FormId}, version: {result.Version}&quot;);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<FormResult> GetFormByKeyAsync(FormKey formKey, ConsistencyOptions<FormResult>? consistency = null, CancellationToken ct = default)
+    {
+        var path = $"/forms/{Uri.EscapeDataString(formKey.ToString()!)}";
+        if (consistency != null && consistency.WaitUpToMs > 0)
+        {
+            return await EventualPoller.PollAsync("getFormByKey", true,
+                () => InvokeWithRetryAsync(() => SendAsync<FormResult>(HttpMethod.Get, path, null, ct), "getFormByKey", false, ct),
+                consistency!, _logger, ct);
+        }
+
+        return await InvokeWithRetryAsync(() => SendAsync<FormResult>(HttpMethod.Get, path, null, ct), "getFormByKey", false, ct);
     }
 
     /// <summary>
@@ -4208,6 +4308,54 @@ public partial class CamundaClient
         }
 
         return await InvokeWithRetryAsync(() => SendAsync<object>(HttpMethod.Get, path, null, ct), "getResourceContent", false, ct);
+    }
+
+    /// <summary>
+    /// Get resource content as binary
+    /// Returns the content of a deployed resource in binary format (octet-stream).
+    /// :::info
+    /// This endpoint does not return BPMN process definitions, DMN decision definitions, or form
+    /// resources. To query BPMN process definitions or DMN decision definitions, use their
+    /// respective APIs.
+    /// :::
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: getResourceContentBinary
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task GetResourceContentBinaryExample(ResourceKey resourceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     byte[] content = await client.GetResourceContentBinaryAsync(resourceKey);
+    ///     Console.WriteLine($&quot;Binary content length: {content.Length} bytes&quot;);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task GetResourceContentBinaryExample(ResourceKey resourceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     byte[] content = await client.GetResourceContentBinaryAsync(resourceKey);
+    ///     Console.WriteLine($&quot;Binary content length: {content.Length} bytes&quot;);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<byte[]> GetResourceContentBinaryAsync(ResourceKey resourceKey, ConsistencyOptions<byte[]>? consistency = null, CancellationToken ct = default)
+    {
+        var path = $"/resources/{Uri.EscapeDataString(resourceKey.ToString()!)}/content/binary";
+        if (consistency != null && consistency.WaitUpToMs > 0)
+        {
+            return await EventualPoller.PollAsync("getResourceContentBinary", true,
+                () => InvokeWithRetryAsync(() => SendBinaryAsync(HttpMethod.Get, path, null, ct), "getResourceContentBinary", false, ct),
+                consistency!, _logger, ct);
+        }
+
+        return await InvokeWithRetryAsync(() => SendBinaryAsync(HttpMethod.Get, path, null, ct), "getResourceContentBinary", false, ct);
     }
 
     /// <summary>
@@ -8067,6 +8215,69 @@ public partial class CamundaClient
     {
         var path = $"/user-tasks/{Uri.EscapeDataString(userTaskKey.ToString()!)}/assignee";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "unassignUserTask", false, ct);
+    }
+
+    /// <summary>
+    /// Update agent instance
+    /// Updates the mutable fields of an agent instance: status, metric counters, and
+    /// tools. Metric values are treated as deltas and applied immediately to the
+    /// aggregate counters. Tool updates replace the existing tool list. At least one of
+    /// status, metrics, or tools must be provided.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: updateAgentInstance
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task UpdateAgentInstanceExample(AgentInstanceKey agentInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     await client.UpdateAgentInstanceAsync(
+    ///         agentInstanceKey,
+    ///         new AgentInstanceUpdateRequest
+    ///         {
+    ///             Status = AgentInstanceStatusEnum.THINKING,
+    ///             Metrics = new AgentInstanceMetricsDelta
+    ///             {
+    ///                 InputTokens = 150,
+    ///                 OutputTokens = 50,
+    ///                 ModelCalls = 1,
+    ///             },
+    ///         });
+    /// 
+    ///     Console.WriteLine($&quot;Updated agent instance: {agentInstanceKey}&quot;);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task UpdateAgentInstanceExample(AgentInstanceKey agentInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     await client.UpdateAgentInstanceAsync(
+    ///         agentInstanceKey,
+    ///         new AgentInstanceUpdateRequest
+    ///         {
+    ///             Status = AgentInstanceStatusEnum.THINKING,
+    ///             Metrics = new AgentInstanceMetricsDelta
+    ///             {
+    ///                 InputTokens = 150,
+    ///                 OutputTokens = 50,
+    ///                 ModelCalls = 1,
+    ///             },
+    ///         });
+    /// 
+    ///     Console.WriteLine($&quot;Updated agent instance: {agentInstanceKey}&quot;);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task UpdateAgentInstanceAsync(AgentInstanceKey agentInstanceKey, AgentInstanceUpdateRequest body, CancellationToken ct = default)
+    {
+        var path = $"/agent-instances/{Uri.EscapeDataString(agentInstanceKey.ToString()!)}";
+        await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Patch, path, body, ct); return 0; }, "updateAgentInstance", false, ct);
     }
 
     /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -3081,6 +3081,49 @@ public sealed class AdvancedVariableKeyFilter
 }
 
 /// <summary>
+/// Request to create a new agent instance.
+/// </summary>
+public sealed class AgentInstanceCreationRequest
+{
+    /// <summary>
+    /// The key of the AHSP or AI Agent Task element instance.
+    /// The engine uses this key to infer processInstanceKey, elementId,
+    /// processDefinitionKey, and tenantId.
+    /// 
+    /// </summary>
+    [JsonPropertyName("elementInstanceKey")]
+    public ElementInstanceKey ElementInstanceKey { get; set; }
+
+    /// <summary>
+    /// Static definition set once at creation.
+    /// </summary>
+    [JsonPropertyName("definition")]
+    public AgentInstanceDefinition Definition { get; set; } = null!;
+
+    /// <summary>
+    /// Limits for the agent execution. When omitted, all limits default to -1
+    /// (no limit).
+    /// 
+    /// </summary>
+    [JsonPropertyName("limits")]
+    public AgentInstanceLimits? Limits { get; set; }
+
+}
+
+/// <summary>
+/// Response returned after successfully creating an agent instance.
+/// </summary>
+public sealed class AgentInstanceCreationResult
+{
+    /// <summary>
+    /// The system-generated key for the created agent instance.
+    /// </summary>
+    [JsonPropertyName("agentInstanceKey")]
+    public AgentInstanceKey AgentInstanceKey { get; set; }
+
+}
+
+/// <summary>
 /// The static definition of an agent instance, set once at creation.
 /// </summary>
 public sealed class AgentInstanceDefinition
@@ -3316,6 +3359,40 @@ public sealed class AgentInstanceMetrics
 }
 
 /// <summary>
+/// Metric increments to apply to the agent instance aggregate counters. The engine
+/// accumulates these deltas into running totals on each UPDATED event. All fields
+/// are optional; omit a field to leave the corresponding counter unchanged.
+/// 
+/// </summary>
+public sealed class AgentInstanceMetricsDelta
+{
+    /// <summary>
+    /// Increment to apply to the total input token counter.
+    /// </summary>
+    [JsonPropertyName("inputTokens")]
+    public long? InputTokens { get; set; }
+
+    /// <summary>
+    /// Increment to apply to the total output token counter.
+    /// </summary>
+    [JsonPropertyName("outputTokens")]
+    public long? OutputTokens { get; set; }
+
+    /// <summary>
+    /// Increment to apply to the total model call counter.
+    /// </summary>
+    [JsonPropertyName("modelCalls")]
+    public long? ModelCalls { get; set; }
+
+    /// <summary>
+    /// Increment to apply to the total tool call counter.
+    /// </summary>
+    [JsonPropertyName("toolCalls")]
+    public long? ToolCalls { get; set; }
+
+}
+
+/// <summary>
 /// AgentInstanceResult
 /// </summary>
 public sealed class AgentInstanceResult
@@ -3349,6 +3426,12 @@ public sealed class AgentInstanceResult
     /// </summary>
     [JsonPropertyName("limits")]
     public AgentInstanceLimits Limits { get; set; } = null!;
+
+    /// <summary>
+    /// The tools available to the agent.
+    /// </summary>
+    [JsonPropertyName("tools")]
+    public List<AgentTool> Tools { get; set; } = null!;
 
     /// <summary>
     /// The BPMN element ID of the ad-hoc sub-process or AI agent task that owns this agent instance.
@@ -3547,6 +3630,61 @@ public sealed class AgentInstanceStatusFilterProperty
     /// </summary>
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
+/// Request to update the mutable state of an agent instance. At least one of
+/// status, metrics, or tools must be provided.
+/// 
+/// </summary>
+public sealed class AgentInstanceUpdateRequest
+{
+    /// <summary>
+    /// The new status of the agent instance.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public AgentInstanceStatusEnum? Status { get; set; }
+
+    /// <summary>
+    /// Metric increments to apply to the aggregate counters.
+    /// </summary>
+    [JsonPropertyName("metrics")]
+    public AgentInstanceMetricsDelta? Metrics { get; set; }
+
+    /// <summary>
+    /// The complete list of tools available to the agent, replacing any previously
+    /// stored tools. When provided, the engine replaces the existing tool list with
+    /// this value.
+    /// 
+    /// </summary>
+    [JsonPropertyName("tools")]
+    public List<AgentTool>? Tools { get; set; }
+
+}
+
+/// <summary>
+/// A tool available to the agent.
+/// </summary>
+public sealed class AgentTool
+{
+    /// <summary>
+    /// The tool name as visible to the LLM.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// A human-readable description of the tool.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The BPMN element ID of the tool element within the ad-hoc sub-process.
+    /// </summary>
+    [JsonPropertyName("elementId")]
+    public string? ElementId { get; set; }
 
 }
 
@@ -9251,6 +9389,12 @@ public sealed class ElementInstanceResult
     /// </summary>
     [JsonPropertyName("incidentKey")]
     public IncidentKey? IncidentKey { get; set; }
+
+    /// <summary>
+    /// The agent instance key associated with this element instance.
+    /// </summary>
+    [JsonPropertyName("agentInstanceKey")]
+    public AgentInstanceKey? AgentInstanceKey { get; set; }
 
 }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:2cba5615c6167400476e32ea604aced0ef54967fbd3e65d0ae8f00765a767af0";
+    public const string SpecHash = "sha256:433d1df1fd5ef63f976db57af8ba03e9dbf47bd9cb64e2ff353415b21bacf000";
 }

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -130,7 +130,7 @@ public static class ConfigurationHydrator
         // IConfiguration section (appsettings.json etc.) — between env and overrides in precedence
         if (configuration != null)
         {
-            var configValues = ExtractFromConfiguration((IConfiguration)configuration);
+            var configValues = ExtractFromConfiguration(configuration);
             foreach (var (k, v) in configValues)
             {
                 // Configuration wins over env vars but loses to explicit overrides

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -130,7 +130,7 @@ public static class ConfigurationHydrator
         // IConfiguration section (appsettings.json etc.) — between env and overrides in precedence
         if (configuration != null)
         {
-            var configValues = ExtractFromConfiguration(configuration);
+            var configValues = ExtractFromConfiguration((IConfiguration)configuration);
             foreach (var (k, v) in configValues)
             {
                 // Configuration wins over env vars but loses to explicit overrides

--- a/test/Camunda.Orchestration.Sdk.Tests/BinarySendTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/BinarySendTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Tests for the binary response path (SendBinaryAsync).
+/// Verifies that octet-stream endpoints return raw byte[] and
+/// that non-2xx responses still throw HttpSdkException.
+/// </summary>
+public class BinarySendTests : IDisposable
+{
+    private readonly MockHttpMessageHandler _handler;
+
+    public BinarySendTests()
+    {
+        _handler = new MockHttpMessageHandler();
+    }
+
+    private CamundaClient CreateClient()
+    {
+        return new CamundaClient(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            },
+            HttpMessageHandler = _handler,
+        });
+    }
+
+    [Fact]
+    public async Task SendBinaryAsync_ReturnsExactBytes()
+    {
+        var expected = new byte[] { 0x00, 0x50, 0x4E, 0x47, 0xFF, 0xD8, 0x01, 0x02 };
+        _handler.Enqueue(r => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(expected),
+        });
+
+        using var client = CreateClient();
+        var docId = DocumentId.AssumeExists("doc-123");
+
+        var result = await client.GetDocumentAsync(docId);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task SendBinaryAsync_ThrowsOnNon2xxResponse()
+    {
+        _handler.Enqueue(HttpStatusCode.NotFound,
+            """{"title":"NOT_FOUND","detail":"Document not found"}""");
+
+        using var client = CreateClient();
+        var docId = DocumentId.AssumeExists("doc-123");
+
+        var act = async () => await client.GetDocumentAsync(docId);
+        var ex = await Assert.ThrowsAsync<HttpSdkException>(act);
+        Assert.Equal(404, ex.Status);
+    }
+
+    [Fact]
+    public async Task SendBinaryAsync_ReturnsEmptyArrayForEmptyBody()
+    {
+        _handler.Enqueue(r => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(Array.Empty<byte>()),
+        });
+
+        using var client = CreateClient();
+        var docId = DocumentId.AssumeExists("doc-456");
+
+        var result = await client.GetDocumentAsync(docId);
+
+        Assert.Empty(result);
+    }
+
+    public void Dispose()
+    {
+        _handler.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -428,6 +428,16 @@ TYPE Camunda.Orchestration.Sdk.AdvancedVariableKeyFilter : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableKey>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
+TYPE Camunda.Orchestration.Sdk.AgentInstanceCreationRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceDefinition Definition { get; set; } [JsonPropertyName("definition")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceLimits? Limits { get; set; } [JsonPropertyName("limits")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceCreationResult : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceKey AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
+
 TYPE Camunda.Orchestration.Sdk.AgentInstanceDefinition : sealed class
   CTOR ()
   PROP System.String Model { get; set; } [JsonPropertyName("model")]
@@ -485,6 +495,13 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceMetrics : sealed class
   PROP System.Int64 OutputTokens { get; set; } [JsonPropertyName("outputTokens")]
   PROP System.Int64 ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
 
+TYPE Camunda.Orchestration.Sdk.AgentInstanceMetricsDelta : sealed class
+  CTOR ()
+  PROP System.Int64? InputTokens { get; set; } [JsonPropertyName("inputTokens")]
+  PROP System.Int64? ModelCalls { get; set; } [JsonPropertyName("modelCalls")]
+  PROP System.Int64? OutputTokens { get; set; } [JsonPropertyName("outputTokens")]
+  PROP System.Int64? ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
+
 TYPE Camunda.Orchestration.Sdk.AgentInstanceResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceDefinition Definition { get; set; } [JsonPropertyName("definition")]
@@ -496,6 +513,7 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceResult : sealed class
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentTool> Tools { get; set; } [JsonPropertyName("tools")]
   PROP System.DateTimeOffset CreationDate { get; set; } [JsonPropertyName("creationDate")]
   PROP System.DateTimeOffset LastUpdatedDate { get; set; } [JsonPropertyName("lastUpdatedDate")]
   PROP System.DateTimeOffset? CompletionDate { get; set; } [JsonPropertyName("completionDate")]
@@ -550,6 +568,18 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusFilterProperty : sealed class
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceStatusEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceUpdateRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceMetricsDelta? Metrics { get; set; } [JsonPropertyName("metrics")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum? Status { get; set; } [JsonPropertyName("status")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentTool>? Tools { get; set; } [JsonPropertyName("tools")]
+
+TYPE Camunda.Orchestration.Sdk.AgentTool : sealed class
+  CTOR ()
+  PROP System.String Name { get; set; } [JsonPropertyName("name")]
+  PROP System.String? Description { get; set; } [JsonPropertyName("description")]
+  PROP System.String? ElementId { get; set; } [JsonPropertyName("elementId")]
 
 TYPE Camunda.Orchestration.Sdk.AncestorScopeInstruction : abstract class
   ATTR JsonPolymorphic discriminator=ancestorScopeType
@@ -1275,9 +1305,11 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task UnassignUserFromGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UnassignUserFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UnassignUserTaskAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task UpdateAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceKey agentInstanceKey, Camunda.Orchestration.Sdk.AgentInstanceUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UpdateAuthorizationAsync(Camunda.Orchestration.Sdk.AuthorizationKey authorizationKey, Camunda.Orchestration.Sdk.AuthorizationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UpdateJobAsync(Camunda.Orchestration.Sdk.JobKey jobKey, Camunda.Orchestration.Sdk.JobUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UpdateUserTaskAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskUpdateRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceCreationResult> CreateAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceCreationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceResult> GetAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceKey agentInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AgentInstanceResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceSearchQueryResult> SearchAgentInstancesAsync(Camunda.Orchestration.Sdk.AgentInstanceSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AgentInstanceSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AuditLogResult> GetAuditLogAsync(Camunda.Orchestration.Sdk.AuditLogKey auditLogKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AuditLogResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1323,6 +1355,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.EvaluateDecisionResult> EvaluateDecisionAsync(Camunda.Orchestration.Sdk.DecisionEvaluationInstruction body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ExpressionEvaluationResult> EvaluateExpressionAsync(Camunda.Orchestration.Sdk.ExpressionEvaluationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ExtendedDeploymentResponse> DeployResourcesFromFilesAsync(System.String[] resourceFilePaths, System.String? tenantId = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.FormResult> GetFormByKeyAsync(Camunda.Orchestration.Sdk.FormKey formKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.FormResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.FormResult> GetStartProcessFormAsync(Camunda.Orchestration.Sdk.ProcessDefinitionKey processDefinitionKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.FormResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.FormResult> GetUserTaskFormAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.FormResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GlobalJobStatisticsQueryResult> GetGlobalJobStatisticsAsync(System.DateTimeOffset from, System.DateTimeOffset to, System.String? jobType = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GlobalJobStatisticsQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1402,9 +1435,10 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchUserTaskEffectiveVariablesAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskEffectiveVariableSearchQueryRequest body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchUserTaskVariablesAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskVariableSearchQueryRequest body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchVariablesAsync(Camunda.Orchestration.Sdk.VariableSearchQuery body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<System.Byte[]> GetDocumentAsync(Camunda.Orchestration.Sdk.DocumentId documentId, System.String? storeId = null, System.String? contentHash = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<System.Byte[]> GetResourceContentBinaryAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Byte[]>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetDecisionDefinitionXmlAsync(Camunda.Orchestration.Sdk.DecisionDefinitionKey decisionDefinitionKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetDecisionRequirementsXmlAsync(Camunda.Orchestration.Sdk.DecisionRequirementsKey decisionRequirementsKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<System.Object> GetDocumentAsync(Camunda.Orchestration.Sdk.DocumentId documentId, System.String? storeId = null, System.String? contentHash = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetProcessDefinitionXmlAsync(Camunda.Orchestration.Sdk.ProcessDefinitionKey processDefinitionKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetProcessInstanceCallHierarchyAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetResourceContentAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -2395,6 +2429,7 @@ TYPE Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty : sealed class
 
 TYPE Camunda.Orchestration.Sdk.ElementInstanceResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceKey? AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementId ElementId { get; set; } [JsonPropertyName("elementId")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceResultType Type { get; set; } [JsonPropertyName("type")]


### PR DESCRIPTION
The C# generator does not handle `application/octet-stream` responses correctly. Operations like `getResourceContentBinary` (type: string, format: binary) fall through to the default `object` return type and are JSON-deserialized, which corrupts binary data.

## Changes

### Generator (`CSharpClientGenerator.cs`)
- `GetResponseSchemaRef()` now detects `application/octet-stream` content types and `format: binary` schemas, returning `byte[]` instead of falling through to `object`
- Resolves `$ref` component schemas before checking `format`, so referenced schemas with `format: binary` are also correctly detected
- `OperationMeta` gains an `IsBinaryResponse` flag
- Method generation emits `SendBinaryAsync()` calls (with body parameter) for binary operations instead of `SendAsync<T>()`

### Runtime (`CamundaClient.cs`)
- New `SendBinaryAsync(HttpMethod, string, object?, CancellationToken)` method that reads the response via `ReadAsByteArrayAsync()` instead of JSON deserialization
- Properly disposes `HttpResponseMessage` with `using var`
- Supports optional JSON request body for endpoints that accept a body but return binary

### Tests (`BinarySendTests.cs`)
- Verifies `SendBinaryAsync` returns exact `byte[]` content
- Verifies non-2xx responses throw `HttpSdkException`
- Verifies empty response body returns empty `byte[]`

### Examples & coverage
- Adds SDK examples for `getFormByKey`, `getResourceContentBinary`, `createAgentInstance`, and `updateAgentInstance`
- Updates operation-map and DocFX overwrites for full example coverage
- Regenerated output and public API baseline updated