### PR TITLE
chore(deps): restrict stable/9 Dependabot to patch-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,11 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -36,6 +41,10 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
       - dependency-name: "camunda-schema-bundler"
         versions: [">=2.0.0"]
 
@@ -56,3 +65,8 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
## What

Restrict all Dependabot updates targeting `stable/9` to **patch versions only** by ignoring `semver-major` and `semver-minor` update types across all three ecosystems (nuget, npm, github-actions).

The existing `camunda-schema-bundler >=2.0.0` ignore rule on `stable/9` npm is preserved as an additional safeguard.

## Why

`stable/9` is a maintenance branch. Major and minor dependency bumps carry risk of breaking changes and create review overhead — currently **20 of 25 open Dependabot PRs** are duplicate pairs bumping the same package on both `main` and `stable/9`, many of which are major version bumps (coverlet 8→10, xunit 2→3, commitlint 20→21).

Restricting to patches:
- Reduces noise — only security and bug-fix patches will be proposed for `stable/9`
- Avoids risky major/minor upgrades on a maintenance branch
- Frees up the `open-pull-requests-limit` slots for patches that actually matter

## Impact

After merging, Dependabot will auto-close the open `stable/9` PRs that propose major or minor bumps. The corresponding `main` PRs are unaffected.

### PRs that would be auto-closed

| PR | Package | Bump |
|---|---|---|
| #187 | System.Text.Json | 10.0.5 → 10.0.8 (patch — **kept**) |
| #186 | Microsoft.SourceLink.GitHub | 10.0.201 → 10.0.300 (minor — closed) |
| #185 | Microsoft.Extensions.Configuration.Abstractions | 10.0.5 → 10.0.8 (patch — **kept**) |
| #183 | FluentAssertions | 8.9.0 → 8.10.0 (minor — closed) |
| #181 | @commitlint/cli | 20.5.0 → 21.0.1 (major — closed) |
| #180 | @commitlint/config-conventional | 20.5.0 → 21.0.1 (major — closed) |
| #178 | camunda-schema-bundler | 1.6.1 → 1.7.0 (minor — closed) |
| #149 | YamlDotNet | 16.3.0 → 17.1.0 (major — closed) |
| #143 | Microsoft.Extensions.DependencyInjection & Logging | 10.0.5 → 10.0.7 (patch — **kept**) |
| #138 | Microsoft.Extensions.Configuration & Configuration.Json | 10.0.5 → 10.0.7 (patch — **kept**) |
| #131 | coverlet.collector | 8.0.1 → 10.0.0 (major — closed) |
| #86 | xunit.runner.visualstudio | 2.5.3 → 3.1.5 (major — closed) |
| #84 | xunit | 2.5.3 → 2.9.3 (minor — closed) |