### PR TITLE
fix: harden release pipeline against unreviewed file staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,12 @@ jobs:
         run: |
           git config user.name 'github-actions'
           git config user.email 'actions@github.com'
-          git add -A
+          git add \
+            src/Camunda.Orchestration.Sdk/Generated/ \
+            external-spec/bundled/ \
+            spec-snapshots/
+          echo "--- staged files ---"
+          git diff --cached --stat
           git commit -m "fix(gen): regenerate artifacts"
           git push origin "HEAD:${{ github.ref_name }}"
 

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
     "release": "semantic-release"
   },
   "devDependencies": {
-    "@camunda8/sdk-infra": "^1.3.0",
-    "@commitlint/cli": "^21.0.1",
-    "@commitlint/config-conventional": "^21.0.1",
-    "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/exec": "^7.0.3",
-    "@semantic-release/git": "^10.0.1",
-    "camunda-schema-bundler": "^2.4.1",
-    "semantic-release": "^25.0.2"
+    "@camunda8/sdk-infra": "1.3.0",
+    "@commitlint/cli": "21.0.1",
+    "@commitlint/config-conventional": "21.0.1",
+    "@semantic-release/changelog": "6.0.3",
+    "@semantic-release/exec": "7.1.0",
+    "@semantic-release/git": "10.0.1",
+    "camunda-schema-bundler": "2.4.1",
+    "semantic-release": "25.0.3"
   }
 }


### PR DESCRIPTION
## What

Phase 1 hardening of the release pipeline to reduce the blast radius of a supply-chain attack via auto-committed generated artifacts.

Addresses camunda/security-testing-findings#66.

## Changes

### 1. Replace `git add -A` with explicit allowlist

The `Commit generated artifacts` step in `release.yml` previously staged **every file** in the working tree. This meant any side-effect file left by the bundler, generator, or test harness would be silently committed to a protected branch without review.

Now only the three expected directories are staged:
- `src/Camunda.Orchestration.Sdk/Generated/` — regenerated C# client
- `external-spec/bundled/` — bundled OpenAPI spec
- `spec-snapshots/` — content-hashed spec tarballs

A `git diff --cached --stat` is printed for the CI audit trail.

### 2. Pin all devDependencies to exact versions

All `^` ranges in `package.json` are replaced with exact version pins matching the current `package-lock.json`. This prevents `npm ci` from silently picking up a new semver-compatible release of `camunda-schema-bundler` or other dependencies. Dependabot/Renovate will handle upgrades via PR review.

| Package | Before | After |
|---------|--------|-------|
| `@camunda8/sdk-infra` | `^1.3.0` | `1.3.0` |
| `@commitlint/cli` | `^21.0.1` | `21.0.1` |
| `@commitlint/config-conventional` | `^21.0.1` | `21.0.1` |
| `@semantic-release/changelog` | `^6.0.3` | `6.0.3` |
| `@semantic-release/exec` | `^7.0.3` | `7.1.0` |
| `@semantic-release/git` | `^10.0.1` | `10.0.1` |
| `camunda-schema-bundler` | `^2.4.1` | `2.4.1` |
| `semantic-release` | `^25.0.2` | `25.0.3` |

## What's not in scope (phase 2)

The following higher-impact changes are planned as follow-up:
- **PR gate**: Replace the direct `git push` with `peter-evans/create-pull-request` so generated artifacts go through review before landing on protected branches
- **Workflow split**: Separate the generate and publish jobs into independent workflows so publish never runs against unreviewed code

These are tracked in camunda/security-testing-findings#66.