### PR TITLE
ci: add breaking change guard to PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: camunda/sdk-infra/.github/workflows/sdk-commitlint.yml@v1
 
+  breaking-change-guard:
+    if: github.event_name == 'pull_request'
+    uses: camunda/sdk-infra/.github/workflows/sdk-breaking-change-guard.yml@v1
+
   spec-ref-guard:
     uses: camunda/sdk-infra/.github/workflows/sdk-spec-ref-guard.yml@v1
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,12 @@ jobs:
         run: |
           git config user.name 'github-actions'
           git config user.email 'actions@github.com'
-          git add -A
+          git add \
+            src/Camunda.Orchestration.Sdk/Generated/ \
+            external-spec/bundled/ \
+            spec-snapshots/
+          echo "--- staged files ---"
+          git diff --cached --stat
           git commit -m "fix(gen): regenerate artifacts"
           git push origin "HEAD:${{ github.ref_name }}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,12 @@ chore: address review comments — use logger.json for dry-run
 fix: address review comments — use logger.json for dry-run
 ```
 
+### Breaking change commits
+
+Breaking change markers (`BREAKING CHANGE:` in the body/footer) trigger a major version bump and a CHANGELOG entry. **Never** use these markers for intra-branch corrections on a feature branch — they pollute the release history and cause unnecessary major version increments.
+
+PR CI includes a breaking change guard that fails when it detects these markers. If the breaking change is intentional, add the `breaking-change-approved` label to the PR. Otherwise, rewrite the commit history to remove the markers before merging.
+
 ### Separate generator changes from regenerated output
 
 When a change modifies the generator (`src/Camunda.Orchestration.Sdk.Generator/`, bundler integration, build scripts) **and** that change causes `src/Camunda.Orchestration.Sdk/Generated/*` to differ, **split the work into two commits**:

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
     "release": "semantic-release"
   },
   "devDependencies": {
-    "@camunda8/sdk-infra": "^1.3.0",
-    "@commitlint/cli": "^21.0.1",
-    "@commitlint/config-conventional": "^21.0.1",
-    "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/exec": "^7.0.3",
-    "@semantic-release/git": "^10.0.1",
-    "camunda-schema-bundler": "^2.4.1",
-    "semantic-release": "^25.0.2"
+    "@camunda8/sdk-infra": "1.3.0",
+    "@commitlint/cli": "21.0.1",
+    "@commitlint/config-conventional": "21.0.1",
+    "@semantic-release/changelog": "6.0.3",
+    "@semantic-release/exec": "7.1.0",
+    "@semantic-release/git": "10.0.1",
+    "camunda-schema-bundler": "2.4.1",
+    "semantic-release": "25.0.3"
   }
 }


### PR DESCRIPTION
Adds the shared `sdk-breaking-change-guard` reusable workflow from `sdk-infra` to PR CI. This fails the build when PR commits contain `BREAKING CHANGE:` notes that would trigger an unintended major version bump via semantic-release.

## Changes

- **`.github/workflows/ci.yml`**: Added `breaking-change-guard` job (runs on PRs only)
- **`AGENTS.md`**: Documented breaking change commit conventions and the bypass label

## Bypass

Add the `breaking-change-approved` label to skip the guard for intentional breaking changes.

Closes #205