### PR TITLE
fix: use git add -f for gitignored spec artifacts in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           git config user.name 'github-actions'
           git config user.email 'actions@github.com'
-          git add \
+          git add -f \
             src/Camunda.Orchestration.Sdk/Generated/ \
             external-spec/bundled/ \
             spec-snapshots/


### PR DESCRIPTION
The release workflow fails at the "Commit generated artifacts" step because `external-spec/bundled/` matches the `.gitignore` pattern `external-spec/**/*`.

**Error:**
```
The following paths are ignored by one of your .gitignore files:
external-spec/bundled
Use -f if you really want to add them.
```

**Fix:** Add `-f` flag to `git add` so it force-adds the gitignored spec artifacts that the release pipeline intentionally regenerates and commits.