### PR TITLE
chore: update OpenAPI spec to latest main and Docker to 8.10-SNAPSHOT

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   camunda:
-    image: camunda/camunda:${CAMUNDA_VERSION:-8.9.0-alpha4}
+    image: camunda/camunda:${CAMUNDA_VERSION:-8.10-SNAPSHOT}
     container_name: camunda-engine
     environment:
       SPRING_PROFILES_ACTIVE: 'broker,consolidated-auth'

--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -1423,6 +1423,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.SearchElementInstanceWaitStatesAsync(Camunda.Orchestration.Sdk.ElementInstanceWaitStateQuery,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.ElementInstanceWaitStateQueryResult},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/VariableElement.cs#SearchElementInstanceWaitStates)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.SearchGlobalTaskListenersAsync(Camunda.Orchestration.Sdk.GlobalTaskListenerSearchQueryRequest,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.GlobalTaskListenerSearchQueryResult},System.Threading.CancellationToken)
 example:
 - *content

--- a/examples/AgentInstance.cs
+++ b/examples/AgentInstance.cs
@@ -59,7 +59,7 @@ public static class AgentInstanceExamples
     #region UpdateAgentInstance
 
     // <UpdateAgentInstance>
-    public static async Task UpdateAgentInstanceExample(AgentInstanceKey agentInstanceKey)
+    public static async Task UpdateAgentInstanceExample(AgentInstanceKey agentInstanceKey, ElementInstanceKey elementInstanceKey)
     {
         using var client = CamundaClient.Create();
 
@@ -67,7 +67,8 @@ public static class AgentInstanceExamples
             agentInstanceKey,
             new AgentInstanceUpdateRequest
             {
-                Status = AgentInstanceStatusEnum.THINKING,
+                ElementInstanceKey = elementInstanceKey,
+                Status = AgentInstanceUpdateStatusEnum.THINKING,
                 Metrics = new AgentInstanceMetricsDelta
                 {
                     InputTokens = 150,

--- a/examples/VariableElement.cs
+++ b/examples/VariableElement.cs
@@ -85,6 +85,33 @@ public static class VariableElementExamples
     // </SearchElementInstanceIncidents>
     #endregion SearchElementInstanceIncidents
 
+    #region SearchElementInstanceWaitStates
+
+    // <SearchElementInstanceWaitStates>
+    public static async Task SearchElementInstanceWaitStatesExample(ProcessInstanceKey processInstanceKey)
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.SearchElementInstanceWaitStatesAsync(
+            new ElementInstanceWaitStateQuery
+            {
+                Filter = new ElementInstanceWaitStateFilter
+                {
+                    ProcessInstanceKey = new ProcessInstanceKeyFilterProperty
+                    {
+                        Eq = processInstanceKey,
+                    },
+                },
+            });
+
+        foreach (var waitState in result.Items)
+        {
+            Console.WriteLine($"{waitState.ElementId}: {waitState.WaitStateType}");
+        }
+    }
+    // </SearchElementInstanceWaitStates>
+    #endregion SearchElementInstanceWaitStates
+
     #region CreateElementInstanceVariables
 
     // <CreateElementInstanceVariables>

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -1066,6 +1066,13 @@
       "label": "Search element instance incidents"
     }
   ],
+  "searchElementInstanceWaitStates": [
+    {
+      "file": "VariableElement.cs",
+      "region": "SearchElementInstanceWaitStates",
+      "label": "Search element instance wait states"
+    }
+  ],
   "createElementInstanceVariables": [
     {
       "file": "VariableElement.cs",

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -157,6 +157,14 @@
           "Agent instance"
         ],
         "operationId": "createAgentInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Create agent instance",
         "description": "Creates a new agent instance. The returned key identifies the instance and must\nbe used in subsequent update and query calls.\n",
         "requestBody": {
@@ -258,6 +266,14 @@
           "Agent instance"
         ],
         "operationId": "getAgentInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get agent instance",
         "description": "Returns agent instance as JSON.",
         "parameters": [
@@ -358,8 +374,16 @@
           "Agent instance"
         ],
         "operationId": "updateAgentInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update agent instance",
-        "description": "Updates the mutable fields of an agent instance: status, metric counters, and\ntools. Metric values are treated as deltas and applied immediately to the\naggregate counters. Tool updates replace the existing tool list. At least one of\nstatus, metrics, or tools must be provided.\n",
+        "description": "Updates the mutable fields of an agent instance: status, metric counters, and\ntools. Metric values are treated as deltas and applied immediately to the\naggregate counters. Tool updates replace the existing tool list.\n",
         "parameters": [
           {
             "name": "agentInstanceKey",
@@ -453,6 +477,14 @@
           "Agent instance"
         ],
         "operationId": "searchAgentInstances",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search agent instances",
         "description": "Search for agent instances based on given criteria.",
         "requestBody": {
@@ -534,6 +566,14 @@
           "Audit Log"
         ],
         "operationId": "searchAuditLogs",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search audit logs",
         "description": "Search for audit logs based on given criteria.",
         "requestBody": {
@@ -608,6 +648,14 @@
           "Audit Log"
         ],
         "operationId": "getAuditLog",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get audit log",
         "description": "Get an audit log entry by auditLogKey.",
         "parameters": [
@@ -694,7 +742,7 @@
         "description": "Retrieves the current authenticated user.",
         "security": [
           {
-            "BearerAuth": []
+            "bearerAuth": []
           }
         ],
         "responses": {
@@ -756,6 +804,14 @@
           "Authorization"
         ],
         "operationId": "createAuthorization",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Create authorization",
         "description": "Create the authorization.",
         "requestBody": {
@@ -859,6 +915,14 @@
         "summary": "Search authorizations",
         "description": "Search for authorizations based on given criteria.",
         "operationId": "searchAuthorizations",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -937,6 +1001,14 @@
           "Authorization"
         ],
         "operationId": "updateAuthorization",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update authorization",
         "description": "Update the authorization with the given key.",
         "parameters": [
@@ -1020,6 +1092,14 @@
           "Authorization"
         ],
         "operationId": "getAuthorization",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get authorization",
         "description": "Get authorization by the given key.",
         "parameters": [
@@ -1100,6 +1180,14 @@
           "Authorization"
         ],
         "operationId": "deleteAuthorization",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete authorization",
         "description": "Deletes the authorization with the given key.",
         "parameters": [
@@ -1175,6 +1263,14 @@
           "Batch operation"
         ],
         "operationId": "searchBatchOperationItems",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search batch operation items",
         "description": "Search for batch operation items based on given criteria.",
         "requestBody": {
@@ -1229,6 +1325,14 @@
           "Batch operation"
         ],
         "operationId": "searchBatchOperations",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search batch operations",
         "description": "Search for batch operations based on given criteria.",
         "requestBody": {
@@ -1283,6 +1387,14 @@
           "Batch operation"
         ],
         "operationId": "getBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get batch operation",
         "description": "Get batch operation by key.",
         "parameters": [
@@ -1348,6 +1460,14 @@
           "Batch operation"
         ],
         "operationId": "cancelBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Cancel Batch operation",
         "description": "Cancels a running batch operation.\nThis is done asynchronously, the progress can be tracked using the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "parameters": [
@@ -1423,6 +1543,14 @@
           "Batch operation"
         ],
         "operationId": "resumeBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Resume Batch operation",
         "description": "Resumes a suspended batch operation.\nThis is done asynchronously, the progress can be tracked using the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "parameters": [
@@ -1508,6 +1636,14 @@
           "Batch operation"
         ],
         "operationId": "suspendBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Suspend Batch operation",
         "description": "Suspends a running batch operation.\nThis is done asynchronously, the progress can be tracked using the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "parameters": [
@@ -1593,6 +1729,14 @@
           "Clock"
         ],
         "operationId": "pinClock",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Pin internal clock (alpha)",
         "description": "Set a precise, static time for the Zeebe engine's internal clock.\nWhen the clock is pinned, it remains at the specified time and does not advance.\nTo change the time, the clock must be pinned again with a new timestamp.\n\nThis endpoint is an alpha feature and may be subject to change\nin future releases.\n",
         "requestBody": {
@@ -1650,6 +1794,14 @@
           "Clock"
         ],
         "operationId": "resetClock",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Reset internal clock (alpha)",
         "description": "Resets the Zeebe engine's internal clock to the current system time, enabling it to tick in real-time.\nThis operation is useful for returning the clock to\nnormal behavior after it has been pinned to a specific time.\n\nThis endpoint is an alpha feature and may be subject to change\nin future releases.\n",
         "responses": {
@@ -1683,6 +1835,14 @@
     "/cluster-variables/global": {
       "post": {
         "operationId": "createGlobalClusterVariable",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": false,
         "tags": [
           "Cluster Variable"
@@ -1757,6 +1917,16 @@
               }
             }
           },
+          "409": {
+            "description": "A cluster variable with this name already exists.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "500": {
             "description": "An internal error occurred while processing the request.",
             "content": {
@@ -1774,6 +1944,14 @@
     "/cluster-variables/global/{name}": {
       "get": {
         "operationId": "getGlobalClusterVariable",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": true,
         "tags": [
           "Cluster Variable"
@@ -1873,6 +2051,14 @@
       },
       "put": {
         "operationId": "updateGlobalClusterVariable",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": false,
         "tags": [
           "Cluster Variable"
@@ -1982,6 +2168,14 @@
       },
       "delete": {
         "operationId": "deleteGlobalClusterVariable",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": false,
         "tags": [
           "Cluster Variable"
@@ -2079,6 +2273,14 @@
           "Cluster Variable"
         ],
         "operationId": "searchClusterVariables",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": true,
         "description": "Search for cluster variables based on given criteria. By default, long variable values in the response are truncated.",
         "parameters": [
@@ -2167,6 +2369,14 @@
     "/cluster-variables/tenants/{tenantId}": {
       "post": {
         "operationId": "createTenantClusterVariable",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": false,
         "tags": [
           "Cluster Variable"
@@ -2276,6 +2486,16 @@
               }
             }
           },
+          "409": {
+            "description": "A cluster variable with this name already exists for the given tenant.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "500": {
             "description": "An internal error occurred while processing the request.",
             "content": {
@@ -2293,6 +2513,14 @@
     "/cluster-variables/tenants/{tenantId}/{name}": {
       "get": {
         "operationId": "getTenantClusterVariable",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": true,
         "tags": [
           "Cluster Variable"
@@ -2405,6 +2633,14 @@
       },
       "put": {
         "operationId": "updateTenantClusterVariable",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": false,
         "tags": [
           "Cluster Variable"
@@ -2527,6 +2763,14 @@
       },
       "delete": {
         "operationId": "deleteTenantClusterVariable",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": false,
         "tags": [
           "Cluster Variable"
@@ -2638,6 +2882,14 @@
           "Conditional"
         ],
         "operationId": "evaluateConditionals",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Evaluate root level conditional start events",
         "description": "Evaluates root-level conditional start events for process definitions.\nIf the evaluation is successful, it will return the keys of all created process instances, along with their associated process definition key.\nMultiple root-level conditional start events of the same process definition can trigger if their conditions evaluate to true.\n",
         "requestBody": {
@@ -2751,6 +3003,14 @@
           "Message subscription"
         ],
         "operationId": "searchCorrelatedMessageSubscriptions",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search correlated message subscriptions",
         "description": "Search correlated message subscriptions based on given criteria.",
         "requestBody": {
@@ -2832,6 +3092,14 @@
           "Decision definition"
         ],
         "operationId": "evaluateDecision",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Evaluate decision",
         "description": "Evaluates a decision.\nYou specify the decision to evaluate either by using its unique key (as returned by\nDeployResource), or using the decision ID. When using the decision ID, the latest deployed\nversion of the decision is used.\n",
         "requestBody": {
@@ -2852,7 +3120,7 @@
                 "By decision definition ID": {
                   "summary": "Evaluate the decision by decisionDefinitionId.",
                   "value": {
-                    "decisionDefinitionId": "1234-5678",
+                    "decisionDefinitionId": "my-decision",
                     "variables": {}
                   }
                 }
@@ -2922,6 +3190,14 @@
           "Decision definition"
         ],
         "operationId": "searchDecisionDefinitions",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search decision definitions",
         "description": "Search for decision definitions based on given criteria.",
         "requestBody": {
@@ -3003,6 +3279,14 @@
           "Decision definition"
         ],
         "operationId": "getDecisionDefinition",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get decision definition",
         "description": "Returns a decision definition by key.",
         "parameters": [
@@ -3095,6 +3379,14 @@
           "Decision definition"
         ],
         "operationId": "getDecisionDefinitionXML",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get decision definition XML",
         "description": "Returns decision definition as XML.",
         "parameters": [
@@ -3187,6 +3479,14 @@
           "Decision instance"
         ],
         "operationId": "searchDecisionInstances",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search decision instances",
         "description": "Search for decision instances based on given criteria.",
         "requestBody": {
@@ -3268,6 +3568,14 @@
           "Decision instance"
         ],
         "operationId": "getDecisionInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get decision instance",
         "description": "Returns a decision instance.",
         "parameters": [
@@ -3360,6 +3668,14 @@
           "Decision instance"
         ],
         "operationId": "deleteDecisionInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete decision instance",
         "description": "Delete all associated decision evaluations based on provided key.",
         "parameters": [
@@ -3455,6 +3771,14 @@
           "Decision instance"
         ],
         "operationId": "deleteDecisionInstancesBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete decision instances (batch)",
         "description": "Delete multiple decision instances. This will delete the historic data from secondary storage.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "requestBody": {
@@ -3536,6 +3860,14 @@
           "Decision requirements"
         ],
         "operationId": "searchDecisionRequirements",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search decision requirements",
         "description": "Search for decision requirements based on given criteria.",
         "requestBody": {
@@ -3617,6 +3949,14 @@
           "Decision requirements"
         ],
         "operationId": "getDecisionRequirements",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get decision requirements",
         "description": "Returns Decision Requirements as JSON.",
         "parameters": [
@@ -3709,6 +4049,14 @@
           "Decision requirements"
         ],
         "operationId": "getDecisionRequirementsXML",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get decision requirements XML",
         "description": "Returns decision requirements as XML.",
         "parameters": [
@@ -3801,6 +4149,14 @@
           "Resource"
         ],
         "operationId": "createDeployment",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Deploy resources",
         "description": "Deploys one or more resources (e.g. processes, decision models, or forms).\nThis is an atomic call, i.e. either all resources are deployed or none of them are.\n",
         "requestBody": {
@@ -3872,6 +4228,14 @@
           "Document"
         ],
         "operationId": "createDocument",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Upload document",
         "description": "Upload a document to the Camunda 8 cluster.\n\nNote that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)\n",
         "parameters": [
@@ -3964,6 +4328,14 @@
           "Document"
         ],
         "operationId": "createDocuments",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Upload multiple documents",
         "description": "Upload multiple documents to the Camunda 8 cluster.\n\nThe caller must provide a file name for each document, which will be used in case of a multi-status response\nto identify which documents failed to upload. The file name can be provided in the `Content-Disposition` header\nof the file part or in the `fileName` field of the metadata. You can add a parallel array of metadata objects. These\nare matched with the files based on index, and must have the same length as the files array.\nTo pass homogenous metadata for all files, spread the metadata over the metadata array.\nA filename value provided explicitly via the metadata array in the request overrides the `Content-Disposition` header\nof the file part.\n\nIn case of a multi-status response, the response body will contain a list of `DocumentBatchProblemDetail` objects,\neach of which contains the file name of the document that failed to upload and the reason for the failure.\nThe client can choose to retry the whole batch or individual documents based on the response.\n\nNote that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)\n",
         "parameters": [
@@ -4079,6 +4451,14 @@
           "Document"
         ],
         "operationId": "getDocument",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Download document",
         "description": "Download a document from the Camunda 8 cluster.\n\nNote that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)\n",
         "parameters": [
@@ -4151,6 +4531,14 @@
           "Document"
         ],
         "operationId": "deleteDocument",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete document",
         "description": "Delete a document from the Camunda 8 cluster.\n\nNote that this is currently supported for document stores of type: AWS, Azure, GCP, in-memory (non-production), local (non-production)\n",
         "parameters": [
@@ -4208,6 +4596,14 @@
           "Document"
         ],
         "operationId": "createDocumentLink",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Create document link",
         "description": "Create a link to a document in the Camunda 8 cluster.\n\nNote that this is currently supported for document stores of type: AWS, Azure, GCP\n",
         "parameters": [
@@ -4281,6 +4677,14 @@
           "Ad-hoc sub-process"
         ],
         "operationId": "activateAdHocSubProcessActivities",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Activate activities within an ad-hoc sub-process",
         "description": "Activates selected activities within an ad-hoc sub-process identified by element ID.\nThe provided element IDs must exist within the ad-hoc sub-process instance identified by the\nprovided adHocSubProcessInstanceKey.\n",
         "parameters": [
@@ -4379,6 +4783,95 @@
         "x-added-in-version": "8.8"
       }
     },
+    "/element-instances/wait-states/search": {
+      "post": {
+        "x-eventually-consistent": true,
+        "tags": [
+          "Element instance"
+        ],
+        "operationId": "searchElementInstanceWaitStates",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Search element instance wait states",
+        "description": "Returns the wait states for element instances matching the given filter.\n",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ElementInstanceWaitStateQuery"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The element instance wait state search result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ElementInstanceWaitStateQueryResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/element-instances/search": {
       "post": {
         "x-eventually-consistent": true,
@@ -4386,6 +4879,14 @@
           "Element instance"
         ],
         "operationId": "searchElementInstances",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search element instances",
         "description": "Search for element instances based on given criteria.",
         "requestBody": {
@@ -4467,6 +4968,14 @@
           "Element instance"
         ],
         "operationId": "getElementInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get element instance",
         "description": "Returns element instance as JSON.",
         "parameters": [
@@ -4559,6 +5068,14 @@
           "Element instance"
         ],
         "operationId": "searchElementInstanceIncidents",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search for incidents of a specific element instance",
         "description": "Search for incidents caused by the specified element instance, including incidents of any child instances created from this element instance.\n\nAlthough the `elementInstanceKey` is provided as a path parameter to indicate the root element instance,\nyou may also include an `elementInstanceKey` within the filter object to narrow results to specific\nchild element instances. This is useful, for example, if you want to isolate incidents associated with\nnested or subordinate elements within the given element instance while excluding incidents directly tied\nto the root element itself.\n",
         "parameters": [
@@ -4661,6 +5178,14 @@
           "Element instance"
         ],
         "operationId": "createElementInstanceVariables",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update element instance variables",
         "description": "Updates all the variables of a particular scope (for example, process instance, element instance) with the given variable data.\nSpecify the element instance in the `elementInstanceKey` parameter.\nVariable updates can be delayed by listener-related processing; if processing exceeds the\nrequest timeout, this endpoint can return 504. Other gateway timeout causes are also\npossible. Retry with backoff and inspect listener worker availability and logs when this\nrepeats.\n",
         "parameters": [
@@ -4746,12 +5271,20 @@
     "/expression/evaluation": {
       "post": {
         "operationId": "evaluateExpression",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": false,
         "tags": [
           "Expression"
         ],
         "summary": "Evaluate an expression",
-        "description": "Evaluates a FEEL expression and returns the result. Supports references to tenant scoped cluster variables when a tenant ID is provided.",
+        "description": "Evaluates a FEEL expression and returns the result. Supports references to tenant scoped\ncluster variables when a tenant ID is provided. Optionally, provide a `scopeKey` to make the\nvariables of a specific process instance or element instance visible while evaluating the\nexpression.\n",
         "requestBody": {
           "required": true,
           "content": {
@@ -4831,6 +5364,14 @@
           "Form"
         ],
         "operationId": "getFormByKey",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get form by key",
         "description": "Get a form by its unique form key.\n",
         "parameters": [
@@ -4923,6 +5464,14 @@
           "Global listener"
         ],
         "operationId": "createGlobalTaskListener",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Create global user task listener",
         "description": "Create a new global user task listener.",
         "x-semantic-establishes": {
@@ -5034,6 +5583,14 @@
           "Global listener"
         ],
         "operationId": "getGlobalTaskListener",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get global user task listener",
         "description": "Get a global user task listener by its id.",
         "x-semantic-requires": {
@@ -5123,6 +5680,14 @@
           "Global listener"
         ],
         "operationId": "updateGlobalTaskListener",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update global user task listener",
         "description": "Updates a global user task listener.",
         "x-semantic-requires": {
@@ -5242,6 +5807,14 @@
           "Global listener"
         ],
         "operationId": "deleteGlobalTaskListener",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete global user task listener",
         "description": "Deletes a global user task listener.",
         "x-semantic-requires": {
@@ -5346,6 +5919,14 @@
           "Global listener"
         ],
         "operationId": "searchGlobalTaskListeners",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search global user task listeners",
         "description": "Search for global user task listeners based on given criteria.",
         "requestBody": {
@@ -5426,6 +6007,14 @@
           "Group"
         ],
         "operationId": "createGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Create group",
         "description": "Create a new group.\n\nThe supplied `groupId` is validated against `^[a-zA-Z0-9_~@.+-]+$`\n(max 256 characters) by `IdentifierValidator.validateId` in the\nruntime. This strict validation applies wherever the Groups API\nis available: in OIDC deployments that set\n`camunda.security.authentication.oidc.groupsClaim` the Groups\nAPI (including this endpoint) is disabled entirely, so group\nCRUD never sees externally-minted IdP IDs. The BYOG relaxation\nonly loosens validation when a group is referenced *as a member*\nof a role or tenant (`assignRoleToGroup`,\n`assignGroupToTenant`); group CRUD itself always uses the strict\ndefault-id regex. The constraint is not advertised on the\n`GroupId` schema so that the same schema can be reused at\nmember-reference sites without falsely rejecting\nexternally-minted IdP group IDs there.\n",
         "x-semantic-establishes": {
@@ -5495,6 +6084,16 @@
               }
             }
           },
+          "409": {
+            "description": "Group with this id already exists.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "500": {
             "description": "An internal error occurred while processing the request.",
             "content": {
@@ -5526,6 +6125,14 @@
           "Group"
         ],
         "operationId": "searchGroups",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search groups",
         "description": "Search for groups based on given criteria.",
         "requestBody": {
@@ -5607,6 +6214,14 @@
           "Group"
         ],
         "operationId": "getGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get group",
         "description": "Get a group by its ID.",
         "x-semantic-requires": {
@@ -5696,6 +6311,14 @@
           "Group"
         ],
         "operationId": "updateGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update group",
         "description": "Update a group with the given ID.",
         "x-semantic-requires": {
@@ -5805,6 +6428,14 @@
           "Group"
         ],
         "operationId": "deleteGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete group",
         "description": "Deletes the group with the given ID.",
         "x-semantic-requires": {
@@ -5889,6 +6520,14 @@
           "Group"
         ],
         "operationId": "searchClientsForGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search group clients",
         "description": "Search clients assigned to a group.",
         "x-semantic-requires": {
@@ -6000,6 +6639,14 @@
           "Group"
         ],
         "operationId": "assignClientToGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a client to a group",
         "description": "Assigns a client to a group, making it a member of the group.\nMembers of the group inherit the group authorizations, roles, and tenant assignments.\n",
         "x-semantic-establishes": {
@@ -6111,6 +6758,14 @@
           "Group"
         ],
         "operationId": "unassignClientFromGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a client from a group",
         "description": "Unassigns a client from a group.\nThe client is removed as a group member, with associated authorizations, roles, and tenant assignments no longer applied.\n",
         "x-semantic-requires": {
@@ -6211,6 +6866,14 @@
           "Group"
         ],
         "operationId": "searchMappingRulesForGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search group mapping rules",
         "description": "Search mapping rules assigned to a group.",
         "x-semantic-requires": {
@@ -6322,6 +6985,14 @@
           "Group"
         ],
         "operationId": "assignMappingRuleToGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a mapping rule to a group",
         "description": "Assigns a mapping rule to a group.",
         "x-semantic-establishes": {
@@ -6433,6 +7104,14 @@
           "Group"
         ],
         "operationId": "unassignMappingRuleFromGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a mapping rule from a group",
         "description": "Unassigns a mapping rule from a group.",
         "x-semantic-requires": {
@@ -6533,6 +7212,14 @@
           "Group"
         ],
         "operationId": "searchRolesForGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search group roles",
         "description": "Search roles assigned to a group.",
         "x-semantic-requires": {
@@ -6644,6 +7331,14 @@
           "Group"
         ],
         "operationId": "searchUsersForGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search group users",
         "description": "Search users assigned to a group.",
         "x-semantic-requires": {
@@ -6755,6 +7450,14 @@
           "Group"
         ],
         "operationId": "assignUserToGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a user to a group",
         "description": "Assigns a user to a group, making the user a member of the group.\nGroup members inherit the group authorizations, roles, and tenant assignments.\n",
         "x-semantic-establishes": {
@@ -6866,6 +7569,14 @@
           "Group"
         ],
         "operationId": "unassignUserFromGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a user from a group",
         "description": "Unassigns a user from a group.\nThe user is removed as a group member, with associated authorizations, roles, and tenant assignments no longer applied.\n",
         "x-semantic-requires": {
@@ -6966,6 +7677,14 @@
           "Incident"
         ],
         "operationId": "searchIncidents",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search incidents",
         "description": "Search for incidents based on given criteria.\n",
         "requestBody": {
@@ -7047,6 +7766,14 @@
           "Incident"
         ],
         "operationId": "getIncident",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get incident",
         "description": "Returns incident as JSON.\n",
         "parameters": [
@@ -7139,6 +7866,14 @@
           "Incident"
         ],
         "operationId": "resolveIncident",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Resolve incident",
         "description": "Marks the incident as resolved; most likely a call to Update job will be necessary\nto reset the job's retries, followed by this call.\n",
         "parameters": [
@@ -7227,6 +7962,14 @@
           "Incident"
         ],
         "operationId": "getProcessInstanceStatisticsByDefinition",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get process instance statistics by definition",
         "description": "Returns statistics for active process instances with incidents, grouped by process\ndefinition. The result set is scoped to a specific incident error hash code, which must be\nprovided as a filter in the request body.\n",
         "requestBody": {
@@ -7308,6 +8051,14 @@
           "Incident"
         ],
         "operationId": "getProcessInstanceStatisticsByError",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get process instance statistics by error",
         "description": "Returns statistics for active process instances that currently have active incidents,\ngrouped by incident error hash code.\n",
         "requestBody": {
@@ -7389,6 +8140,14 @@
           "Job"
         ],
         "operationId": "activateJobs",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Activate jobs",
         "description": "Iterate through all known partitions and activate jobs up to the requested maximum.\n",
         "requestBody": {
@@ -7470,6 +8229,14 @@
           "Job"
         ],
         "operationId": "searchJobs",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search jobs",
         "description": "Search for jobs based on given criteria.",
         "requestBody": {
@@ -7551,6 +8318,14 @@
           "Job"
         ],
         "operationId": "updateJob",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update job",
         "description": "Update a job with the given key.",
         "parameters": [
@@ -7639,6 +8414,14 @@
           "Job"
         ],
         "operationId": "completeJob",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Complete job",
         "description": "Complete a job with the given payload, which allows completing the associated service task.\n",
         "parameters": [
@@ -7727,6 +8510,14 @@
           "Job"
         ],
         "operationId": "throwJobError",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Throw error for job",
         "description": "Reports a business error (i.e. non-technical) that occurs while processing a job.\n",
         "parameters": [
@@ -7815,6 +8606,14 @@
           "Job"
         ],
         "operationId": "failJob",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Fail job",
         "description": "Mark the job as failed.\n",
         "parameters": [
@@ -7903,6 +8702,14 @@
           "Job"
         ],
         "operationId": "getGlobalJobStatistics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Global job statistics",
         "description": "Returns global aggregated counts for jobs. Filter by the creation time window (required) and optionally by jobType.\n",
         "parameters": [
@@ -8008,6 +8815,14 @@
           "Job"
         ],
         "operationId": "getJobTypeStatistics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get job statistics by type",
         "description": "Get statistics about jobs, grouped by job type.\n",
         "requestBody": {
@@ -8089,6 +8904,14 @@
           "Job"
         ],
         "operationId": "getJobWorkerStatistics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get job statistics by worker",
         "description": "Get statistics about jobs, grouped by worker, for a given job type.\n",
         "requestBody": {
@@ -8170,6 +8993,14 @@
           "Job"
         ],
         "operationId": "getJobTimeSeriesStatistics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get time-series metrics for a job type",
         "description": "Returns a list of time-bucketed metrics ordered ascending by time.\nThe `from` and `to` fields select the time window of interest.\nEach item in the response corresponds to one time bucket of the requested resolution.\n",
         "requestBody": {
@@ -8251,6 +9082,14 @@
           "Job"
         ],
         "operationId": "getJobErrorStatistics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get error metrics for a job type",
         "description": "Returns aggregated metrics per error for the given jobType.\n",
         "requestBody": {
@@ -8332,6 +9171,7 @@
           "License"
         ],
         "operationId": "getLicense",
+        "security": [],
         "summary": "Get license status",
         "description": "Obtains the status of the current Camunda license.",
         "responses": {
@@ -8366,6 +9206,14 @@
           "Mapping rule"
         ],
         "operationId": "createMappingRule",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Create mapping rule",
         "description": "Create a new mapping rule\n",
         "x-semantic-establishes": {
@@ -8428,6 +9276,16 @@
               }
             }
           },
+          "409": {
+            "description": "Mapping rule with this id already exists.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "500": {
             "description": "An internal error occurred while processing the request.",
             "content": {
@@ -8449,6 +9307,14 @@
           "Mapping rule"
         ],
         "operationId": "searchMappingRule",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search mapping rules",
         "description": "Search for mapping rules based on given criteria.\n",
         "requestBody": {
@@ -8529,6 +9395,14 @@
           "Mapping rule"
         ],
         "operationId": "updateMappingRule",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update mapping rule",
         "description": "Update a mapping rule.\n",
         "x-semantic-requires": {
@@ -8630,6 +9504,14 @@
           "Mapping rule"
         ],
         "operationId": "deleteMappingRule",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete a mapping rule",
         "description": "Deletes the mapping rule with the given ID.\n",
         "x-semantic-requires": {
@@ -8712,6 +9594,14 @@
           "Mapping rule"
         ],
         "operationId": "getMappingRule",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get a mapping rule",
         "description": "Gets the mapping rule with the given ID.\n",
         "x-semantic-requires": {
@@ -8793,6 +9683,14 @@
           "Message subscription"
         ],
         "operationId": "searchMessageSubscriptions",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search message subscriptions",
         "description": "Search for message subscriptions based on given criteria.\n\nBy default, both start and intermediate event subscriptions are returned. Use the\n`messageSubscriptionType` filter to restrict results to a single type.\n\n**Version notes:**\n- Start event subscriptions are only captured for deployments made with 8.10 or later.\n- The `messageSubscriptionType` field is only populated for data created\n  with Camunda 8.10 or later. For pre-8.10 data, intermediate event entries have no\n  `messageSubscriptionType` value stored. For convenience, the API returns `PROCESS_EVENT`\n  as a default for such search results, though.\n- Searching for intermediate event subscriptions **including legacy data** can be achieved\n  by filtering for `messageSubscriptionType` not matching `START_EVENT`.\n",
         "requestBody": {
@@ -8874,6 +9772,14 @@
           "Message"
         ],
         "operationId": "correlateMessage",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Correlate message",
         "description": "Publishes a message and correlates it to a subscription.\nIf correlation is successful it will return the first process instance key the message correlated with.\nThe message is not buffered.\nUse the publish message endpoint to send messages that can be buffered.\n",
         "requestBody": {
@@ -8958,6 +9864,14 @@
           "Message"
         ],
         "operationId": "publishMessage",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Publish message",
         "description": "Publishes a single message.\nMessages are published to specific partitions computed from their correlation keys.\nMessages can be buffered.\nThe endpoint does not wait for a correlation result.\nUse the message correlation endpoint for such use cases.\n",
         "requestBody": {
@@ -9022,6 +9936,14 @@
           "Process definition"
         ],
         "operationId": "searchProcessDefinitions",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search process definitions",
         "description": "Search for process definitions based on given criteria.",
         "requestBody": {
@@ -9103,6 +10025,14 @@
           "Process definition"
         ],
         "operationId": "getProcessDefinitionMessageSubscriptionStatistics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get message subscription statistics",
         "description": "Get message subscription statistics, grouped by process definition.\n",
         "requestBody": {
@@ -9184,6 +10114,14 @@
           "Process definition"
         ],
         "operationId": "getProcessDefinitionInstanceStatistics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get process instance statistics",
         "description": "Get statistics about process instances, grouped by process definition and tenant.\n",
         "requestBody": {
@@ -9265,6 +10203,14 @@
           "Process definition"
         ],
         "operationId": "getProcessDefinition",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get process definition",
         "description": "Returns process definition as JSON.",
         "parameters": [
@@ -9357,6 +10303,14 @@
           "Process definition"
         ],
         "operationId": "getStartProcessForm",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get process start form",
         "description": "Get the start form of a process.\nNote that this endpoint will only return linked forms. This endpoint does not support embedded forms.\n",
         "parameters": [
@@ -9452,6 +10406,14 @@
           "Process definition"
         ],
         "operationId": "getProcessDefinitionStatistics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get process definition statistics",
         "description": "Get statistics about elements in currently running process instances by process definition key and search filter.",
         "parameters": [
@@ -9544,6 +10506,14 @@
           "Process definition"
         ],
         "operationId": "getProcessDefinitionXML",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get process definition XML",
         "description": "Returns process definition as XML.",
         "parameters": [
@@ -9646,6 +10616,14 @@
           "Process definition"
         ],
         "operationId": "getProcessDefinitionInstanceVersionStatistics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get process instance statistics by version",
         "description": "Get statistics about process instances, grouped by version for a given process definition.\nThe process definition ID must be provided as a required field in the request body filter.\n",
         "requestBody": {
@@ -9727,6 +10705,14 @@
           "Process instance"
         ],
         "operationId": "createProcessInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Create process instance",
         "description": "Creates and starts an instance of the specified process.\nThe process definition to use to create the instance can be specified either using its unique key\n(as returned by Deploy resources), or using the BPMN process id and a version.\n\nWaits for the completion of the process instance before returning a result\nwhen awaitCompletion is enabled.\n",
         "requestBody": {
@@ -9828,6 +10814,14 @@
           "Process instance"
         ],
         "operationId": "cancelProcessInstancesBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Cancel process instances (batch)",
         "description": "Cancels multiple running process instances.\nSince only ACTIVE root instances can be cancelled, any given filters for state and\nparentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "requestBody": {
@@ -9909,6 +10903,14 @@
           "Process instance"
         ],
         "operationId": "deleteProcessInstancesBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete process instances (batch)",
         "description": "Delete multiple process instances. This will delete the historic data from secondary storage.\nOnly process instances in a final state (COMPLETED or TERMINATED) can be deleted.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "requestBody": {
@@ -9990,6 +10992,14 @@
           "Process instance"
         ],
         "operationId": "resolveIncidentsBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Resolve related incidents (batch)",
         "description": "Resolves multiple instances of process instances.\nSince only process instances with ACTIVE state can have unresolved incidents, any given\nfilters for state are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "requestBody": {
@@ -10071,6 +11081,14 @@
           "Process instance"
         ],
         "operationId": "migrateProcessInstancesBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Migrate process instances (batch)",
         "description": "Migrate multiple process instances.\nSince only process instances with ACTIVE state can be migrated, any given\nfilters for state are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "requestBody": {
@@ -10152,6 +11170,14 @@
           "Process instance"
         ],
         "operationId": "modifyProcessInstancesBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Modify process instances (batch)",
         "description": "Modify multiple process instances.\nSince only process instances with ACTIVE state can be modified, any given\nfilters for state are ignored and overridden during this batch operation.\nIn contrast to single modification operation, it is not possible to add variable instructions or modify by element key.\nIt is only possible to use the element id of the source and target.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "requestBody": {
@@ -10233,6 +11259,14 @@
           "Process instance"
         ],
         "operationId": "searchProcessInstances",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search process instances",
         "description": "Search for process instances based on given criteria.",
         "requestBody": {
@@ -10314,6 +11348,14 @@
           "Process instance"
         ],
         "operationId": "getProcessInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get process instance",
         "description": "Get the process instance by the process instance key.",
         "parameters": [
@@ -10406,6 +11448,14 @@
           "Process instance"
         ],
         "operationId": "getProcessInstanceCallHierarchy",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get call hierarchy",
         "description": "Returns the call hierarchy for a given process instance, showing its ancestry up to the root instance.",
         "parameters": [
@@ -10501,6 +11551,14 @@
           "Process instance"
         ],
         "operationId": "cancelProcessInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Cancel process instance",
         "description": "Cancels a running process instance. As a cancellation includes more than just the removal of the process instance resource, the cancellation resource must be posted. Cancellation can wait on listener-related processing; when that processing does not complete in time, this endpoint can return 504. Other gateway timeout causes are also possible. Retry with backoff and inspect listener worker availability and logs when this repeats.\n",
         "parameters": [
@@ -10600,6 +11658,14 @@
           "Process instance"
         ],
         "operationId": "deleteProcessInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete process instance",
         "description": "Deletes a process instance. Only instances that are completed or terminated can be deleted.",
         "parameters": [
@@ -10705,6 +11771,14 @@
           "Process instance"
         ],
         "operationId": "resolveProcessInstanceIncidents",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Resolve related incidents",
         "description": "Creates a batch operation to resolve multiple incidents of a process instance.",
         "parameters": [
@@ -10797,6 +11871,14 @@
           "Process instance"
         ],
         "operationId": "searchProcessInstanceIncidents",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search related incidents",
         "description": "Search for incidents caused by the process instance or any of its called process or decision instances.\n\nAlthough the `processInstanceKey` is provided as a path parameter to indicate the root process instance,\nyou may also include a `processInstanceKey` within the filter object to narrow results to specific\nchild process instances. This is useful, for example, if you want to isolate incidents associated with\nsubprocesses or called processes under the root instance while excluding incidents directly tied to the root.\n",
         "parameters": [
@@ -10899,6 +11981,14 @@
           "Process instance"
         ],
         "operationId": "migrateProcessInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Migrate process instance",
         "description": "Migrates a process instance to a new process definition.\nThis request can contain multiple mapping instructions to define mapping between the active\nprocess instance's elements and target process definition elements.\n\nUse this to upgrade a process instance to a new version of a process or to\na different process definition, e.g. to keep your running instances up-to-date with the\nlatest process improvements.\n",
         "parameters": [
@@ -10987,6 +12077,14 @@
           "Process instance"
         ],
         "operationId": "modifyProcessInstance",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Modify process instance",
         "description": "Modifies a running process instance.\nThis request can contain multiple instructions to activate an element of the process or\nto terminate an active instance of an element.\n\nUse this to repair a process instance that is stuck on an element or took an unintended path.\nFor example, because an external system is not available or doesn't respond as expected.\n",
         "parameters": [
@@ -11065,6 +12163,14 @@
           "Process instance"
         ],
         "operationId": "getProcessInstanceSequenceFlows",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get sequence flows",
         "description": "Get sequence flows taken by the process instance.",
         "parameters": [
@@ -11147,6 +12253,14 @@
           "Process instance"
         ],
         "operationId": "getProcessInstanceStatistics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get element instance statistics",
         "description": "Get statistics about elements by the process instance key.",
         "parameters": [
@@ -11229,6 +12343,14 @@
           "Resource"
         ],
         "operationId": "searchResources",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search resources",
         "description": "Search for deployed resources based on given criteria.\n:::info\nThis endpoint does not return BPMN process definitions, DMN decision definitions, or form\nresources. To query BPMN process definitions or DMN decision definitions, use their\nrespective search APIs.\n:::\n",
         "requestBody": {
@@ -11310,6 +12432,14 @@
           "Resource"
         ],
         "operationId": "getResource",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get resource",
         "description": "Returns a deployed resource.\n:::info\nThis endpoint does not return BPMN process definitions, DMN decision definitions, or form\nresources. To query BPMN process definitions or DMN decision definitions, use their\nrespective APIs.\n:::\n",
         "parameters": [
@@ -11366,6 +12496,14 @@
           "Resource"
         ],
         "operationId": "getResourceContent",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get RPA resource content (deprecated)",
         "description": "**Deprecated** — use `/resources/{resourceKey}/content/binary` instead, which supports all\nresource types and returns content as binary (octet-stream).\n\nReturns the content of a deployed RPA resource as JSON.\n:::info\nThis endpoint only supports RPA resources. For generic resource content in binary format,\nuse the `/resources/{resourceKey}/content/binary` endpoint.\n:::\n",
         "parameters": [
@@ -11432,6 +12570,14 @@
           "Resource"
         ],
         "operationId": "getResourceContentBinary",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get resource content as binary",
         "description": "Returns the content of a deployed resource in binary format (octet-stream).\n:::info\nThis endpoint does not return BPMN process definitions, DMN decision definitions, or form\nresources. To query BPMN process definitions or DMN decision definitions, use their\nrespective APIs.\n:::\n",
         "parameters": [
@@ -11488,6 +12634,14 @@
           "Resource"
         ],
         "operationId": "deleteResource",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete resource",
         "description": "Deletes a deployed resource. This can be a process definition, decision requirements\ndefinition, or form definition deployed using the deploy resources endpoint. Specify the\nresource you want to delete in the `resourceKey` parameter.\n\nOnce a resource has been deleted it cannot be recovered. If the resource needs to be\navailable again, a new deployment of the resource is required.\n\nBy default, only the resource itself is deleted from the runtime state. To also delete the\nhistoric data associated with a resource, set the `deleteHistory` flag in the request body\nto `true`. The historic data is deleted asynchronously via a batch operation. The details of\nthe created batch operation are included in the response. Note that history deletion is only\nsupported for process resources; for other resource types this flag is ignored and no history\nwill be deleted.",
         "parameters": [
@@ -11573,6 +12727,14 @@
           "Role"
         ],
         "operationId": "createRole",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Create role",
         "description": "Create a new role.",
         "x-semantic-establishes": {
@@ -11642,6 +12804,16 @@
               }
             }
           },
+          "409": {
+            "description": "Role with this id already exists.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "500": {
             "description": "An internal error occurred while processing the request.",
             "content": {
@@ -11673,6 +12845,14 @@
           "Role"
         ],
         "operationId": "searchRoles",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search roles",
         "description": "Search for roles based on given criteria.",
         "requestBody": {
@@ -11754,6 +12934,14 @@
           "Role"
         ],
         "operationId": "getRole",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get role",
         "description": "Get a role by its ID.",
         "x-semantic-requires": {
@@ -11843,6 +13031,14 @@
           "Role"
         ],
         "operationId": "updateRole",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update role",
         "description": "Update a role with the given ID.",
         "x-semantic-requires": {
@@ -11952,6 +13148,14 @@
           "Role"
         ],
         "operationId": "deleteRole",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete role",
         "description": "Deletes the role with the given ID.",
         "x-semantic-requires": {
@@ -12036,6 +13240,14 @@
           "Role"
         ],
         "operationId": "searchClientsForRole",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search role clients",
         "description": "Search clients with assigned role.",
         "x-semantic-requires": {
@@ -12147,6 +13359,14 @@
           "Role"
         ],
         "operationId": "assignRoleToClient",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a role to a client",
         "description": "Assigns the specified role to the client. The client will inherit the authorizations associated with this role.",
         "x-semantic-establishes": {
@@ -12258,6 +13478,14 @@
           "Role"
         ],
         "operationId": "unassignRoleFromClient",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a role from a client",
         "description": "Unassigns the specified role from the client. The client will no longer inherit the authorizations associated with this role.",
         "x-semantic-requires": {
@@ -12358,6 +13586,14 @@
           "Role"
         ],
         "operationId": "searchGroupsForRole",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search role groups",
         "description": "Search groups with assigned role.",
         "x-semantic-requires": {
@@ -12469,6 +13705,14 @@
           "Role"
         ],
         "operationId": "assignRoleToGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a role to a group",
         "description": "Assigns the specified role to the group. Every member of the group (user or client) will inherit the authorizations associated with this role.",
         "x-semantic-establishes": {
@@ -12581,6 +13825,14 @@
           "Role"
         ],
         "operationId": "unassignRoleFromGroup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a role from a group",
         "description": "Unassigns the specified role from the group. All group members (user or client) no longer inherit the authorizations associated with this role.",
         "x-semantic-requires": {
@@ -12681,6 +13933,14 @@
           "Role"
         ],
         "operationId": "searchMappingRulesForRole",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search role mapping rules",
         "description": "Search mapping rules with assigned role.",
         "x-semantic-requires": {
@@ -12792,6 +14052,14 @@
           "Role"
         ],
         "operationId": "assignRoleToMappingRule",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a role to a mapping rule",
         "description": "Assigns a role to a mapping rule.",
         "x-semantic-establishes": {
@@ -12903,6 +14171,14 @@
           "Role"
         ],
         "operationId": "unassignRoleFromMappingRule",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a role from a mapping rule",
         "description": "Unassigns a role from a mapping rule.",
         "x-semantic-requires": {
@@ -13003,6 +14279,14 @@
           "Role"
         ],
         "operationId": "searchUsersForRole",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search role users",
         "description": "Search users with assigned role.",
         "x-semantic-requires": {
@@ -13114,6 +14398,14 @@
           "Role"
         ],
         "operationId": "assignRoleToUser",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a role to a user",
         "description": "Assigns the specified role to the user. The user will inherit the authorizations associated with this role.",
         "x-semantic-establishes": {
@@ -13225,6 +14517,14 @@
           "Role"
         ],
         "operationId": "unassignRoleFromUser",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a role from a user",
         "description": "Unassigns a role from a user. The user will no longer inherit the authorizations associated with this role.",
         "x-semantic-requires": {
@@ -13325,6 +14625,7 @@
           "Setup"
         ],
         "operationId": "createAdminUser",
+        "security": [],
         "summary": "Create admin user",
         "description": "Creates a new user and assigns the admin role to it. This endpoint is only usable when users are managed in the Orchestration Cluster and while no user is assigned to the admin role.",
         "requestBody": {
@@ -13368,6 +14669,16 @@
               }
             }
           },
+          "409": {
+            "description": "A user with this username already exists.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "500": {
             "description": "An internal error occurred while processing the request.",
             "content": {
@@ -13399,6 +14710,14 @@
           "Signal"
         ],
         "operationId": "broadcastSignal",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Broadcast signal",
         "description": "Broadcasts a signal.",
         "requestBody": {
@@ -13473,6 +14792,7 @@
           "Cluster"
         ],
         "operationId": "getStatus",
+        "security": [],
         "summary": "Get cluster status",
         "description": "Checks the health status of the cluster by verifying if there's at least one partition with a healthy leader.",
         "responses": {
@@ -13493,6 +14813,14 @@
           "System"
         ],
         "operationId": "getUsageMetrics",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get usage metrics",
         "description": "Retrieve the usage metrics based on given criteria.",
         "parameters": [
@@ -13637,6 +14965,14 @@
           "System"
         ],
         "operationId": "getSystemConfiguration",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "x-eventually-consistent": false,
         "summary": "System configuration (alpha)",
         "description": "Returns the current system configuration. The response is an envelope\nthat groups settings by feature area.\n\nThis endpoint is an alpha feature and may be subject to change\nin future releases.\n",
@@ -13666,9 +15002,7 @@
                         ]
                       },
                       "deployment": {
-                        "isEnterprise": false,
                         "isMultiTenancyEnabled": false,
-                        "contextPath": "",
                         "maxRequestSize": 4194304
                       },
                       "authentication": {
@@ -13676,11 +15010,7 @@
                         "isLoginDelegated": false
                       },
                       "cloud": {
-                        "organizationId": null,
-                        "clusterId": null,
-                        "stage": null,
-                        "mixpanelToken": null,
-                        "mixpanelAPIHost": null
+                        "stage": "prod"
                       }
                     }
                   }
@@ -13726,6 +15056,14 @@
           "Tenant"
         ],
         "operationId": "createTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Create tenant",
         "description": "Creates a new tenant.",
         "x-semantic-establishes": {
@@ -13790,7 +15128,14 @@
             }
           },
           "409": {
-            "description": "Tenant with this id already exists."
+            "description": "Tenant with this id already exists.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "500": {
             "description": "An internal error occurred while processing the request.",
@@ -13823,6 +15168,14 @@
           "Tenant"
         ],
         "operationId": "searchTenants",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search tenants",
         "description": "Retrieves a filtered and sorted list of tenants.",
         "requestBody": {
@@ -13914,6 +15267,14 @@
           "Tenant"
         ],
         "operationId": "getTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get tenant",
         "description": "Retrieves a single tenant by tenant ID.",
         "x-semantic-requires": {
@@ -14013,6 +15374,14 @@
           "Tenant"
         ],
         "operationId": "updateTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update tenant",
         "description": "Updates an existing tenant.",
         "x-semantic-requires": {
@@ -14115,6 +15484,14 @@
           "Tenant"
         ],
         "operationId": "deleteTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete tenant",
         "description": "Deletes an existing tenant.",
         "x-semantic-requires": {
@@ -14202,6 +15579,14 @@
           "Tenant"
         ],
         "operationId": "searchClientsForTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search clients for tenant",
         "description": "Retrieves a filtered and sorted list of clients for a specified tenant.",
         "x-semantic-requires": {
@@ -14256,6 +15641,14 @@
           "Tenant"
         ],
         "operationId": "assignClientToTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a client to a tenant",
         "description": "Assign the client to the specified tenant.\nThe client can then access tenant data and perform authorized actions.\n",
         "x-semantic-establishes": {
@@ -14357,6 +15750,14 @@
           "Tenant"
         ],
         "operationId": "unassignClientFromTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a client from a tenant",
         "description": "Unassigns the client from the specified tenant.\nThe client can no longer access tenant data.\n",
         "x-semantic-requires": {
@@ -14457,6 +15858,14 @@
           "Tenant"
         ],
         "operationId": "searchGroupIdsForTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search groups for tenant",
         "description": "Retrieves a filtered and sorted list of groups for a specified tenant.",
         "x-semantic-requires": {
@@ -14511,6 +15920,14 @@
           "Tenant"
         ],
         "operationId": "assignGroupToTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a group to a tenant",
         "description": "Assigns a group to a specified tenant.\nGroup members (users, clients) can then access tenant data and perform authorized actions.\n",
         "x-semantic-establishes": {
@@ -14613,6 +16030,14 @@
           "Tenant"
         ],
         "operationId": "unassignGroupFromTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a group from a tenant",
         "description": "Unassigns a group from a specified tenant.\nMembers of the group (users, clients) will no longer have access to the tenant's data - except they are assigned directly to the tenant.\n",
         "x-semantic-requires": {
@@ -14713,6 +16138,14 @@
           "Tenant"
         ],
         "operationId": "searchMappingRulesForTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search mapping rules for tenant",
         "description": "Retrieves a filtered and sorted list of MappingRules for a specified tenant.",
         "x-semantic-requires": {
@@ -14767,6 +16200,14 @@
           "Tenant"
         ],
         "operationId": "assignMappingRuleToTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a mapping rule to a tenant",
         "description": "Assign a single mapping rule to a specified tenant.",
         "x-semantic-establishes": {
@@ -14868,6 +16309,14 @@
           "Tenant"
         ],
         "operationId": "unassignMappingRuleFromTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a mapping rule from a tenant",
         "description": "Unassigns a single mapping rule from a specified tenant without deleting the rule.",
         "x-semantic-requires": {
@@ -14968,6 +16417,14 @@
           "Tenant"
         ],
         "operationId": "searchRolesForTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search roles for tenant",
         "description": "Retrieves a filtered and sorted list of roles for a specified tenant.",
         "x-semantic-requires": {
@@ -15022,6 +16479,14 @@
           "Tenant"
         ],
         "operationId": "assignRoleToTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a role to a tenant",
         "description": "Assigns a role to a specified tenant.\nUsers, Clients or Groups, that have the role assigned, will get access to the tenant's data and can perform actions according to their authorizations.\n",
         "x-semantic-establishes": {
@@ -15123,6 +16588,14 @@
           "Tenant"
         ],
         "operationId": "unassignRoleFromTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a role from a tenant",
         "description": "Unassigns a role from a specified tenant.\nUsers, Clients or Groups, that have the role assigned, will no longer have access to the\ntenant's data - unless they are assigned directly to the tenant.\n",
         "x-semantic-requires": {
@@ -15223,6 +16696,14 @@
           "Tenant"
         ],
         "operationId": "searchUsersForTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search users for tenant",
         "description": "Retrieves a filtered and sorted list of users for a specified tenant.",
         "x-semantic-requires": {
@@ -15277,6 +16758,14 @@
           "Tenant"
         ],
         "operationId": "assignUserToTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign a user to a tenant",
         "description": "Assign a single user to a specified tenant. The user can then access tenant data and perform authorized actions.",
         "x-semantic-establishes": {
@@ -15378,6 +16867,14 @@
           "Tenant"
         ],
         "operationId": "unassignUserFromTenant",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign a user from a tenant",
         "description": "Unassigns the user from the specified tenant.\nThe user can no longer access tenant data.\n",
         "x-semantic-requires": {
@@ -15478,6 +16975,14 @@
           "Cluster"
         ],
         "operationId": "getTopology",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get cluster topology",
         "description": "Obtains the current topology of the cluster the gateway is part of.",
         "responses": {
@@ -15529,6 +17034,14 @@
           "User"
         ],
         "operationId": "createUser",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Create user",
         "description": "Create a new user.",
         "x-semantic-establishes": {
@@ -15640,6 +17153,14 @@
           "User"
         ],
         "operationId": "searchUsers",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search users",
         "description": "Search for users based on given criteria.",
         "requestBody": {
@@ -15720,6 +17241,14 @@
           "User"
         ],
         "operationId": "getUser",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get user",
         "description": "Get a user by its username.",
         "x-semantic-requires": {
@@ -15809,6 +17338,14 @@
           "User"
         ],
         "operationId": "updateUser",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update user",
         "description": "Updates a user.",
         "x-semantic-requires": {
@@ -15911,6 +17448,14 @@
           "User"
         ],
         "operationId": "deleteUser",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Delete user",
         "description": "Deletes a user.",
         "x-semantic-requires": {
@@ -15988,6 +17533,14 @@
           "User task"
         ],
         "operationId": "searchUserTasks",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search user tasks",
         "description": "Search for user tasks based on given criteria.",
         "requestBody": {
@@ -16069,6 +17622,14 @@
           "User task"
         ],
         "operationId": "getUserTask",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get user task",
         "description": "Get the user task by the user task key.",
         "parameters": [
@@ -16159,6 +17720,14 @@
           "User task"
         ],
         "operationId": "updateUserTask",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Update user task",
         "description": "Update a user task with the given key. Updates wait for blocking task listeners on this lifecycle transition. If listener processing is delayed beyond the request timeout, this endpoint can return 504. Other gateway timeout causes are also possible. Retry with backoff and inspect listener worker availability and logs when this repeats.\n",
         "parameters": [
@@ -16268,6 +17837,14 @@
           "User task"
         ],
         "operationId": "unassignUserTask",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Unassign user task",
         "description": "Removes the assignee of a task with the given key. Unassignment waits for blocking task listeners on this lifecycle transition. If listener processing is delayed beyond the request timeout, this endpoint can return 504. Other gateway timeout causes are also possible. Retry with backoff and inspect listener worker availability and logs when this repeats.\n",
         "parameters": [
@@ -16367,6 +17944,14 @@
           "User task"
         ],
         "operationId": "assignUserTask",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Assign user task",
         "description": "Assigns a user task with the given key to the given assignee. Assignment waits for blocking task listeners on this lifecycle transition. If listener processing is delayed beyond the request timeout, this endpoint can return 504. Other gateway timeout causes are also possible. Retry with backoff and inspect listener worker availability and logs when this repeats.\n",
         "parameters": [
@@ -16476,6 +18061,14 @@
           "User task"
         ],
         "operationId": "searchUserTaskAuditLogs",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search user task audit logs",
         "description": "Search for user task audit logs based on given criteria.",
         "parameters": [
@@ -16541,6 +18134,14 @@
           "User task"
         ],
         "operationId": "completeUserTask",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Complete user task",
         "description": "Completes a user task with the given key. Completion waits for blocking task listeners on this lifecycle transition. If listener processing is delayed beyond the request timeout, this endpoint can return 504. Other gateway timeout causes are also possible. Retry with backoff and inspect listener worker availability and logs when this repeats.\n",
         "parameters": [
@@ -16650,6 +18251,14 @@
           "User task"
         ],
         "operationId": "searchUserTaskEffectiveVariables",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search user task effective variables",
         "description": "Search for the effective variables of a user task. This endpoint returns deduplicated\nvariables where each variable name appears at most once. When the same variable name exists\nat multiple scope levels in the scope hierarchy, the value from the innermost scope (closest\nto the user task) takes precedence. This is useful for retrieving the actual runtime state\nof variables as seen by the user task. By default, long variable values in the response are\ntruncated.\n",
         "parameters": [
@@ -16724,6 +18333,14 @@
           "User task"
         ],
         "operationId": "getUserTaskForm",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get user task form",
         "description": "Get the form of a user task.\nNote that this endpoint will only return linked forms. This endpoint does not support embedded forms.\n",
         "parameters": [
@@ -16819,6 +18436,14 @@
           "User task"
         ],
         "operationId": "searchUserTaskVariables",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search user task variables",
         "description": "Search for user task variables based on given criteria. This endpoint returns all variable\ndocuments visible from the user task's scope, including variables from parent scopes in the\nscope hierarchy. If the same variable name exists at multiple scope levels, each scope's\nvariable is returned as a separate result. Use the\n`/user-tasks/{userTaskKey}/effective-variables/search` endpoint to get deduplicated variables\nwhere the innermost scope takes precedence. By default, long variable values in the response\nare truncated.\n",
         "parameters": [
@@ -16893,6 +18518,14 @@
           "Variable"
         ],
         "operationId": "searchVariables",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Search variables",
         "description": "Search for variables based on given criteria.\n\nThis endpoint returns variables that exist directly at the specified scopes - it does not\ninclude variables from parent scopes that would be visible through the scope hierarchy.\n\nVariables can be process-level (scoped to the process instance) or local (scoped to specific\nBPMN elements like tasks, subprocesses, etc.).\n\nBy default, long variable values in the response are truncated.",
         "parameters": [
@@ -16985,6 +18618,14 @@
           "Variable"
         ],
         "operationId": "getVariable",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
         "summary": "Get variable",
         "description": "Get a variable by its key.\n\nThis endpoint returns both process-level and local (element-scoped) variables.\nThe variable's scopeKey indicates whether it's a process-level variable or scoped to a\nspecific element instance.",
         "parameters": [
@@ -17073,14 +18714,26 @@
   },
   "components": {
     "securitySchemes": {
-      "BearerAuth": {
+      "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "bearerFormat": "JWT"
+        "bearerFormat": "JWT",
+        "x-enforcement": "conditional",
+        "x-enforcement-modes": {
+          "auth": [
+            "secured"
+          ]
+        }
       },
       "basicAuth": {
         "type": "http",
-        "scheme": "basic"
+        "scheme": "basic",
+        "x-enforcement": "conditional",
+        "x-enforcement-modes": {
+          "auth": [
+            "secured"
+          ]
+        }
       }
     },
     "schemas": {
@@ -17218,6 +18871,30 @@
                 }
               ]
             }
+          },
+          "processDefinitionId": {
+            "description": "The BPMN process ID of the process definition associated with this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ]
+          },
+          "processDefinitionVersion": {
+            "description": "The version of the process definition associated with this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IntegerFilterProperty"
+              }
+            ]
+          },
+          "processDefinitionVersionTag": {
+            "description": "The version tag of the process definition associated with this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ]
           }
         }
       },
@@ -17246,19 +18923,23 @@
         "type": "object",
         "required": [
           "agentInstanceKey",
-          "status",
-          "definition",
-          "metrics",
-          "limits",
-          "tools",
-          "elementId",
-          "processInstanceKey",
-          "processDefinitionKey",
-          "tenantId",
-          "creationDate",
-          "lastUpdatedDate",
           "completionDate",
-          "elementInstanceKeys"
+          "creationDate",
+          "definition",
+          "elementId",
+          "elementInstanceKeys",
+          "lastUpdatedDate",
+          "limits",
+          "metrics",
+          "processDefinitionId",
+          "processDefinitionKey",
+          "processDefinitionVersion",
+          "processDefinitionVersionTag",
+          "processInstanceKey",
+          "rootProcessInstanceKey",
+          "status",
+          "tenantId",
+          "tools"
         ],
         "properties": {
           "agentInstanceKey": {
@@ -17319,6 +19000,14 @@
               }
             ]
           },
+          "rootProcessInstanceKey": {
+            "description": "The key of the root process instance. The root process instance is the top-level\nancestor in the process instance hierarchy.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessInstanceKey"
+              }
+            ]
+          },
           "processDefinitionKey": {
             "description": "The key of the process definition associated with this agent instance.",
             "allOf": [
@@ -17326,6 +19015,24 @@
                 "$ref": "#/components/schemas/ProcessDefinitionKey"
               }
             ]
+          },
+          "processDefinitionId": {
+            "description": "The BPMN process ID of the process definition associated with this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessDefinitionId"
+              }
+            ]
+          },
+          "processDefinitionVersion": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The version of the process definition associated with this agent instance."
+          },
+          "processDefinitionVersionTag": {
+            "type": "string",
+            "nullable": true,
+            "description": "The version tag of the process definition associated with this agent instance."
           },
           "tenantId": {
             "description": "The tenant ID of this agent instance.",
@@ -17391,9 +19098,9 @@
         "description": "A tool available to the agent.",
         "type": "object",
         "required": [
-          "name",
           "description",
-          "elementId"
+          "elementId",
+          "name"
         ],
         "properties": {
           "name": {
@@ -17417,8 +19124,8 @@
         "type": "object",
         "required": [
           "inputTokens",
-          "outputTokens",
           "modelCalls",
+          "outputTokens",
           "toolCalls"
         ],
         "properties": {
@@ -17434,12 +19141,12 @@
           },
           "modelCalls": {
             "type": "integer",
-            "format": "int64",
+            "format": "int32",
             "description": "Total number of LLM calls made."
           },
           "toolCalls": {
             "type": "integer",
-            "format": "int64",
+            "format": "int32",
             "description": "Total number of tool calls made."
           }
         }
@@ -17455,12 +19162,12 @@
         "properties": {
           "maxModelCalls": {
             "type": "integer",
-            "format": "int64",
+            "format": "int32",
             "description": "Maximum LLM calls allowed. -1 if no limit is configured."
           },
           "maxToolCalls": {
             "type": "integer",
-            "format": "int64",
+            "format": "int32",
             "description": "Maximum tool calls allowed. -1 if no limit is configured."
           },
           "maxTokens": {
@@ -17474,9 +19181,20 @@
         "description": "The current status of an agent instance.",
         "type": "string",
         "enum": [
+          "UNKNOWN",
           "COMPLETED",
           "IDLE",
           "INITIALIZING",
+          "THINKING",
+          "TOOL_CALLING",
+          "TOOL_DISCOVERY"
+        ]
+      },
+      "AgentInstanceUpdateStatusEnum": {
+        "description": "The status values that can be set on an agent instance via an update request.\n",
+        "type": "string",
+        "enum": [
+          "IDLE",
           "THINKING",
           "TOOL_CALLING",
           "TOOL_DISCOVERY"
@@ -17486,8 +19204,8 @@
         "description": "Request to create a new agent instance.",
         "type": "object",
         "required": [
-          "elementInstanceKey",
-          "definition"
+          "definition",
+          "elementInstanceKey"
         ],
         "properties": {
           "elementInstanceKey": {
@@ -17554,27 +19272,39 @@
           },
           "modelCalls": {
             "type": "integer",
-            "format": "int64",
+            "format": "int32",
             "minimum": 0,
             "description": "Increment to apply to the total model call counter."
           },
           "toolCalls": {
             "type": "integer",
-            "format": "int64",
+            "format": "int32",
             "minimum": 0,
             "description": "Increment to apply to the total tool call counter."
           }
         }
       },
       "AgentInstanceUpdateRequest": {
-        "description": "Request to update the mutable state of an agent instance. At least one of\nstatus, metrics, or tools must be provided.\n",
+        "description": "Request to update the mutable state of an agent instance.\n",
         "type": "object",
+        "required": [
+          "elementInstanceKey"
+        ],
         "properties": {
+          "elementInstanceKey": {
+            "nullable": false,
+            "description": "The key of the currently-active element instance for this agent instance.\nUsed for ownership/equality validation against the stored agent instance\nand, when the supplied key differs from the previous association (re-entry\nof an ad-hoc sub-process or AI Agent task), appended to elementInstanceKeys\nwith the reverse link updated on the supplied element instance.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementInstanceKey"
+              }
+            ]
+          },
           "status": {
             "description": "The new status of the agent instance.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/AgentInstanceStatusEnum"
+                "$ref": "#/components/schemas/AgentInstanceUpdateStatusEnum"
               }
             ]
           },
@@ -17588,6 +19318,7 @@
           },
           "tools": {
             "description": "The complete list of tools available to the agent, replacing any previously\nstored tools. When provided, the engine replaces the existing tool list with\nthis value.\n",
+            "nullable": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/AgentTool"
@@ -17647,37 +19378,37 @@
         "description": "Audit log item.",
         "type": "object",
         "required": [
-          "auditLogKey",
-          "entityKey",
-          "entityType",
-          "operationType",
-          "batchOperationKey",
-          "batchOperationType",
-          "timestamp",
           "actorId",
           "actorType",
           "agentElementId",
-          "tenantId",
-          "result",
+          "auditLogKey",
+          "batchOperationKey",
+          "batchOperationType",
           "category",
-          "processDefinitionId",
-          "processDefinitionKey",
-          "processInstanceKey",
-          "rootProcessInstanceKey",
-          "elementInstanceKey",
-          "jobKey",
-          "userTaskKey",
-          "decisionRequirementsId",
-          "decisionRequirementsKey",
           "decisionDefinitionId",
           "decisionDefinitionKey",
           "decisionEvaluationKey",
+          "decisionRequirementsId",
+          "decisionRequirementsKey",
           "deploymentKey",
+          "elementInstanceKey",
+          "entityDescription",
+          "entityKey",
+          "entityType",
           "formKey",
-          "resourceKey",
+          "jobKey",
+          "operationType",
+          "processDefinitionId",
+          "processDefinitionKey",
+          "processInstanceKey",
           "relatedEntityKey",
           "relatedEntityType",
-          "entityDescription"
+          "resourceKey",
+          "result",
+          "rootProcessInstanceKey",
+          "tenantId",
+          "timestamp",
+          "userTaskKey"
         ],
         "properties": {
           "auditLogKey": {
@@ -18608,14 +20339,14 @@
         "type": "object",
         "required": [
           "authorizedComponents",
-          "tenants",
-          "groups",
-          "roles",
-          "salesPlanType",
           "c8Links",
           "canLogout",
           "displayName",
           "email",
+          "groups",
+          "roles",
+          "salesPlanType",
+          "tenants",
           "username"
         ],
         "properties": {
@@ -18734,9 +20465,9 @@
         "required": [
           "ownerId",
           "ownerType",
+          "permissionTypes",
           "resourceId",
-          "resourceType",
-          "permissionTypes"
+          "resourceType"
         ]
       },
       "AuthorizationPropertyBasedRequest": {
@@ -18777,9 +20508,9 @@
         "required": [
           "ownerId",
           "ownerType",
+          "permissionTypes",
           "resourcePropertyName",
-          "resourceType",
-          "permissionTypes"
+          "resourceType"
         ],
         "x-properties-added-in-version": [
           {
@@ -18892,13 +20623,13 @@
       },
       "AuthorizationResult": {
         "required": [
+          "authorizationKey",
           "ownerId",
           "ownerType",
-          "resourceType",
+          "permissionTypes",
           "resourceId",
           "resourcePropertyName",
-          "permissionTypes",
-          "authorizationKey"
+          "resourceType"
         ],
         "type": "object",
         "properties": {
@@ -19250,17 +20981,17 @@
       },
       "BatchOperationResponse": {
         "required": [
+          "actorId",
+          "actorType",
           "batchOperationKey",
           "batchOperationType",
-          "state",
+          "endDate",
+          "errors",
           "operationsCompletedCount",
           "operationsFailedCount",
           "operationsTotalCount",
-          "actorType",
-          "actorId",
-          "errors",
-          "endDate",
-          "startDate"
+          "startDate",
+          "state"
         ],
         "type": "object",
         "properties": {
@@ -19490,13 +21221,13 @@
       "BatchOperationItemResponse": {
         "type": "object",
         "required": [
-          "rootProcessInstanceKey",
           "batchOperationKey",
           "errorMessage",
           "itemKey",
           "operationType",
-          "processedDate",
           "processInstanceKey",
+          "processedDate",
+          "rootProcessInstanceKey",
           "state"
         ],
         "properties": {
@@ -19715,8 +21446,8 @@
           }
         },
         "required": [
-          "targetProcessDefinitionKey",
-          "mappingInstructions"
+          "mappingInstructions",
+          "targetProcessDefinitionKey"
         ]
       },
       "ProcessInstanceModificationBatchOperationRequest": {
@@ -20061,8 +21792,8 @@
         "description": "Cluster variable search response item.",
         "type": "object",
         "required": [
-          "value",
-          "isTruncated"
+          "isTruncated",
+          "value"
         ],
         "allOf": [
           {
@@ -20272,12 +22003,12 @@
         "type": "object",
         "required": [
           "brokers",
+          "clusterId",
           "clusterSize",
-          "partitionsCount",
-          "replicationFactor",
           "gatewayVersion",
           "lastCompletedChangeId",
-          "clusterId"
+          "partitionsCount",
+          "replicationFactor"
         ],
         "properties": {
           "brokers": {
@@ -20356,10 +22087,10 @@
         "description": "Provides information on a broker node.",
         "type": "object",
         "required": [
-          "nodeId",
           "host",
-          "port",
+          "nodeId",
           "partitions",
+          "port",
           "version"
         ],
         "properties": {
@@ -20398,9 +22129,9 @@
         "description": "Provides information on a partition within a broker node.",
         "type": "object",
         "required": [
+          "health",
           "partitionId",
-          "role",
-          "health"
+          "role"
         ],
         "properties": {
           "partitionId": {
@@ -20466,8 +22197,8 @@
       "EvaluateConditionalResult": {
         "type": "object",
         "required": [
-          "processInstances",
           "conditionalEvaluationKey",
+          "processInstances",
           "tenantId"
         ],
         "x-semantic-provider": [
@@ -20998,14 +22729,14 @@
       },
       "EvaluatedDecisionResult": {
         "required": [
-          "decisionDefinitionType",
-          "evaluatedInputs",
-          "matchedRules",
           "decisionDefinitionId",
           "decisionDefinitionKey",
           "decisionDefinitionName",
+          "decisionDefinitionType",
           "decisionDefinitionVersion",
           "decisionEvaluationInstanceKey",
+          "evaluatedInputs",
+          "matchedRules",
           "output",
           "tenantId"
         ],
@@ -21629,11 +23360,11 @@
       },
       "EvaluatedDecisionOutputItem": {
         "required": [
-          "ruleId",
-          "ruleIndex",
           "outputId",
           "outputName",
-          "outputValue"
+          "outputValue",
+          "ruleId",
+          "ruleIndex"
         ],
         "type": "object",
         "description": "The evaluated decision outputs.",
@@ -22016,8 +23747,11 @@
         "type": "object",
         "required": [
           "deploymentKey",
-          "tenantId",
-          "deployments"
+          "deployments",
+          "tenantId"
+        ],
+        "x-semantic-provider": [
+          "deploymentKey"
         ],
         "properties": {
           "deploymentKey": {
@@ -22048,10 +23782,10 @@
       "DeploymentMetadataResult": {
         "type": "object",
         "required": [
-          "processDefinition",
           "decisionDefinition",
           "decisionRequirements",
           "form",
+          "processDefinition",
           "resource"
         ],
         "properties": {
@@ -22117,9 +23851,9 @@
         "type": "object",
         "required": [
           "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionVersion",
           "resourceName",
-          "processDefinitionKey",
           "tenantId"
         ],
         "properties": {
@@ -22384,8 +24118,8 @@
       "DeleteResourceResponse": {
         "type": "object",
         "required": [
-          "resourceKey",
-          "batchOperation"
+          "batchOperation",
+          "resourceKey"
         ],
         "properties": {
           "resourceKey": {
@@ -22420,12 +24154,12 @@
       "ResourceResult": {
         "type": "object",
         "required": [
-          "resourceName",
-          "version",
-          "versionTag",
           "resourceId",
+          "resourceKey",
+          "resourceName",
           "tenantId",
-          "resourceKey"
+          "version",
+          "versionTag"
         ],
         "properties": {
           "resourceName": {
@@ -22807,10 +24541,10 @@
         "type": "object",
         "required": [
           "camunda.document.type",
-          "storeId",
-          "documentId",
           "contentHash",
-          "metadata"
+          "documentId",
+          "metadata",
+          "storeId"
         ],
         "properties": {
           "camunda.document.type": {
@@ -22907,8 +24641,8 @@
           {
             "type": "object",
             "required": [
-              "failedDocuments",
-              "createdDocuments"
+              "createdDocuments",
+              "failedDocuments"
             ],
             "properties": {
               "failedDocuments": {
@@ -23008,13 +24742,13 @@
         "description": "Information about the document that is returned in responses.",
         "type": "object",
         "required": [
-          "fileName",
-          "expiresAt",
-          "size",
           "contentType",
           "customProperties",
+          "expiresAt",
+          "fileName",
           "processDefinitionId",
-          "processInstanceKey"
+          "processInstanceKey",
+          "size"
         ],
         "properties": {
           "contentType": {
@@ -23089,8 +24823,8 @@
       "DocumentLink": {
         "type": "object",
         "required": [
-          "url",
-          "expiresAt"
+          "expiresAt",
+          "url"
         ],
         "properties": {
           "url": {
@@ -23167,7 +24901,33 @@
         }
       },
       "ElementInstanceFilter": {
-        "description": "Element instance filter.",
+        "description": "Element instance search filter.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ElementInstanceFilterFields"
+          },
+          {
+            "type": "object",
+            "x-properties-added-in-version": [
+              {
+                "propertyName": "$or",
+                "addedInVersion": "8.10"
+              }
+            ],
+            "properties": {
+              "$or": {
+                "description": "Defines a list of alternative filter groups combined using OR logic. Each object in the array is evaluated independently, and the filter matches if any one of them is satisfied.\n\nTop-level fields and the `$or` clause are combined using AND logic — meaning: (top-level filters) AND (any of the `$or` filters) must match.\n<br>\n<em>Example:</em>\n\n```json\n{\n  \"processInstanceKey\": \"2251799813685323\",\n  \"$or\": [\n    { \"elementName\": { \"$like\": \"*Order*\" } },\n    { \"elementId\":   { \"$like\": \"*Order*\" } }\n  ]\n}\n```\nThis matches element instances scoped to the given process instance whose:\n\n<ul style=\"padding-left: 20px; margin-left: 20px;\">\n  <li style=\"list-style-type: disc;\"><code>elementName</code> contains <em>Order</em>, or</li>\n  <li style=\"list-style-type: disc;\"><code>elementId</code> contains <em>Order</em></li>\n</ul>\n<br>\n<p>Note: Using complex <code>$or</code> conditions may impact performance, use with caution in high-volume environments.\n",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ElementInstanceFilterFields"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "ElementInstanceFilterFields": {
+        "description": "Element instance filter fields.",
         "type": "object",
         "properties": {
           "processDefinitionId": {
@@ -23375,20 +25135,20 @@
       "ElementInstanceResult": {
         "type": "object",
         "required": [
-          "processDefinitionId",
-          "startDate",
           "elementId",
-          "elementName",
-          "type",
-          "state",
-          "hasIncident",
-          "tenantId",
           "elementInstanceKey",
-          "processInstanceKey",
-          "processDefinitionKey",
-          "rootProcessInstanceKey",
+          "elementName",
           "endDate",
-          "incidentKey"
+          "hasIncident",
+          "incidentKey",
+          "processDefinitionId",
+          "processDefinitionKey",
+          "processInstanceKey",
+          "rootProcessInstanceKey",
+          "startDate",
+          "state",
+          "tenantId",
+          "type"
         ],
         "properties": {
           "processDefinitionId": {
@@ -23554,6 +25314,394 @@
           "elements"
         ]
       },
+      "ElementInstanceWaitStateQuery": {
+        "description": "Element instance inspection request.",
+        "type": "object",
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SearchQueryRequest"
+          }
+        ],
+        "properties": {
+          "filter": {
+            "description": "Filter criteria for the inspection.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementInstanceWaitStateFilter"
+              }
+            ]
+          }
+        }
+      },
+      "ElementInstanceWaitStateFilter": {
+        "description": "Filters for the element instance inspection.",
+        "type": "object",
+        "properties": {
+          "elementInstanceKey": {
+            "description": "Filter by element instance key.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementInstanceKeyFilterProperty"
+              }
+            ]
+          },
+          "processInstanceKey": {
+            "description": "Filter by process instance key.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessInstanceKeyFilterProperty"
+              }
+            ]
+          },
+          "rootProcessInstanceKey": {
+            "description": "Filter by root process instance key.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessInstanceKeyFilterProperty"
+              }
+            ]
+          },
+          "elementId": {
+            "description": "Filter by element ID.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementIdFilterProperty"
+              }
+            ]
+          },
+          "elementType": {
+            "description": "Filter by element type.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WaitStateElementTypeFilterProperty"
+              }
+            ]
+          },
+          "waitStateType": {
+            "description": "Filter by wait state type.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WaitStateTypeFilterProperty"
+              }
+            ]
+          }
+        }
+      },
+      "WaitStateElementTypeFilterProperty": {
+        "description": "Element type property with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/WaitStateElementTypeExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedWaitStateElementTypeFilter"
+          }
+        ]
+      },
+      "AdvancedWaitStateElementTypeFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced element type filter.",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WaitStateElementTypeEnum"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WaitStateElementTypeEnum"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WaitStateElementTypeEnum"
+            }
+          },
+          "$like": {
+            "$ref": "#/components/schemas/LikeFilter"
+          }
+        }
+      },
+      "WaitStateElementTypeEnum": {
+        "description": "The BPMN element type of a waiting element instance.",
+        "type": "string",
+        "enum": [
+          "AD_HOC_SUB_PROCESS",
+          "AD_HOC_SUB_PROCESS_INNER_INSTANCE",
+          "BOUNDARY_EVENT",
+          "BUSINESS_RULE_TASK",
+          "CALL_ACTIVITY",
+          "END_EVENT",
+          "EVENT_BASED_GATEWAY",
+          "EVENT_SUB_PROCESS",
+          "EXCLUSIVE_GATEWAY",
+          "INCLUSIVE_GATEWAY",
+          "INTERMEDIATE_CATCH_EVENT",
+          "INTERMEDIATE_THROW_EVENT",
+          "MANUAL_TASK",
+          "MULTI_INSTANCE_BODY",
+          "PARALLEL_GATEWAY",
+          "PROCESS",
+          "RECEIVE_TASK",
+          "SCRIPT_TASK",
+          "SEND_TASK",
+          "SEQUENCE_FLOW",
+          "SERVICE_TASK",
+          "START_EVENT",
+          "SUB_PROCESS",
+          "TASK",
+          "UNKNOWN",
+          "UNSPECIFIED",
+          "USER_TASK"
+        ]
+      },
+      "WaitStateTypeFilterProperty": {
+        "description": "Wait state type property with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/WaitStateTypeExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedWaitStateTypeFilter"
+          }
+        ]
+      },
+      "AdvancedWaitStateTypeFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced wait state type filter.",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WaitStateTypeEnum"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WaitStateTypeEnum"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WaitStateTypeEnum"
+            }
+          },
+          "$like": {
+            "$ref": "#/components/schemas/LikeFilter"
+          }
+        }
+      },
+      "ElementInstanceWaitStateQueryResult": {
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SearchQueryResponse"
+          }
+        ],
+        "properties": {
+          "items": {
+            "description": "The matching waiting states.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ElementInstanceWaitStateResult"
+            }
+          }
+        }
+      },
+      "ElementInstanceWaitStateResult": {
+        "description": "An element instance waiting state.",
+        "type": "object",
+        "required": [
+          "elementId",
+          "elementInstanceKey",
+          "elementType",
+          "jobDetails",
+          "messageDetails",
+          "processInstanceKey",
+          "rootProcessInstanceKey",
+          "tenantId",
+          "waitStateType"
+        ],
+        "properties": {
+          "waitStateType": {
+            "description": "The type of waiting state an element instance is in.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WaitStateTypeEnum"
+              }
+            ]
+          },
+          "rootProcessInstanceKey": {
+            "description": "Key of the root process instance.",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessInstanceKey"
+              }
+            ]
+          },
+          "processInstanceKey": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessInstanceKey"
+              }
+            ],
+            "description": "The process instance key associated to this element instance."
+          },
+          "elementInstanceKey": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementInstanceKey"
+              }
+            ],
+            "description": "The element instance key associated to this element instance."
+          },
+          "elementId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementId"
+              }
+            ],
+            "description": "The element ID for this element instance."
+          },
+          "elementType": {
+            "description": "The BPMN element type of this element instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WaitStateElementTypeEnum"
+              }
+            ]
+          },
+          "tenantId": {
+            "description": "The tenant ID of the element instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantId"
+              }
+            ]
+          },
+          "jobDetails": {
+            "description": "Job details, present when waitStateType is JOB.",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobWaitStateDetails"
+              }
+            ]
+          },
+          "messageDetails": {
+            "description": "Message details, present when waitStateType is MESSAGE.",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MessageWaitStateDetails"
+              }
+            ]
+          }
+        }
+      },
+      "WaitStateTypeEnum": {
+        "description": "The type of waiting state an element instance is in.",
+        "type": "string",
+        "enum": [
+          "JOB",
+          "MESSAGE"
+        ]
+      },
+      "JobWaitStateDetails": {
+        "type": "object",
+        "required": [
+          "jobKey",
+          "jobKind",
+          "jobType",
+          "listenerEventType",
+          "retries"
+        ],
+        "properties": {
+          "jobKey": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobKey"
+              }
+            ],
+            "description": "The key of the job."
+          },
+          "jobType": {
+            "description": "The job type (worker subscription identifier).",
+            "type": "string"
+          },
+          "jobKind": {
+            "description": "The kind of job.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobKindEnum"
+              }
+            ]
+          },
+          "listenerEventType": {
+            "description": "The listener event type of the job (only set for execution listener and task listener jobs).",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobListenerEventTypeEnum"
+              }
+            ]
+          },
+          "retries": {
+            "description": "The number of retries remaining for the job.",
+            "nullable": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "MessageWaitStateDetails": {
+        "type": "object",
+        "required": [
+          "correlationKey",
+          "messageName"
+        ],
+        "properties": {
+          "messageName": {
+            "description": "The name of the message being awaited.",
+            "type": "string"
+          },
+          "correlationKey": {
+            "description": "The correlation key for the message subscription (null for start events).",
+            "nullable": true,
+            "type": "string"
+          }
+        }
+      },
       "AdHocSubProcessActivateActivityReference": {
         "type": "object",
         "properties": {
@@ -23591,6 +25739,14 @@
             "description": "Required when the expression references tenant-scoped cluster variables",
             "example": "tenant_123"
           },
+          "scopeKey": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScopeKey"
+              }
+            ],
+            "description": "Key of the process instance or element instance whose variables should be made visible\nto the expression. Use a process instance key to evaluate against the process instance\nscope, or an element instance key to evaluate against that element instance scope. If\nomitted, the expression is evaluated unscoped, using only cluster variables\nand request-body variables.\n"
+          },
           "variables": {
             "type": "object",
             "description": "Optional variables for expression evaluation. These variables are only used for the current evaluation and do not persist beyond it.",
@@ -23601,7 +25757,13 @@
             "additionalProperties": true,
             "nullable": true
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "scopeKey",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "ExpressionEvaluationResult": {
         "type": "object",
@@ -23953,11 +26115,11 @@
           "formKey"
         ],
         "required": [
-          "tenantId",
           "formId",
+          "formKey",
           "schema",
-          "version",
-          "formKey"
+          "tenantId",
+          "version"
         ],
         "properties": {
           "tenantId": {
@@ -24082,9 +26244,9 @@
       "CreateGlobalTaskListenerRequest": {
         "type": "object",
         "required": [
+          "eventTypes",
           "id",
-          "type",
-          "eventTypes"
+          "type"
         ],
         "allOf": [
           {
@@ -24100,8 +26262,8 @@
       "UpdateGlobalTaskListenerRequest": {
         "type": "object",
         "required": [
-          "type",
-          "eventTypes"
+          "eventTypes",
+          "type"
         ],
         "allOf": [
           {
@@ -24112,13 +26274,13 @@
       "GlobalTaskListenerResult": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "retries",
-          "eventTypes",
           "afterNonGlobal",
+          "eventTypes",
+          "id",
           "priority",
-          "source"
+          "retries",
+          "source",
+          "type"
         ],
         "allOf": [
           {
@@ -24409,9 +26571,9 @@
           }
         },
         "required": [
+          "description",
           "groupId",
-          "name",
-          "description"
+          "name"
         ]
       },
       "GroupUpdateRequest": {
@@ -24452,9 +26614,9 @@
           }
         },
         "required": [
+          "description",
           "groupId",
-          "name",
-          "description"
+          "name"
         ]
       },
       "GroupResult": {
@@ -24480,9 +26642,9 @@
           }
         },
         "required": [
-          "name",
+          "description",
           "groupId",
-          "description"
+          "name"
         ]
       },
       "GroupSearchQuerySortRequest": {
@@ -25465,18 +27627,18 @@
       "IncidentResult": {
         "type": "object",
         "required": [
+          "creationTime",
+          "elementId",
+          "elementInstanceKey",
+          "errorMessage",
+          "errorType",
           "incidentKey",
+          "jobKey",
+          "processDefinitionId",
           "processDefinitionKey",
           "processInstanceKey",
-          "elementInstanceKey",
-          "creationTime",
-          "state",
-          "errorType",
-          "errorMessage",
-          "elementId",
-          "processDefinitionId",
           "rootProcessInstanceKey",
-          "jobKey",
+          "state",
           "tenantId"
         ],
         "properties": {
@@ -25858,8 +28020,8 @@
         "description": "Global job statistics query result.",
         "type": "object",
         "required": [
-          "created",
           "completed",
+          "created",
           "failed",
           "isIncomplete"
         ],
@@ -25954,8 +28116,8 @@
         "description": "Job type statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -25976,10 +28138,10 @@
         "description": "Statistics for a single job type.",
         "type": "object",
         "required": [
-          "jobType",
-          "created",
           "completed",
+          "created",
           "failed",
+          "jobType",
           "workers"
         ],
         "properties": {
@@ -26030,8 +28192,8 @@
         "type": "object",
         "required": [
           "from",
-          "to",
-          "jobType"
+          "jobType",
+          "to"
         ],
         "properties": {
           "from": {
@@ -26057,8 +28219,8 @@
         "description": "Job worker statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -26079,10 +28241,10 @@
         "description": "Statistics for a single worker within a job type.",
         "type": "object",
         "required": [
-          "worker",
-          "created",
           "completed",
-          "failed"
+          "created",
+          "failed",
+          "worker"
         ],
         "properties": {
           "worker": {
@@ -26126,8 +28288,8 @@
         "type": "object",
         "required": [
           "from",
-          "to",
-          "jobType"
+          "jobType",
+          "to"
         ],
         "properties": {
           "from": {
@@ -26158,8 +28320,8 @@
         "description": "Job time-series statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -26180,10 +28342,10 @@
         "description": "Aggregated job metrics for a single time bucket.",
         "type": "object",
         "required": [
-          "time",
-          "created",
           "completed",
-          "failed"
+          "created",
+          "failed",
+          "time"
         ],
         "properties": {
           "time": {
@@ -26228,8 +28390,8 @@
         "type": "object",
         "required": [
           "from",
-          "to",
-          "jobType"
+          "jobType",
+          "to"
         ],
         "properties": {
           "from": {
@@ -26271,8 +28433,8 @@
         "description": "Job error statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -26378,9 +28540,9 @@
           }
         },
         "required": [
-          "type",
           "maxJobsToActivate",
-          "timeout"
+          "timeout",
+          "type"
         ],
         "x-properties-added-in-version": [
           {
@@ -26413,25 +28575,26 @@
         ],
         "type": "object",
         "required": [
-          "type",
-          "processDefinitionId",
-          "processDefinitionVersion",
-          "elementId",
           "customHeaders",
-          "worker",
-          "retries",
           "deadline",
-          "variables",
-          "tenantId",
-          "jobKey",
-          "processInstanceKey",
-          "processDefinitionKey",
+          "elementId",
           "elementInstanceKey",
+          "jobKey",
           "kind",
           "listenerEventType",
+          "priority",
+          "processDefinitionId",
+          "processDefinitionKey",
+          "processDefinitionVersion",
+          "processInstanceKey",
+          "retries",
           "rootProcessInstanceKey",
           "tags",
-          "userTask"
+          "tenantId",
+          "type",
+          "userTask",
+          "variables",
+          "worker"
         ],
         "properties": {
           "type": {
@@ -26555,6 +28718,11 @@
                 "$ref": "#/components/schemas/ProcessInstanceKey"
               }
             ]
+          },
+          "priority": {
+            "description": "The priority of the job. Higher values indicate higher priority. Jobs created before 8.10 have no stored priority; the API returns 0 for such jobs.\n",
+            "type": "integer",
+            "format": "int32"
           }
         },
         "x-properties-added-in-version": [
@@ -26577,16 +28745,20 @@
           {
             "propertyName": "rootProcessInstanceKey",
             "addedInVersion": "8.9"
+          },
+          {
+            "propertyName": "priority",
+            "addedInVersion": "8.10"
           }
         ]
       },
       "UserTaskProperties": {
         "required": [
+          "action",
+          "assignee",
           "candidateGroups",
           "candidateUsers",
           "changedAttributes",
-          "action",
-          "assignee",
           "dueDate",
           "followUpDate",
           "formKey",
@@ -26710,6 +28882,7 @@
               "jobKey",
               "kind",
               "listenerEventType",
+              "priority",
               "processDefinitionId",
               "processDefinitionKey",
               "processInstanceKey",
@@ -26822,6 +28995,14 @@
               }
             ]
           },
+          "priority": {
+            "description": "The priority of the job. Jobs created before 8.10 have no stored priority and are excluded from results when this filter is applied.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IntegerFilterProperty"
+              }
+            ]
+          },
           "processDefinitionId": {
             "description": "The process definition ID associated with the job.",
             "allOf": [
@@ -26911,6 +29092,10 @@
           {
             "propertyName": "lastUpdateTime",
             "addedInVersion": "8.9"
+          },
+          {
+            "propertyName": "priority",
+            "addedInVersion": "8.10"
           }
         ]
       },
@@ -26938,30 +29123,31 @@
       "JobSearchResult": {
         "type": "object",
         "required": [
+          "creationTime",
           "customHeaders",
+          "deadline",
+          "deniedReason",
           "elementId",
           "elementInstanceKey",
+          "endTime",
+          "errorCode",
+          "errorMessage",
           "hasFailedWithRetriesLeft",
+          "isDenied",
           "jobKey",
           "kind",
+          "lastUpdateTime",
           "listenerEventType",
+          "priority",
           "processDefinitionId",
           "processDefinitionKey",
           "processInstanceKey",
           "retries",
+          "rootProcessInstanceKey",
           "state",
           "tenantId",
           "type",
-          "worker",
-          "rootProcessInstanceKey",
-          "creationTime",
-          "deadline",
-          "deniedReason",
-          "endTime",
-          "errorCode",
-          "errorMessage",
-          "isDenied",
-          "lastUpdateTime"
+          "worker"
         ],
         "properties": {
           "customHeaders": {
@@ -27101,6 +29287,11 @@
             "nullable": true,
             "type": "string",
             "format": "date-time"
+          },
+          "priority": {
+            "description": "The priority of the job. Higher values indicate higher priority. Jobs created before 8.10 have no stored priority; they appear last when sorting by this field and are excluded when filtering by this field. The API returns 0 for such jobs.\n",
+            "type": "integer",
+            "format": "int32"
           }
         },
         "x-properties-added-in-version": [
@@ -27115,6 +29306,10 @@
           {
             "propertyName": "lastUpdateTime",
             "addedInVersion": "8.9"
+          },
+          {
+            "propertyName": "priority",
+            "addedInVersion": "8.10"
           }
         ]
       },
@@ -27411,6 +29606,7 @@
         "enum": [
           "ASSIGNING",
           "BEFORE_ALL",
+          "CANCEL",
           "CANCELING",
           "COMPLETING",
           "CREATING",
@@ -27647,7 +29843,6 @@
         "type": "string",
         "format": "ScopeKey",
         "x-semantic-type": "ScopeKey",
-        "example": "2251799813683890",
         "oneOf": [
           {
             "$ref": "#/components/schemas/ProcessInstanceKey"
@@ -28588,10 +30783,10 @@
         "description": "The response of a license request.",
         "type": "object",
         "required": [
-          "validLicense",
-          "licenseType",
+          "expiresAt",
           "isCommercial",
-          "expiresAt"
+          "licenseType",
+          "validLicense"
         ],
         "properties": {
           "validLicense": {
@@ -28705,8 +30900,8 @@
         "required": [
           "claimName",
           "claimValue",
-          "name",
-          "mappingRuleId"
+          "mappingRuleId",
+          "name"
         ]
       },
       "MappingRuleCreateResult": {
@@ -28772,8 +30967,8 @@
         "required": [
           "claimName",
           "claimValue",
-          "name",
-          "mappingRuleId"
+          "mappingRuleId",
+          "name"
         ]
       },
       "MappingRuleSearchQuerySortRequest": {
@@ -28888,9 +31083,9 @@
         ],
         "type": "object",
         "required": [
-          "tenantId",
           "messageKey",
-          "processInstanceKey"
+          "processInstanceKey",
+          "tenantId"
         ],
         "properties": {
           "tenantId": {
@@ -28968,8 +31163,8 @@
         ],
         "type": "object",
         "required": [
-          "tenantId",
-          "messageKey"
+          "messageKey",
+          "tenantId"
         ],
         "properties": {
           "tenantId": {
@@ -29013,11 +31208,9 @@
       "MessageSubscriptionResult": {
         "type": "object",
         "required": [
-          "rootProcessInstanceKey",
           "correlationKey",
           "elementId",
           "elementInstanceKey",
-          "toolProperties",
           "inboundConnectorType",
           "lastUpdatedDate",
           "messageName",
@@ -29029,8 +31222,10 @@
           "processDefinitionName",
           "processDefinitionVersion",
           "processInstanceKey",
+          "rootProcessInstanceKey",
           "tenantId",
-          "toolName"
+          "toolName",
+          "toolProperties"
         ],
         "properties": {
           "messageSubscriptionKey": {
@@ -29460,16 +31655,16 @@
           "correlationKey",
           "correlationTime",
           "elementId",
+          "elementInstanceKey",
           "messageKey",
           "messageName",
           "partitionId",
           "processDefinitionId",
+          "processDefinitionKey",
           "processInstanceKey",
-          "subscriptionKey",
-          "tenantId",
           "rootProcessInstanceKey",
-          "elementInstanceKey",
-          "processDefinitionKey"
+          "subscriptionKey",
+          "tenantId"
         ],
         "properties": {
           "correlationKey": {
@@ -29920,11 +32115,11 @@
         "description": "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
         "type": "object",
         "required": [
-          "type",
-          "title",
-          "status",
           "detail",
-          "instance"
+          "instance",
+          "status",
+          "title",
+          "type"
         ],
         "properties": {
           "type": {
@@ -30092,14 +32287,14 @@
       "ProcessDefinitionResult": {
         "type": "object",
         "required": [
-          "processDefinitionKey",
+          "hasStartForm",
           "name",
-          "resourceName",
-          "version",
-          "versionTag",
           "processDefinitionId",
+          "processDefinitionKey",
+          "resourceName",
           "tenantId",
-          "hasStartForm"
+          "version",
+          "versionTag"
         ],
         "properties": {
           "name": {
@@ -30535,13 +32730,13 @@
           }
         },
         "required": [
+          "activeInstancesWithIncidentCount",
+          "activeInstancesWithoutIncidentCount",
           "processDefinitionId",
           "processDefinitionKey",
-          "tenantId",
           "processDefinitionName",
           "processDefinitionVersion",
-          "activeInstancesWithIncidentCount",
-          "activeInstancesWithoutIncidentCount"
+          "tenantId"
         ]
       },
       "ProcessDefinitionInstanceVersionStatisticsQuerySortRequest": {
@@ -30829,14 +33024,14 @@
           "processInstanceKey"
         ],
         "required": [
+          "businessId",
           "processDefinitionId",
           "processDefinitionKey",
           "processDefinitionVersion",
-          "tenantId",
-          "variables",
           "processInstanceKey",
           "tags",
-          "businessId"
+          "tenantId",
+          "variables"
         ],
         "type": "object",
         "properties": {
@@ -31330,22 +33525,22 @@
         "description": "Process instance search response item.",
         "type": "object",
         "required": [
+          "businessId",
+          "endDate",
+          "hasIncident",
+          "parentElementInstanceKey",
+          "parentProcessInstanceKey",
           "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionName",
           "processDefinitionVersion",
           "processDefinitionVersionTag",
-          "startDate",
-          "endDate",
-          "state",
-          "hasIncident",
-          "tenantId",
           "processInstanceKey",
-          "processDefinitionKey",
-          "parentProcessInstanceKey",
-          "parentElementInstanceKey",
           "rootProcessInstanceKey",
+          "startDate",
+          "state",
           "tags",
-          "businessId"
+          "tenantId"
         ],
         "properties": {
           "processDefinitionId": {
@@ -31533,9 +33728,9 @@
       "ProcessInstanceCallHierarchyEntry": {
         "type": "object",
         "required": [
-          "processInstanceKey",
           "processDefinitionKey",
-          "processDefinitionName"
+          "processDefinitionName",
+          "processInstanceKey"
         ],
         "properties": {
           "processInstanceKey": {
@@ -31580,11 +33775,11 @@
         "description": "Process instance sequence flow result.",
         "type": "object",
         "required": [
-          "rootProcessInstanceKey",
           "elementId",
           "processDefinitionId",
           "processDefinitionKey",
           "processInstanceKey",
+          "rootProcessInstanceKey",
           "sequenceFlowId",
           "tenantId"
         ],
@@ -31686,8 +33881,8 @@
           }
         },
         "required": [
-          "targetProcessDefinitionKey",
-          "mappingInstructions"
+          "mappingInstructions",
+          "targetProcessDefinitionKey"
         ]
       },
       "MigrateProcessInstanceMappingInstruction": {
@@ -31943,7 +34138,7 @@
           },
           "ancestorElementInstanceKey": {
             "description": "The key of the ancestor scope the element instance should be created in.\nSet to -1 to create the new element instance within an existing element instance of the\nflow scope. If multiple instances of the target element's flow scope exist, choose one\nspecifically with this property by providing its key.\n",
-            "oneOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/ElementInstanceKey"
               }
@@ -32114,8 +34309,8 @@
           }
         },
         "required": [
-          "roleId",
-          "name"
+          "name",
+          "roleId"
         ]
       },
       "RoleCreateResult": {
@@ -32140,9 +34335,9 @@
           }
         },
         "required": [
-          "roleId",
+          "description",
           "name",
-          "description"
+          "roleId"
         ]
       },
       "RoleUpdateRequest": {
@@ -32183,9 +34378,9 @@
           }
         },
         "required": [
-          "roleId",
+          "description",
           "name",
-          "description"
+          "roleId"
         ]
       },
       "RoleResult": {
@@ -32211,9 +34406,9 @@
           }
         },
         "required": [
-          "roleId",
+          "description",
           "name",
-          "description"
+          "roleId"
         ]
       },
       "RoleSearchQuerySortRequest": {
@@ -32705,10 +34900,10 @@
         "description": "Pagination information about the search results.",
         "type": "object",
         "required": [
-          "totalItems",
+          "endCursor",
           "hasMoreTotalItems",
           "startCursor",
-          "endCursor"
+          "totalItems"
         ],
         "x-semantic-provider": [
           "startCursor",
@@ -32787,8 +34982,8 @@
       "SignalBroadcastResult": {
         "type": "object",
         "required": [
-          "tenantId",
-          "signalKey"
+          "signalKey",
+          "tenantId"
         ],
         "x-semantic-provider": [
           "signalKey"
@@ -32826,8 +35021,8 @@
       },
       "UsageMetricsResponse": {
         "required": [
-          "tenants",
-          "activeTenants"
+          "activeTenants",
+          "tenants"
         ],
         "type": "object",
         "allOf": [
@@ -32859,9 +35054,9 @@
       },
       "UsageMetricsResponseItem": {
         "required": [
-          "processInstances",
+          "assignees",
           "decisionInstances",
-          "assignees"
+          "processInstances"
         ],
         "type": "object",
         "properties": {
@@ -32886,11 +35081,11 @@
         "description": "Envelope for all system configuration sections. Each property\nrepresents a feature area.\n",
         "type": "object",
         "required": [
-          "jobMetrics",
+          "authentication",
+          "cloud",
           "components",
           "deployment",
-          "authentication",
-          "cloud"
+          "jobMetrics"
         ],
         "properties": {
           "jobMetrics": {
@@ -32934,10 +35129,10 @@
         "required": [
           "enabled",
           "exportInterval",
-          "maxWorkerNameLength",
           "maxJobTypeLength",
           "maxTenantIdLength",
-          "maxUniqueKeys"
+          "maxUniqueKeys",
+          "maxWorkerNameLength"
         ],
         "properties": {
           "enabled": {
@@ -33000,26 +35195,14 @@
         "description": "Configuration for deployment characteristics.",
         "type": "object",
         "required": [
-          "isEnterprise",
           "isMultiTenancyEnabled",
-          "contextPath",
           "maxRequestSize"
         ],
         "properties": {
-          "isEnterprise": {
-            "description": "Whether this is an enterprise deployment.",
-            "type": "boolean",
-            "example": false
-          },
           "isMultiTenancyEnabled": {
             "description": "Whether multi-tenancy is enabled.",
             "type": "boolean",
             "example": false
-          },
-          "contextPath": {
-            "description": "The servlet context path for the deployment.",
-            "type": "string",
-            "example": ""
           },
           "maxRequestSize": {
             "description": "The maximum HTTP request size in bytes.",
@@ -33053,27 +35236,12 @@
         "description": "Configuration for SaaS/cloud-specific settings.",
         "type": "object",
         "required": [
-          "organizationId",
-          "clusterId",
-          "stage",
-          "mixpanelToken",
-          "mixpanelAPIHost"
+          "stage"
         ],
         "properties": {
-          "organizationId": {
-            "description": "The SaaS organization ID, if applicable.",
-            "type": "string",
-            "nullable": true,
-            "example": "org-123456"
-          },
-          "clusterId": {
-            "description": "The SaaS cluster ID, if applicable.",
-            "type": "string",
-            "nullable": true,
-            "example": "cluster-abc"
-          },
           "stage": {
             "description": "The cloud deployment stage.",
+            "type": "string",
             "nullable": true,
             "allOf": [
               {
@@ -33081,18 +35249,6 @@
               }
             ],
             "example": "prod"
-          },
-          "mixpanelToken": {
-            "description": "The Mixpanel analytics token for the cloud UI.",
-            "type": "string",
-            "nullable": true,
-            "example": "abc123token"
-          },
-          "mixpanelAPIHost": {
-            "description": "The Mixpanel API host URL.",
-            "type": "string",
-            "nullable": true,
-            "example": "https://api.mixpanel.com"
           }
         }
       },
@@ -33136,8 +35292,8 @@
           }
         },
         "required": [
-          "tenantId",
-          "name"
+          "name",
+          "tenantId"
         ]
       },
       "TenantCreateResult": {
@@ -33167,9 +35323,9 @@
           }
         },
         "required": [
-          "tenantId",
+          "description",
           "name",
-          "description"
+          "tenantId"
         ]
       },
       "TenantUpdateRequest": {
@@ -33211,9 +35367,9 @@
           }
         },
         "required": [
-          "tenantId",
+          "description",
           "name",
-          "description"
+          "tenantId"
         ]
       },
       "TenantResult": {
@@ -33241,9 +35397,9 @@
           }
         },
         "required": [
-          "tenantId",
+          "description",
           "name",
-          "description"
+          "tenantId"
         ]
       },
       "TenantSearchQuerySortRequest": {
@@ -33867,30 +36023,30 @@
       "UserTaskResult": {
         "type": "object",
         "required": [
-          "tenantId",
-          "userTaskKey",
-          "name",
-          "processInstanceKey",
-          "rootProcessInstanceKey",
-          "processDefinitionKey",
-          "elementInstanceKey",
-          "processDefinitionId",
-          "processName",
-          "state",
+          "assignee",
           "candidateGroups",
           "candidateUsers",
-          "elementId",
+          "completionDate",
           "creationDate",
           "customHeaders",
-          "priority",
-          "tags",
-          "assignee",
-          "completionDate",
           "dueDate",
+          "elementId",
+          "elementInstanceKey",
           "externalFormReference",
           "followUpDate",
+          "formKey",
+          "name",
+          "priority",
+          "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionVersion",
-          "formKey"
+          "processInstanceKey",
+          "processName",
+          "rootProcessInstanceKey",
+          "state",
+          "tags",
+          "tenantId",
+          "userTaskKey"
         ],
         "properties": {
           "name": {
@@ -34520,8 +36676,8 @@
           }
         },
         "required": [
-          "username",
-          "password"
+          "password",
+          "username"
         ]
       },
       "UserCreateResult": {
@@ -34550,9 +36706,9 @@
           }
         },
         "required": [
-          "username",
+          "email",
           "name",
-          "email"
+          "username"
         ]
       },
       "UserUpdateRequest": {
@@ -34595,9 +36751,9 @@
           }
         },
         "required": [
-          "username",
+          "email",
           "name",
-          "email"
+          "username"
         ]
       },
       "UserResult": {
@@ -34623,9 +36779,9 @@
           }
         },
         "required": [
-          "username",
+          "email",
           "name",
-          "email"
+          "username"
         ]
       },
       "UserSearchQuerySortRequest": {
@@ -34900,10 +37056,10 @@
         "required": [
           "name",
           "processInstanceKey",
-          "tenantId",
-          "variableKey",
+          "rootProcessInstanceKey",
           "scopeKey",
-          "rootProcessInstanceKey"
+          "tenantId",
+          "variableKey"
         ],
         "properties": {
           "name": {
@@ -35149,6 +37305,26 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/ElementInstanceStateEnum"
+          }
+        ]
+      },
+      "WaitStateElementTypeExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/WaitStateElementTypeEnum"
+          }
+        ]
+      },
+      "WaitStateTypeExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/WaitStateTypeEnum"
           }
         ]
       },

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -34807,9 +34807,6 @@
       "CursorForwardPagination": {
         "type": "object",
         "title": "Cursor-based forward pagination",
-        "required": [
-          "after"
-        ],
         "properties": {
           "after": {
             "description": "Use the `endCursor` value from the previous response to fetch the next page of results.",
@@ -34842,9 +34839,6 @@
       "CursorBackwardPagination": {
         "type": "object",
         "title": "Cursor-based backward pagination",
-        "required": [
-          "before"
-        ],
         "properties": {
           "before": {
             "description": "Use the `startCursor` value from the previous response to fetch the previous page of results.",

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:cb633855979423c3641876a384ff83d246452b2d34b631b83fb349a82bd425f7",
+  "specHash": "sha256:b7867e21d395ab0be549e976bf90398c181e9b72c0206c6fcb73463ce23cd84c",
   "semanticKeys": [
     {
       "name": "AgentInstanceKey",

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:f85a4345e56552ece2e63ba93164e70abb16973b17a4256803dc5d64346869c6",
+  "specHash": "sha256:cb633855979423c3641876a384ff83d246452b2d34b631b83fb349a82bd425f7",
   "semanticKeys": [
     {
       "name": "AgentInstanceKey",
@@ -2073,6 +2073,38 @@
         }
       ],
       "stableId": "variable-key-filter-property"
+    },
+    {
+      "name": "WaitStateElementTypeFilterProperty",
+      "kind": "union-wrapper",
+      "description": "Element type property with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "WaitStateElementTypeExactMatch"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AdvancedWaitStateElementTypeFilter"
+        }
+      ],
+      "stableId": "wait-state-element-type-filter-property"
+    },
+    {
+      "name": "WaitStateTypeFilterProperty",
+      "kind": "union-wrapper",
+      "description": "Wait state type property with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "WaitStateTypeExactMatch"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AdvancedWaitStateTypeFilter"
+        }
+      ],
+      "stableId": "wait-state-type-filter-property"
     }
   ],
   "arrays": [
@@ -2255,6 +2287,14 @@
       "method": "get",
       "tags": [
         "Decision requirements"
+      ]
+    },
+    {
+      "operationId": "searchElementInstanceWaitStates",
+      "path": "/element-instances/wait-states/search",
+      "method": "post",
+      "tags": [
+        "Element instance"
       ]
     },
     {
@@ -2860,7 +2900,7 @@
         "Agent instance"
       ],
       "summary": "Update agent instance",
-      "description": "Updates the mutable fields of an agent instance: status, metric counters, and\ntools. Metric values are treated as deltas and applied immediately to the\naggregate counters. Tool updates replace the existing tool list. At least one of\nstatus, metrics, or tools must be provided.\n",
+      "description": "Updates the mutable fields of an agent instance: status, metric counters, and\ntools. Metric values are treated as deltas and applied immediately to the\naggregate counters. Tool updates replace the existing tool list.\n",
       "eventuallyConsistent": false,
       "hasRequestBody": true,
       "requestBodyUnion": false,
@@ -4348,6 +4388,35 @@
       }
     },
     {
+      "operationId": "searchElementInstanceWaitStates",
+      "path": "/element-instances/wait-states/search",
+      "method": "post",
+      "tags": [
+        "Element instance"
+      ],
+      "summary": "Search element instance wait states",
+      "description": "Returns the wait states for element instances matching the given filter.\n",
+      "eventuallyConsistent": true,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": true,
+      "pathParams": [],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "element-instances.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "ElementInstanceWaitStateQuery",
+      "successResponseSchemaRef": "ElementInstanceWaitStateQueryResult",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": true,
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "searchElementInstances",
       "path": "/element-instances/search",
       "method": "post",
@@ -4473,7 +4542,7 @@
         "Expression"
       ],
       "summary": "Evaluate an expression",
-      "description": "Evaluates a FEEL expression and returns the result. Supports references to tenant scoped cluster variables when a tenant ID is provided.",
+      "description": "Evaluates a FEEL expression and returns the result. Supports references to tenant scoped\ncluster variables when a tenant ID is provided. Optionally, provide a `scopeKey` to make the\nvariables of a specific process instance or element instance visible while evaluating the\nexpression.\n",
       "eventuallyConsistent": false,
       "hasRequestBody": true,
       "requestBodyUnion": false,
@@ -9273,6 +9342,13 @@
       "stableId": "deployment-resource-result"
     },
     {
+      "schemaName": "DeploymentResult",
+      "providers": [
+        "deploymentKey"
+      ],
+      "stableId": "deployment-result"
+    },
+    {
       "schemaName": "DocumentReference",
       "providers": [
         "documentId"
@@ -9354,10 +9430,10 @@
   ],
   "integrity": {
     "totalSemanticKeys": 40,
-    "totalUnions": 57,
-    "totalOperations": 190,
-    "totalEventuallyConsistent": 88,
+    "totalUnions": 59,
+    "totalOperations": 191,
+    "totalEventuallyConsistent": 89,
     "totalDeprecatedEnumSchemas": 2,
-    "totalSemanticProviders": 21
+    "totalSemanticProviders": 22
   }
 }

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -6114,7 +6114,59 @@ public partial class CamundaClient
     /// Returns the wait states for element instances matching the given filter.
     /// 
     /// </summary>
-    /// <remarks>Operation: searchElementInstanceWaitStates</remarks>
+    /// <remarks>
+    /// Operation: searchElementInstanceWaitStates
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SearchElementInstanceWaitStatesExample(ProcessInstanceKey processInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SearchElementInstanceWaitStatesAsync(
+    ///         new ElementInstanceWaitStateQuery
+    ///         {
+    ///             Filter = new ElementInstanceWaitStateFilter
+    ///             {
+    ///                 ProcessInstanceKey = new ProcessInstanceKeyFilterProperty
+    ///                 {
+    ///                     Eq = processInstanceKey,
+    ///                 },
+    ///             },
+    ///         });
+    /// 
+    ///     foreach (var waitState in result.Items)
+    ///     {
+    ///         Console.WriteLine($&quot;{waitState.ElementId}: {waitState.WaitStateType}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SearchElementInstanceWaitStatesExample(ProcessInstanceKey processInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SearchElementInstanceWaitStatesAsync(
+    ///         new ElementInstanceWaitStateQuery
+    ///         {
+    ///             Filter = new ElementInstanceWaitStateFilter
+    ///             {
+    ///                 ProcessInstanceKey = new ProcessInstanceKeyFilterProperty
+    ///                 {
+    ///                     Eq = processInstanceKey,
+    ///                 },
+    ///             },
+    ///         });
+    /// 
+    ///     foreach (var waitState in result.Items)
+    ///     {
+    ///         Console.WriteLine($&quot;{waitState.ElementId}: {waitState.WaitStateType}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
     public async Task<ElementInstanceWaitStateQueryResult> SearchElementInstanceWaitStatesAsync(ElementInstanceWaitStateQuery body, ConsistencyOptions<ElementInstanceWaitStateQueryResult>? consistency = null, CancellationToken ct = default)
     {
         var path = $"/element-instances/wait-states/search";
@@ -8251,7 +8303,7 @@ public partial class CamundaClient
     /// Operation: updateAgentInstance
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateAgentInstanceExample(AgentInstanceKey agentInstanceKey)
+    /// public static async Task UpdateAgentInstanceExample(AgentInstanceKey agentInstanceKey, ElementInstanceKey elementInstanceKey)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
@@ -8259,7 +8311,8 @@ public partial class CamundaClient
     ///         agentInstanceKey,
     ///         new AgentInstanceUpdateRequest
     ///         {
-    ///             Status = AgentInstanceStatusEnum.THINKING,
+    ///             ElementInstanceKey = elementInstanceKey,
+    ///             Status = AgentInstanceUpdateStatusEnum.THINKING,
     ///             Metrics = new AgentInstanceMetricsDelta
     ///             {
     ///                 InputTokens = 150,
@@ -8275,7 +8328,7 @@ public partial class CamundaClient
     /// <example>
     /// <para><b>Example:</b></para>
     /// <code>
-    /// public static async Task UpdateAgentInstanceExample(AgentInstanceKey agentInstanceKey)
+    /// public static async Task UpdateAgentInstanceExample(AgentInstanceKey agentInstanceKey, ElementInstanceKey elementInstanceKey)
     /// {
     ///     using var client = CamundaClient.Create();
     /// 
@@ -8283,7 +8336,8 @@ public partial class CamundaClient
     ///         agentInstanceKey,
     ///         new AgentInstanceUpdateRequest
     ///         {
-    ///             Status = AgentInstanceStatusEnum.THINKING,
+    ///             ElementInstanceKey = elementInstanceKey,
+    ///             Status = AgentInstanceUpdateStatusEnum.THINKING,
     ///             Metrics = new AgentInstanceMetricsDelta
     ///             {
     ///                 InputTokens = 150,

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -2410,7 +2410,11 @@ public partial class CamundaClient
 
     /// <summary>
     /// Evaluate an expression
-    /// Evaluates a FEEL expression and returns the result. Supports references to tenant scoped cluster variables when a tenant ID is provided.
+    /// Evaluates a FEEL expression and returns the result. Supports references to tenant scoped
+    /// cluster variables when a tenant ID is provided. Optionally, provide a `scopeKey` to make the
+    /// variables of a specific process instance or element instance visible while evaluating the
+    /// expression.
+    /// 
     /// </summary>
     /// <remarks>
     /// Operation: evaluateExpression
@@ -6106,6 +6110,25 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Search element instance wait states
+    /// Returns the wait states for element instances matching the given filter.
+    /// 
+    /// </summary>
+    /// <remarks>Operation: searchElementInstanceWaitStates</remarks>
+    public async Task<ElementInstanceWaitStateQueryResult> SearchElementInstanceWaitStatesAsync(ElementInstanceWaitStateQuery body, ConsistencyOptions<ElementInstanceWaitStateQueryResult>? consistency = null, CancellationToken ct = default)
+    {
+        var path = $"/element-instances/wait-states/search";
+        if (consistency != null && consistency.WaitUpToMs > 0)
+        {
+            return await EventualPoller.PollAsync("searchElementInstanceWaitStates", false,
+                () => InvokeWithRetryAsync(() => SendAsync<ElementInstanceWaitStateQueryResult>(HttpMethod.Post, path, body, ct), "searchElementInstanceWaitStates", false, ct),
+                consistency!, _logger, ct);
+        }
+
+        return await InvokeWithRetryAsync(() => SendAsync<ElementInstanceWaitStateQueryResult>(HttpMethod.Post, path, body, ct), "searchElementInstanceWaitStates", false, ct);
+    }
+
+    /// <summary>
     /// Search element instances
     /// Search for element instances based on given criteria.
     /// </summary>
@@ -8221,8 +8244,7 @@ public partial class CamundaClient
     /// Update agent instance
     /// Updates the mutable fields of an agent instance: status, metric counters, and
     /// tools. Metric values are treated as deltas and applied immediately to the
-    /// aggregate counters. Tool updates replace the existing tool list. At least one of
-    /// status, metrics, or tools must be provided.
+    /// aggregate counters. Tool updates replace the existing tool list.
     /// 
     /// </summary>
     /// <remarks>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -309,6 +309,68 @@ public enum DocumentReferenceCamundaDocumentType
 /// Type of element as defined set of values.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ElementInstanceFilterFieldsType
+{
+    [JsonPropertyName("UNSPECIFIED")]
+    UNSPECIFIED,
+    [JsonPropertyName("PROCESS")]
+    PROCESS,
+    [JsonPropertyName("SUB_PROCESS")]
+    SUBPROCESS,
+    [JsonPropertyName("EVENT_SUB_PROCESS")]
+    EVENTSUBPROCESS,
+    [JsonPropertyName("AD_HOC_SUB_PROCESS")]
+    ADHOCSUBPROCESS,
+    [JsonPropertyName("AD_HOC_SUB_PROCESS_INNER_INSTANCE")]
+    ADHOCSUBPROCESSINNERINSTANCE,
+    [JsonPropertyName("START_EVENT")]
+    STARTEVENT,
+    [JsonPropertyName("INTERMEDIATE_CATCH_EVENT")]
+    INTERMEDIATECATCHEVENT,
+    [JsonPropertyName("INTERMEDIATE_THROW_EVENT")]
+    INTERMEDIATETHROWEVENT,
+    [JsonPropertyName("BOUNDARY_EVENT")]
+    BOUNDARYEVENT,
+    [JsonPropertyName("END_EVENT")]
+    ENDEVENT,
+    [JsonPropertyName("SERVICE_TASK")]
+    SERVICETASK,
+    [JsonPropertyName("RECEIVE_TASK")]
+    RECEIVETASK,
+    [JsonPropertyName("USER_TASK")]
+    USERTASK,
+    [JsonPropertyName("MANUAL_TASK")]
+    MANUALTASK,
+    [JsonPropertyName("TASK")]
+    TASK,
+    [JsonPropertyName("EXCLUSIVE_GATEWAY")]
+    EXCLUSIVEGATEWAY,
+    [JsonPropertyName("INCLUSIVE_GATEWAY")]
+    INCLUSIVEGATEWAY,
+    [JsonPropertyName("PARALLEL_GATEWAY")]
+    PARALLELGATEWAY,
+    [JsonPropertyName("EVENT_BASED_GATEWAY")]
+    EVENTBASEDGATEWAY,
+    [JsonPropertyName("SEQUENCE_FLOW")]
+    SEQUENCEFLOW,
+    [JsonPropertyName("MULTI_INSTANCE_BODY")]
+    MULTIINSTANCEBODY,
+    [JsonPropertyName("CALL_ACTIVITY")]
+    CALLACTIVITY,
+    [JsonPropertyName("BUSINESS_RULE_TASK")]
+    BUSINESSRULETASK,
+    [JsonPropertyName("SCRIPT_TASK")]
+    SCRIPTTASK,
+    [JsonPropertyName("SEND_TASK")]
+    SENDTASK,
+    [JsonPropertyName("UNKNOWN")]
+    UNKNOWN,
+}
+
+/// <summary>
+/// Type of element as defined set of values.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ElementInstanceFilterType
 {
     [JsonPropertyName("UNSPECIFIED")]
@@ -597,6 +659,8 @@ public enum JobSearchQuerySortRequestField
     Kind,
     [JsonPropertyName("listenerEventType")]
     ListenerEventType,
+    [JsonPropertyName("priority")]
+    Priority,
     [JsonPropertyName("processDefinitionId")]
     ProcessDefinitionId,
     [JsonPropertyName("processDefinitionKey")]
@@ -1094,6 +1158,13 @@ public sealed class ActivatedJobResult
     /// </summary>
     [JsonPropertyName("rootProcessInstanceKey")]
     public ProcessInstanceKey? RootProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The priority of the job. Higher values indicate higher priority. Jobs created before 8.10 have no stored priority; the API returns 0 for such jobs.
+    /// 
+    /// </summary>
+    [JsonPropertyName("priority")]
+    public int Priority { get; set; }
 
 }
 
@@ -3081,6 +3152,96 @@ public sealed class AdvancedVariableKeyFilter
 }
 
 /// <summary>
+/// Advanced element type filter.
+/// </summary>
+public sealed class AdvancedWaitStateElementTypeFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public WaitStateElementTypeEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public WaitStateElementTypeEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<WaitStateElementTypeEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
+/// Advanced wait state type filter.
+/// </summary>
+public sealed class AdvancedWaitStateTypeFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public WaitStateTypeEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public WaitStateTypeEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<WaitStateTypeEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
 /// Request to create a new agent instance.
 /// </summary>
 public sealed class AgentInstanceCreationRequest
@@ -3214,6 +3375,24 @@ public sealed class AgentInstanceFilter
     [JsonPropertyName("elementInstanceKeys")]
     public List<ElementInstanceKeyFilterProperty>? ElementInstanceKeys { get; set; }
 
+    /// <summary>
+    /// The BPMN process ID of the process definition associated with this agent instance.
+    /// </summary>
+    [JsonPropertyName("processDefinitionId")]
+    public StringFilterProperty? ProcessDefinitionId { get; set; }
+
+    /// <summary>
+    /// The version of the process definition associated with this agent instance.
+    /// </summary>
+    [JsonPropertyName("processDefinitionVersion")]
+    public IntegerFilterProperty? ProcessDefinitionVersion { get; set; }
+
+    /// <summary>
+    /// The version tag of the process definition associated with this agent instance.
+    /// </summary>
+    [JsonPropertyName("processDefinitionVersionTag")]
+    public StringFilterProperty? ProcessDefinitionVersionTag { get; set; }
+
 }
 
 /// <summary>
@@ -3318,13 +3497,13 @@ public sealed class AgentInstanceLimits
     /// Maximum LLM calls allowed. -1 if no limit is configured.
     /// </summary>
     [JsonPropertyName("maxModelCalls")]
-    public long MaxModelCalls { get; set; }
+    public int MaxModelCalls { get; set; }
 
     /// <summary>
     /// Maximum tool calls allowed. -1 if no limit is configured.
     /// </summary>
     [JsonPropertyName("maxToolCalls")]
-    public long MaxToolCalls { get; set; }
+    public int MaxToolCalls { get; set; }
 
     /// <summary>
     /// Maximum total tokens allowed. -1 if no limit is configured.
@@ -3355,13 +3534,13 @@ public sealed class AgentInstanceMetrics
     /// Total number of LLM calls made.
     /// </summary>
     [JsonPropertyName("modelCalls")]
-    public long ModelCalls { get; set; }
+    public int ModelCalls { get; set; }
 
     /// <summary>
     /// Total number of tool calls made.
     /// </summary>
     [JsonPropertyName("toolCalls")]
-    public long ToolCalls { get; set; }
+    public int ToolCalls { get; set; }
 
 }
 
@@ -3389,13 +3568,13 @@ public sealed class AgentInstanceMetricsDelta
     /// Increment to apply to the total model call counter.
     /// </summary>
     [JsonPropertyName("modelCalls")]
-    public long? ModelCalls { get; set; }
+    public int? ModelCalls { get; set; }
 
     /// <summary>
     /// Increment to apply to the total tool call counter.
     /// </summary>
     [JsonPropertyName("toolCalls")]
-    public long? ToolCalls { get; set; }
+    public int? ToolCalls { get; set; }
 
 }
 
@@ -3453,10 +3632,36 @@ public sealed class AgentInstanceResult
     public ProcessInstanceKey ProcessInstanceKey { get; set; }
 
     /// <summary>
+    /// The key of the root process instance. The root process instance is the top-level
+    /// ancestor in the process instance hierarchy.
+    /// 
+    /// </summary>
+    [JsonPropertyName("rootProcessInstanceKey")]
+    public ProcessInstanceKey RootProcessInstanceKey { get; set; }
+
+    /// <summary>
     /// The key of the process definition associated with this agent instance.
     /// </summary>
     [JsonPropertyName("processDefinitionKey")]
     public ProcessDefinitionKey ProcessDefinitionKey { get; set; }
+
+    /// <summary>
+    /// The BPMN process ID of the process definition associated with this agent instance.
+    /// </summary>
+    [JsonPropertyName("processDefinitionId")]
+    public ProcessDefinitionId ProcessDefinitionId { get; set; }
+
+    /// <summary>
+    /// The version of the process definition associated with this agent instance.
+    /// </summary>
+    [JsonPropertyName("processDefinitionVersion")]
+    public int ProcessDefinitionVersion { get; set; }
+
+    /// <summary>
+    /// The version tag of the process definition associated with this agent instance.
+    /// </summary>
+    [JsonPropertyName("processDefinitionVersionTag")]
+    public string? ProcessDefinitionVersionTag { get; set; }
 
     /// <summary>
     /// The tenant ID of this agent instance.
@@ -3559,6 +3764,8 @@ public sealed class AgentInstanceSearchQuerySortRequest
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AgentInstanceStatusEnum
 {
+    [JsonPropertyName("UNKNOWN")]
+    UNKNOWN,
     [JsonPropertyName("COMPLETED")]
     COMPLETED,
     [JsonPropertyName("IDLE")]
@@ -3647,17 +3854,27 @@ public sealed class AgentInstanceStatusFilterProperty
 }
 
 /// <summary>
-/// Request to update the mutable state of an agent instance. At least one of
-/// status, metrics, or tools must be provided.
+/// Request to update the mutable state of an agent instance.
 /// 
 /// </summary>
 public sealed class AgentInstanceUpdateRequest
 {
     /// <summary>
+    /// The key of the currently-active element instance for this agent instance.
+    /// Used for ownership/equality validation against the stored agent instance
+    /// and, when the supplied key differs from the previous association (re-entry
+    /// of an ad-hoc sub-process or AI Agent task), appended to elementInstanceKeys
+    /// with the reverse link updated on the supplied element instance.
+    /// 
+    /// </summary>
+    [JsonPropertyName("elementInstanceKey")]
+    public ElementInstanceKey ElementInstanceKey { get; set; }
+
+    /// <summary>
     /// The new status of the agent instance.
     /// </summary>
     [JsonPropertyName("status")]
-    public AgentInstanceStatusEnum? Status { get; set; }
+    public AgentInstanceUpdateStatusEnum? Status { get; set; }
 
     /// <summary>
     /// Metric increments to apply to the aggregate counters.
@@ -3674,6 +3891,23 @@ public sealed class AgentInstanceUpdateRequest
     [JsonPropertyName("tools")]
     public List<AgentTool>? Tools { get; set; }
 
+}
+
+/// <summary>
+/// The status values that can be set on an agent instance via an update request.
+/// 
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AgentInstanceUpdateStatusEnum
+{
+    [JsonPropertyName("IDLE")]
+    IDLE,
+    [JsonPropertyName("THINKING")]
+    THINKING,
+    [JsonPropertyName("TOOL_CALLING")]
+    TOOLCALLING,
+    [JsonPropertyName("TOOL_DISCOVERY")]
+    TOOLDISCOVERY,
 }
 
 /// <summary>
@@ -6145,34 +6379,10 @@ public sealed class ClockPinRequest
 public sealed class CloudConfigurationResponse
 {
     /// <summary>
-    /// The SaaS organization ID, if applicable.
-    /// </summary>
-    [JsonPropertyName("organizationId")]
-    public string? OrganizationId { get; set; }
-
-    /// <summary>
-    /// The SaaS cluster ID, if applicable.
-    /// </summary>
-    [JsonPropertyName("clusterId")]
-    public string? ClusterId { get; set; }
-
-    /// <summary>
     /// The cloud deployment stage.
     /// </summary>
     [JsonPropertyName("stage")]
-    public CloudStage? Stage { get; set; }
-
-    /// <summary>
-    /// The Mixpanel analytics token for the cloud UI.
-    /// </summary>
-    [JsonPropertyName("mixpanelToken")]
-    public string? MixpanelToken { get; set; }
-
-    /// <summary>
-    /// The Mixpanel API host URL.
-    /// </summary>
-    [JsonPropertyName("mixpanelAPIHost")]
-    public string? MixpanelAPIHost { get; set; }
+    public string? Stage { get; set; }
 
 }
 
@@ -8477,22 +8687,10 @@ public sealed class DeleteResourceResponse
 public sealed class DeploymentConfigurationResponse
 {
     /// <summary>
-    /// Whether this is an enterprise deployment.
-    /// </summary>
-    [JsonPropertyName("isEnterprise")]
-    public bool IsEnterprise { get; set; }
-
-    /// <summary>
     /// Whether multi-tenancy is enabled.
     /// </summary>
     [JsonPropertyName("isMultiTenancyEnabled")]
     public bool IsMultiTenancyEnabled { get; set; }
-
-    /// <summary>
-    /// The servlet context path for the deployment.
-    /// </summary>
-    [JsonPropertyName("contextPath")]
-    public string ContextPath { get; set; } = null!;
 
     /// <summary>
     /// The maximum HTTP request size in bytes.
@@ -8883,7 +9081,7 @@ public sealed class DirectAncestorKeyInstruction : AncestorScopeInstruction
     /// 
     /// </summary>
     [JsonPropertyName("ancestorElementInstanceKey")]
-    public object AncestorElementInstanceKey { get; set; } = null!;
+    public ElementInstanceKey AncestorElementInstanceKey { get; set; }
 
 }
 
@@ -9240,7 +9438,7 @@ public sealed class ElementIdFilterProperty
 }
 
 /// <summary>
-/// Element instance filter.
+/// Element instance search filter.
 /// </summary>
 public sealed class ElementInstanceFilter
 {
@@ -9261,6 +9459,128 @@ public sealed class ElementInstanceFilter
     /// </summary>
     [JsonPropertyName("type")]
     public ElementInstanceFilterType? Type { get; set; }
+
+    /// <summary>
+    /// The element ID for this element instance.
+    /// </summary>
+    [JsonPropertyName("elementId")]
+    public ElementIdFilterProperty? ElementId { get; set; }
+
+    /// <summary>
+    /// The element name. This only works for data created with 8.8 and onwards. Instances from prior versions don&apos;t contain this data and cannot be found.
+    /// 
+    /// </summary>
+    [JsonPropertyName("elementName")]
+    public StringFilterProperty? ElementName { get; set; }
+
+    /// <summary>
+    /// Shows whether this element instance has an incident related to.
+    /// </summary>
+    [JsonPropertyName("hasIncident")]
+    public bool? HasIncident { get; set; }
+
+    /// <summary>
+    /// The unique identifier of the tenant.
+    /// </summary>
+    [JsonPropertyName("tenantId")]
+    public TenantId? TenantId { get; set; }
+
+    /// <summary>
+    /// The assigned key, which acts as a unique identifier for this element instance.
+    /// </summary>
+    [JsonPropertyName("elementInstanceKey")]
+    public ElementInstanceKey? ElementInstanceKey { get; set; }
+
+    /// <summary>
+    /// The process instance key associated to this element instance.
+    /// </summary>
+    [JsonPropertyName("processInstanceKey")]
+    public ProcessInstanceKey? ProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The process definition key associated to this element instance.
+    /// </summary>
+    [JsonPropertyName("processDefinitionKey")]
+    public ProcessDefinitionKey? ProcessDefinitionKey { get; set; }
+
+    /// <summary>
+    /// The key of incident if field incident is true.
+    /// </summary>
+    [JsonPropertyName("incidentKey")]
+    public IncidentKey? IncidentKey { get; set; }
+
+    /// <summary>
+    /// The start date of this element instance.
+    /// </summary>
+    [JsonPropertyName("startDate")]
+    public DateTimeFilterProperty? StartDate { get; set; }
+
+    /// <summary>
+    /// The end date of this element instance.
+    /// </summary>
+    [JsonPropertyName("endDate")]
+    public DateTimeFilterProperty? EndDate { get; set; }
+
+    /// <summary>
+    /// The scope key of this element instance. If provided with a process instance key it will return element instances that are immediate children of the process instance. If provided with an element instance key it will return element instances that are immediate children of the element instance.
+    /// 
+    /// </summary>
+    [JsonPropertyName("elementInstanceScopeKey")]
+    public string? ElementInstanceScopeKey { get; set; }
+
+    /// <summary>
+    /// Defines a list of alternative filter groups combined using OR logic. Each object in the array is evaluated independently, and the filter matches if any one of them is satisfied.
+    /// 
+    /// Top-level fields and the `$or` clause are combined using AND logic — meaning: (top-level filters) AND (any of the `$or` filters) must match.
+    /// &lt;br&gt;
+    /// &lt;em&gt;Example:&lt;/em&gt;
+    /// 
+    /// ```json
+    /// {
+    ///   &quot;processInstanceKey&quot;: &quot;2251799813685323&quot;,
+    ///   &quot;$or&quot;: [
+    ///     { &quot;elementName&quot;: { &quot;$like&quot;: &quot;*Order*&quot; } },
+    ///     { &quot;elementId&quot;:   { &quot;$like&quot;: &quot;*Order*&quot; } }
+    ///   ]
+    /// }
+    /// ```
+    /// This matches element instances scoped to the given process instance whose:
+    /// 
+    /// &lt;ul style=&quot;padding-left: 20px; margin-left: 20px;&quot;&gt;
+    ///   &lt;li style=&quot;list-style-type: disc;&quot;&gt;&lt;code&gt;elementName&lt;/code&gt; contains &lt;em&gt;Order&lt;/em&gt;, or&lt;/li&gt;
+    ///   &lt;li style=&quot;list-style-type: disc;&quot;&gt;&lt;code&gt;elementId&lt;/code&gt; contains &lt;em&gt;Order&lt;/em&gt;&lt;/li&gt;
+    /// &lt;/ul&gt;
+    /// &lt;br&gt;
+    /// &lt;p&gt;Note: Using complex &lt;code&gt;$or&lt;/code&gt; conditions may impact performance, use with caution in high-volume environments.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$or")]
+    public List<ElementInstanceFilterFields>? Or { get; set; }
+
+}
+
+/// <summary>
+/// Element instance filter fields.
+/// </summary>
+public sealed class ElementInstanceFilterFields
+{
+    /// <summary>
+    /// The process definition ID associated to this element instance.
+    /// </summary>
+    [JsonPropertyName("processDefinitionId")]
+    public ProcessDefinitionId? ProcessDefinitionId { get; set; }
+
+    /// <summary>
+    /// State of element instance as defined set of values.
+    /// </summary>
+    [JsonPropertyName("state")]
+    public ElementInstanceStateFilterProperty? State { get; set; }
+
+    /// <summary>
+    /// Type of element as defined set of values.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public ElementInstanceFilterFieldsType? Type { get; set; }
 
     /// <summary>
     /// The element ID for this element instance.
@@ -9670,6 +9990,148 @@ public sealed class ElementInstanceStateFilterProperty
 }
 
 /// <summary>
+/// Filters for the element instance inspection.
+/// </summary>
+public sealed class ElementInstanceWaitStateFilter
+{
+    /// <summary>
+    /// Filter by element instance key.
+    /// </summary>
+    [JsonPropertyName("elementInstanceKey")]
+    public ElementInstanceKeyFilterProperty? ElementInstanceKey { get; set; }
+
+    /// <summary>
+    /// Filter by process instance key.
+    /// </summary>
+    [JsonPropertyName("processInstanceKey")]
+    public ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// Filter by root process instance key.
+    /// </summary>
+    [JsonPropertyName("rootProcessInstanceKey")]
+    public ProcessInstanceKeyFilterProperty? RootProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// Filter by element ID.
+    /// </summary>
+    [JsonPropertyName("elementId")]
+    public ElementIdFilterProperty? ElementId { get; set; }
+
+    /// <summary>
+    /// Filter by element type.
+    /// </summary>
+    [JsonPropertyName("elementType")]
+    public WaitStateElementTypeFilterProperty? ElementType { get; set; }
+
+    /// <summary>
+    /// Filter by wait state type.
+    /// </summary>
+    [JsonPropertyName("waitStateType")]
+    public WaitStateTypeFilterProperty? WaitStateType { get; set; }
+
+}
+
+/// <summary>
+/// Element instance inspection request.
+/// </summary>
+public sealed class ElementInstanceWaitStateQuery
+{
+    /// <summary>
+    /// Filter criteria for the inspection.
+    /// </summary>
+    [JsonPropertyName("filter")]
+    public ElementInstanceWaitStateFilter? Filter { get; set; }
+
+    /// <summary>
+    /// Pagination criteria.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public SearchQueryPageRequest? Page { get; set; }
+
+}
+
+/// <summary>
+/// ElementInstanceWaitStateQueryResult
+/// </summary>
+public sealed class ElementInstanceWaitStateQueryResult
+{
+    /// <summary>
+    /// The matching waiting states.
+    /// </summary>
+    [JsonPropertyName("items")]
+    public List<ElementInstanceWaitStateResult> Items { get; set; } = null!;
+
+    /// <summary>
+    /// Pagination information about the search results.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public SearchQueryPageResponse Page { get; set; } = null!;
+
+}
+
+/// <summary>
+/// An element instance waiting state.
+/// </summary>
+public sealed class ElementInstanceWaitStateResult
+{
+    /// <summary>
+    /// The type of waiting state an element instance is in.
+    /// </summary>
+    [JsonPropertyName("waitStateType")]
+    public WaitStateTypeEnum WaitStateType { get; set; }
+
+    /// <summary>
+    /// Key of the root process instance.
+    /// </summary>
+    [JsonPropertyName("rootProcessInstanceKey")]
+    public ProcessInstanceKey? RootProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The process instance key associated to this element instance.
+    /// </summary>
+    [JsonPropertyName("processInstanceKey")]
+    public ProcessInstanceKey ProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The element instance key associated to this element instance.
+    /// </summary>
+    [JsonPropertyName("elementInstanceKey")]
+    public ElementInstanceKey ElementInstanceKey { get; set; }
+
+    /// <summary>
+    /// The element ID for this element instance.
+    /// </summary>
+    [JsonPropertyName("elementId")]
+    public ElementId ElementId { get; set; }
+
+    /// <summary>
+    /// The BPMN element type of this element instance.
+    /// </summary>
+    [JsonPropertyName("elementType")]
+    public WaitStateElementTypeEnum ElementType { get; set; }
+
+    /// <summary>
+    /// The tenant ID of the element instance.
+    /// </summary>
+    [JsonPropertyName("tenantId")]
+    public TenantId TenantId { get; set; }
+
+    /// <summary>
+    /// Job details, present when waitStateType is JOB.
+    /// </summary>
+    [JsonPropertyName("jobDetails")]
+    public JobWaitStateDetails? JobDetails { get; set; }
+
+    /// <summary>
+    /// Message details, present when waitStateType is MESSAGE.
+    /// </summary>
+    [JsonPropertyName("messageDetails")]
+    public MessageWaitStateDetails? MessageDetails { get; set; }
+
+}
+
+/// <summary>
 /// The end cursor in a search query result set.
 /// </summary>
 public readonly record struct EndCursor : global::Camunda.Orchestration.Sdk.ICamundaKey
@@ -10027,6 +10489,17 @@ public sealed class ExpressionEvaluationRequest : global::Camunda.Orchestration.
     /// </summary>
     [JsonPropertyName("tenantId")]
     public string? TenantId { get; set; }
+
+    /// <summary>
+    /// Key of the process instance or element instance whose variables should be made visible
+    /// to the expression. Use a process instance key to evaluate against the process instance
+    /// scope, or an element instance key to evaluate against that element instance scope. If
+    /// omitted, the expression is evaluated unscoped, using only cluster variables
+    /// and request-body variables.
+    /// 
+    /// </summary>
+    [JsonPropertyName("scopeKey")]
+    public ScopeKey? ScopeKey { get; set; }
 
     /// <summary>
     /// Optional variables for expression evaluation. These variables are only used for the current evaluation and do not persist beyond it.
@@ -12226,6 +12699,13 @@ public sealed class JobFilter
     public JobListenerEventTypeFilterProperty? ListenerEventType { get; set; }
 
     /// <summary>
+    /// The priority of the job. Jobs created before 8.10 have no stored priority and are excluded from results when this filter is applied.
+    /// 
+    /// </summary>
+    [JsonPropertyName("priority")]
+    public IntegerFilterProperty? Priority { get; set; }
+
+    /// <summary>
     /// The process definition ID associated with the job.
     /// </summary>
     [JsonPropertyName("processDefinitionId")]
@@ -12479,6 +12959,8 @@ public enum JobListenerEventTypeEnum
     ASSIGNING,
     [JsonPropertyName("BEFORE_ALL")]
     BEFOREALL,
+    [JsonPropertyName("CANCEL")]
+    CANCEL,
     [JsonPropertyName("CANCELING")]
     CANCELING,
     [JsonPropertyName("COMPLETING")]
@@ -12987,6 +13469,13 @@ public sealed class JobSearchResult
     [JsonPropertyName("lastUpdateTime")]
     public DateTimeOffset? LastUpdateTime { get; set; }
 
+    /// <summary>
+    /// The priority of the job. Higher values indicate higher priority. Jobs created before 8.10 have no stored priority; they appear last when sorting by this field and are excluded when filtering by this field. The API returns 0 for such jobs.
+    /// 
+    /// </summary>
+    [JsonPropertyName("priority")]
+    public int Priority { get; set; }
+
 }
 
 /// <summary>
@@ -13312,6 +13801,43 @@ public sealed class JobUpdateRequest
     /// </summary>
     [JsonPropertyName("operationReference")]
     public OperationReference? OperationReference { get; set; }
+
+}
+
+/// <summary>
+/// JobWaitStateDetails
+/// </summary>
+public sealed class JobWaitStateDetails
+{
+    /// <summary>
+    /// The key of the job.
+    /// </summary>
+    [JsonPropertyName("jobKey")]
+    public JobKey JobKey { get; set; }
+
+    /// <summary>
+    /// The job type (worker subscription identifier).
+    /// </summary>
+    [JsonPropertyName("jobType")]
+    public string JobType { get; set; } = null!;
+
+    /// <summary>
+    /// The kind of job.
+    /// </summary>
+    [JsonPropertyName("jobKind")]
+    public JobKindEnum JobKind { get; set; }
+
+    /// <summary>
+    /// The listener event type of the job (only set for execution listener and task listener jobs).
+    /// </summary>
+    [JsonPropertyName("listenerEventType")]
+    public JobListenerEventTypeEnum? ListenerEventType { get; set; }
+
+    /// <summary>
+    /// The number of retries remaining for the job.
+    /// </summary>
+    [JsonPropertyName("retries")]
+    public int? Retries { get; set; }
 
 }
 
@@ -14600,6 +15126,25 @@ public sealed class MessageSubscriptionTypeFilterProperty
     /// </summary>
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
+/// MessageWaitStateDetails
+/// </summary>
+public sealed class MessageWaitStateDetails
+{
+    /// <summary>
+    /// The name of the message being awaited.
+    /// </summary>
+    [JsonPropertyName("messageName")]
+    public string MessageName { get; set; } = null!;
+
+    /// <summary>
+    /// The correlation key for the message subscription (null for start events).
+    /// </summary>
+    [JsonPropertyName("correlationKey")]
+    public string? CorrelationKey { get; set; }
 
 }
 
@@ -20575,6 +21120,226 @@ public sealed class VariableValueFilterProperty
     /// </summary>
     [JsonPropertyName("value")]
     public StringFilterProperty Value { get; set; } = null!;
+
+}
+
+/// <summary>
+/// The BPMN element type of a waiting element instance.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum WaitStateElementTypeEnum
+{
+    [JsonPropertyName("AD_HOC_SUB_PROCESS")]
+    ADHOCSUBPROCESS,
+    [JsonPropertyName("AD_HOC_SUB_PROCESS_INNER_INSTANCE")]
+    ADHOCSUBPROCESSINNERINSTANCE,
+    [JsonPropertyName("BOUNDARY_EVENT")]
+    BOUNDARYEVENT,
+    [JsonPropertyName("BUSINESS_RULE_TASK")]
+    BUSINESSRULETASK,
+    [JsonPropertyName("CALL_ACTIVITY")]
+    CALLACTIVITY,
+    [JsonPropertyName("END_EVENT")]
+    ENDEVENT,
+    [JsonPropertyName("EVENT_BASED_GATEWAY")]
+    EVENTBASEDGATEWAY,
+    [JsonPropertyName("EVENT_SUB_PROCESS")]
+    EVENTSUBPROCESS,
+    [JsonPropertyName("EXCLUSIVE_GATEWAY")]
+    EXCLUSIVEGATEWAY,
+    [JsonPropertyName("INCLUSIVE_GATEWAY")]
+    INCLUSIVEGATEWAY,
+    [JsonPropertyName("INTERMEDIATE_CATCH_EVENT")]
+    INTERMEDIATECATCHEVENT,
+    [JsonPropertyName("INTERMEDIATE_THROW_EVENT")]
+    INTERMEDIATETHROWEVENT,
+    [JsonPropertyName("MANUAL_TASK")]
+    MANUALTASK,
+    [JsonPropertyName("MULTI_INSTANCE_BODY")]
+    MULTIINSTANCEBODY,
+    [JsonPropertyName("PARALLEL_GATEWAY")]
+    PARALLELGATEWAY,
+    [JsonPropertyName("PROCESS")]
+    PROCESS,
+    [JsonPropertyName("RECEIVE_TASK")]
+    RECEIVETASK,
+    [JsonPropertyName("SCRIPT_TASK")]
+    SCRIPTTASK,
+    [JsonPropertyName("SEND_TASK")]
+    SENDTASK,
+    [JsonPropertyName("SEQUENCE_FLOW")]
+    SEQUENCEFLOW,
+    [JsonPropertyName("SERVICE_TASK")]
+    SERVICETASK,
+    [JsonPropertyName("START_EVENT")]
+    STARTEVENT,
+    [JsonPropertyName("SUB_PROCESS")]
+    SUBPROCESS,
+    [JsonPropertyName("TASK")]
+    TASK,
+    [JsonPropertyName("UNKNOWN")]
+    UNKNOWN,
+    [JsonPropertyName("UNSPECIFIED")]
+    UNSPECIFIED,
+    [JsonPropertyName("USER_TASK")]
+    USERTASK,
+}
+
+/// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct WaitStateElementTypeExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private WaitStateElementTypeExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="WaitStateElementTypeExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static WaitStateElementTypeExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "WaitStateElementTypeExactMatch");
+        return new WaitStateElementTypeExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// Element type property with full advanced search capabilities.
+/// </summary>
+public sealed class WaitStateElementTypeFilterProperty
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public WaitStateElementTypeEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public WaitStateElementTypeEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<WaitStateElementTypeEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
+/// The type of waiting state an element instance is in.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum WaitStateTypeEnum
+{
+    [JsonPropertyName("JOB")]
+    JOB,
+    [JsonPropertyName("MESSAGE")]
+    MESSAGE,
+}
+
+/// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct WaitStateTypeExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private WaitStateTypeExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="WaitStateTypeExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static WaitStateTypeExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "WaitStateTypeExactMatch");
+        return new WaitStateTypeExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// Wait state type property with full advanced search capabilities.
+/// </summary>
+public sealed class WaitStateTypeFilterProperty
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public WaitStateTypeEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public WaitStateTypeEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<WaitStateTypeEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
 
 }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -7120,7 +7120,7 @@ public sealed class CursorBackwardPagination : SearchQueryPageRequest
     /// Use the `startCursor` value from the previous response to fetch the previous page of results.
     /// </summary>
     [JsonPropertyName("before")]
-    public StartCursor Before { get; set; }
+    public StartCursor? Before { get; set; }
 
     /// <summary>
     /// The maximum number of items to return in one request.
@@ -7139,7 +7139,7 @@ public sealed class CursorForwardPagination : SearchQueryPageRequest
     /// Use the `endCursor` value from the previous response to fetch the next page of results.
     /// </summary>
     [JsonPropertyName("after")]
-    public EndCursor After { get; set; }
+    public EndCursor? After { get; set; }
 
     /// <summary>
     /// The maximum number of items to return in one request.

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:cb633855979423c3641876a384ff83d246452b2d34b631b83fb349a82bd425f7";
+    public const string SpecHash = "sha256:b7867e21d395ab0be549e976bf90398c181e9b72c0206c6fcb73463ce23cd84c";
 }

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:f85a4345e56552ece2e63ba93164e70abb16973b17a4256803dc5d64346869c6";
+    public const string SpecHash = "sha256:cb633855979423c3641876a384ff83d246452b2d34b631b83fb349a82bd425f7";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PolymorphicDeserializationTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/PolymorphicDeserializationTests.cs
@@ -155,7 +155,8 @@ public class PolymorphicDeserializationTests
 
         var result = JsonSerializer.Deserialize<AncestorScopeInstruction>(json, s_options);
 
-        Assert.IsType<DirectAncestorKeyInstruction>(result);
+        var typed = Assert.IsType<DirectAncestorKeyInstruction>(result);
+        Assert.Equal(ElementInstanceKey.AssumeExists("99999"), typed.AncestorElementInstanceKey);
     }
 
     [Fact]

--- a/test/Camunda.Orchestration.Sdk.Tests/PolymorphicDeserializationTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/PolymorphicDeserializationTests.cs
@@ -149,7 +149,7 @@ public class PolymorphicDeserializationTests
         var json = """
         {
             "ancestorScopeType": "direct",
-            "ancestorElementInstanceKey": 99999
+            "ancestorElementInstanceKey": "99999"
         }
         """;
 

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -38,6 +38,7 @@ TYPE Camunda.Orchestration.Sdk.ActivatedJobResult : sealed class
   PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP Camunda.Orchestration.Sdk.UserTaskProperties? UserTask { get; set; } [JsonPropertyName("userTask")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.Tag> Tags { get; set; } [JsonPropertyName("tags")]
+  PROP System.Int32 Priority { get; set; } [JsonPropertyName("priority")]
   PROP System.Int32 ProcessDefinitionVersion { get; set; } [JsonPropertyName("processDefinitionVersion")]
   PROP System.Int32 Retries { get; set; } [JsonPropertyName("retries")]
   PROP System.Int64 Deadline { get; set; } [JsonPropertyName("deadline")]
@@ -428,6 +429,22 @@ TYPE Camunda.Orchestration.Sdk.AdvancedVariableKeyFilter : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableKey>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
+TYPE Camunda.Orchestration.Sdk.AdvancedWaitStateElementTypeFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP Camunda.Orchestration.Sdk.WaitStateElementTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.WaitStateElementTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.WaitStateElementTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.AdvancedWaitStateTypeFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP Camunda.Orchestration.Sdk.WaitStateTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.WaitStateTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.WaitStateTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
+
 TYPE Camunda.Orchestration.Sdk.AgentInstanceCreationRequest : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceDefinition Definition { get; set; } [JsonPropertyName("definition")]
@@ -452,8 +469,11 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceFilter : sealed class
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? CreationDate { get; set; } [JsonPropertyName("creationDate")]
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? LastUpdatedDate { get; set; } [JsonPropertyName("lastUpdatedDate")]
   PROP Camunda.Orchestration.Sdk.ElementIdFilterProperty? ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? ProcessDefinitionVersion { get; set; } [JsonPropertyName("processDefinitionVersion")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionVersionTag { get; set; } [JsonPropertyName("processDefinitionVersionTag")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty>? ElementInstanceKeys { get; set; } [JsonPropertyName("elementInstanceKeys")]
 
@@ -485,23 +505,23 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceKeyFilterProperty : sealed class
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceLimits : sealed class
   CTOR ()
-  PROP System.Int64 MaxModelCalls { get; set; } [JsonPropertyName("maxModelCalls")]
+  PROP System.Int32 MaxModelCalls { get; set; } [JsonPropertyName("maxModelCalls")]
+  PROP System.Int32 MaxToolCalls { get; set; } [JsonPropertyName("maxToolCalls")]
   PROP System.Int64 MaxTokens { get; set; } [JsonPropertyName("maxTokens")]
-  PROP System.Int64 MaxToolCalls { get; set; } [JsonPropertyName("maxToolCalls")]
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceMetrics : sealed class
   CTOR ()
+  PROP System.Int32 ModelCalls { get; set; } [JsonPropertyName("modelCalls")]
+  PROP System.Int32 ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
   PROP System.Int64 InputTokens { get; set; } [JsonPropertyName("inputTokens")]
-  PROP System.Int64 ModelCalls { get; set; } [JsonPropertyName("modelCalls")]
   PROP System.Int64 OutputTokens { get; set; } [JsonPropertyName("outputTokens")]
-  PROP System.Int64 ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceMetricsDelta : sealed class
   CTOR ()
+  PROP System.Int32? ModelCalls { get; set; } [JsonPropertyName("modelCalls")]
+  PROP System.Int32? ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
   PROP System.Int64? InputTokens { get; set; } [JsonPropertyName("inputTokens")]
-  PROP System.Int64? ModelCalls { get; set; } [JsonPropertyName("modelCalls")]
   PROP System.Int64? OutputTokens { get; set; } [JsonPropertyName("outputTokens")]
-  PROP System.Int64? ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceResult : sealed class
   CTOR ()
@@ -511,14 +531,18 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceResult : sealed class
   PROP Camunda.Orchestration.Sdk.AgentInstanceMetrics Metrics { get; set; } [JsonPropertyName("metrics")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum Status { get; set; } [JsonPropertyName("status")]
   PROP Camunda.Orchestration.Sdk.ElementId ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey RootProcessInstanceKey { get; set; } [JsonPropertyName("rootProcessInstanceKey")]
   PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentTool> Tools { get; set; } [JsonPropertyName("tools")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementInstanceKey> ElementInstanceKeys { get; set; } [JsonPropertyName("elementInstanceKeys")]
   PROP System.DateTimeOffset CreationDate { get; set; } [JsonPropertyName("creationDate")]
   PROP System.DateTimeOffset LastUpdatedDate { get; set; } [JsonPropertyName("lastUpdatedDate")]
   PROP System.DateTimeOffset? CompletionDate { get; set; } [JsonPropertyName("completionDate")]
+  PROP System.Int32 ProcessDefinitionVersion { get; set; } [JsonPropertyName("processDefinitionVersion")]
+  PROP System.String? ProcessDefinitionVersionTag { get; set; } [JsonPropertyName("processDefinitionVersionTag")]
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceSearchQuery : sealed class
   CTOR ()
@@ -547,12 +571,13 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceSearchQuerySortRequestField : enum i
 TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
   underlying=System.Int32
-  MEMBER COMPLETED = 0 json="COMPLETED"
-  MEMBER IDLE = 1 json="IDLE"
-  MEMBER INITIALIZING = 2 json="INITIALIZING"
-  MEMBER THINKING = 3 json="THINKING"
-  MEMBER TOOLCALLING = 4 json="TOOL_CALLING"
-  MEMBER TOOLDISCOVERY = 5 json="TOOL_DISCOVERY"
+  MEMBER UNKNOWN = 0 json="UNKNOWN"
+  MEMBER COMPLETED = 1 json="COMPLETED"
+  MEMBER IDLE = 2 json="IDLE"
+  MEMBER INITIALIZING = 3 json="INITIALIZING"
+  MEMBER THINKING = 4 json="THINKING"
+  MEMBER TOOLCALLING = 5 json="TOOL_CALLING"
+  MEMBER TOOLDISCOVERY = 6 json="TOOL_DISCOVERY"
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentInstanceStatusExactMatch>]
   PROP System.String Value { get; }
@@ -574,8 +599,17 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusFilterProperty : sealed class
 TYPE Camunda.Orchestration.Sdk.AgentInstanceUpdateRequest : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceMetricsDelta? Metrics { get; set; } [JsonPropertyName("metrics")]
-  PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum? Status { get; set; } [JsonPropertyName("status")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceUpdateStatusEnum? Status { get; set; } [JsonPropertyName("status")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentTool>? Tools { get; set; } [JsonPropertyName("tools")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceUpdateStatusEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER IDLE = 0 json="IDLE"
+  MEMBER THINKING = 1 json="THINKING"
+  MEMBER TOOLCALLING = 2 json="TOOL_CALLING"
+  MEMBER TOOLDISCOVERY = 3 json="TOOL_DISCOVERY"
 
 TYPE Camunda.Orchestration.Sdk.AgentTool : sealed class
   CTOR ()
@@ -1358,6 +1392,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.DocumentReference> CreateDocumentAsync(System.Net.Http.MultipartFormDataContent content, System.String? storeId = null, Camunda.Orchestration.Sdk.DocumentId? documentId = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ElementInstanceResult> GetElementInstanceAsync(Camunda.Orchestration.Sdk.ElementInstanceKey elementInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ElementInstanceResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ElementInstanceSearchQueryResult> SearchElementInstancesAsync(Camunda.Orchestration.Sdk.ElementInstanceSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ElementInstanceSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ElementInstanceWaitStateQueryResult> SearchElementInstanceWaitStatesAsync(Camunda.Orchestration.Sdk.ElementInstanceWaitStateQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ElementInstanceWaitStateQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.EvaluateConditionalResult> EvaluateConditionalsAsync(Camunda.Orchestration.Sdk.ConditionalEvaluationInstruction body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.EvaluateDecisionResult> EvaluateDecisionAsync(Camunda.Orchestration.Sdk.DecisionEvaluationInstruction body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ExpressionEvaluationResult> EvaluateExpressionAsync(Camunda.Orchestration.Sdk.ExpressionEvaluationRequest body, System.Threading.CancellationToken ct = null)
@@ -1565,11 +1600,7 @@ TYPE Camunda.Orchestration.Sdk.ClockPinRequest : sealed class
 
 TYPE Camunda.Orchestration.Sdk.CloudConfigurationResponse : sealed class
   CTOR ()
-  PROP Camunda.Orchestration.Sdk.CloudStage? Stage { get; set; } [JsonPropertyName("stage")]
-  PROP System.String? ClusterId { get; set; } [JsonPropertyName("clusterId")]
-  PROP System.String? MixpanelAPIHost { get; set; } [JsonPropertyName("mixpanelAPIHost")]
-  PROP System.String? MixpanelToken { get; set; } [JsonPropertyName("mixpanelToken")]
-  PROP System.String? OrganizationId { get; set; } [JsonPropertyName("organizationId")]
+  PROP System.String? Stage { get; set; } [JsonPropertyName("stage")]
 
 TYPE Camunda.Orchestration.Sdk.CloudStage : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
@@ -2204,10 +2235,8 @@ TYPE Camunda.Orchestration.Sdk.DeleteResourceResponse : sealed class
 
 TYPE Camunda.Orchestration.Sdk.DeploymentConfigurationResponse : sealed class
   CTOR ()
-  PROP System.Boolean IsEnterprise { get; set; } [JsonPropertyName("isEnterprise")]
   PROP System.Boolean IsMultiTenancyEnabled { get; set; } [JsonPropertyName("isMultiTenancyEnabled")]
   PROP System.Int64 MaxRequestSize { get; set; } [JsonPropertyName("maxRequestSize")]
-  PROP System.String ContextPath { get; set; } [JsonPropertyName("contextPath")]
 
 TYPE Camunda.Orchestration.Sdk.DeploymentDecisionRequirementsResult : sealed class
   CTOR ()
@@ -2294,7 +2323,7 @@ TYPE Camunda.Orchestration.Sdk.DeploymentResult : sealed class
 
 TYPE Camunda.Orchestration.Sdk.DirectAncestorKeyInstruction : sealed class base=Camunda.Orchestration.Sdk.AncestorScopeInstruction
   CTOR ()
-  PROP System.Object AncestorElementInstanceKey { get; set; } [JsonPropertyName("ancestorElementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKey AncestorElementInstanceKey { get; set; } [JsonPropertyName("ancestorElementInstanceKey")]
 
 TYPE Camunda.Orchestration.Sdk.DocumentCreationBatchResponse : sealed class
   CTOR ()
@@ -2401,7 +2430,56 @@ TYPE Camunda.Orchestration.Sdk.ElementInstanceFilter : sealed class
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ElementName { get; set; } [JsonPropertyName("elementName")]
   PROP Camunda.Orchestration.Sdk.TenantId? TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Boolean? HasIncident { get; set; } [JsonPropertyName("hasIncident")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementInstanceFilterFields>? Or { get; set; } [JsonPropertyName("$or")]
   PROP System.String? ElementInstanceScopeKey { get; set; } [JsonPropertyName("elementInstanceScopeKey")]
+
+TYPE Camunda.Orchestration.Sdk.ElementInstanceFilterFields : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? EndDate { get; set; } [JsonPropertyName("endDate")]
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? StartDate { get; set; } [JsonPropertyName("startDate")]
+  PROP Camunda.Orchestration.Sdk.ElementIdFilterProperty? ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceFilterFieldsType? Type { get; set; } [JsonPropertyName("type")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKey? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceStateFilterProperty? State { get; set; } [JsonPropertyName("state")]
+  PROP Camunda.Orchestration.Sdk.IncidentKey? IncidentKey { get; set; } [JsonPropertyName("incidentKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ElementName { get; set; } [JsonPropertyName("elementName")]
+  PROP Camunda.Orchestration.Sdk.TenantId? TenantId { get; set; } [JsonPropertyName("tenantId")]
+  PROP System.Boolean? HasIncident { get; set; } [JsonPropertyName("hasIncident")]
+  PROP System.String? ElementInstanceScopeKey { get; set; } [JsonPropertyName("elementInstanceScopeKey")]
+
+TYPE Camunda.Orchestration.Sdk.ElementInstanceFilterFieldsType : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER UNSPECIFIED = 0 json="UNSPECIFIED"
+  MEMBER PROCESS = 1 json="PROCESS"
+  MEMBER SUBPROCESS = 2 json="SUB_PROCESS"
+  MEMBER EVENTSUBPROCESS = 3 json="EVENT_SUB_PROCESS"
+  MEMBER ADHOCSUBPROCESS = 4 json="AD_HOC_SUB_PROCESS"
+  MEMBER ADHOCSUBPROCESSINNERINSTANCE = 5 json="AD_HOC_SUB_PROCESS_INNER_INSTANCE"
+  MEMBER STARTEVENT = 6 json="START_EVENT"
+  MEMBER INTERMEDIATECATCHEVENT = 7 json="INTERMEDIATE_CATCH_EVENT"
+  MEMBER INTERMEDIATETHROWEVENT = 8 json="INTERMEDIATE_THROW_EVENT"
+  MEMBER BOUNDARYEVENT = 9 json="BOUNDARY_EVENT"
+  MEMBER ENDEVENT = 10 json="END_EVENT"
+  MEMBER SERVICETASK = 11 json="SERVICE_TASK"
+  MEMBER RECEIVETASK = 12 json="RECEIVE_TASK"
+  MEMBER USERTASK = 13 json="USER_TASK"
+  MEMBER MANUALTASK = 14 json="MANUAL_TASK"
+  MEMBER TASK = 15 json="TASK"
+  MEMBER EXCLUSIVEGATEWAY = 16 json="EXCLUSIVE_GATEWAY"
+  MEMBER INCLUSIVEGATEWAY = 17 json="INCLUSIVE_GATEWAY"
+  MEMBER PARALLELGATEWAY = 18 json="PARALLEL_GATEWAY"
+  MEMBER EVENTBASEDGATEWAY = 19 json="EVENT_BASED_GATEWAY"
+  MEMBER SEQUENCEFLOW = 20 json="SEQUENCE_FLOW"
+  MEMBER MULTIINSTANCEBODY = 21 json="MULTI_INSTANCE_BODY"
+  MEMBER CALLACTIVITY = 22 json="CALL_ACTIVITY"
+  MEMBER BUSINESSRULETASK = 23 json="BUSINESS_RULE_TASK"
+  MEMBER SCRIPTTASK = 24 json="SCRIPT_TASK"
+  MEMBER SENDTASK = 25 json="SEND_TASK"
+  MEMBER UNKNOWN = 26 json="UNKNOWN"
 
 TYPE Camunda.Orchestration.Sdk.ElementInstanceFilterType : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
@@ -2564,6 +2642,37 @@ TYPE Camunda.Orchestration.Sdk.ElementInstanceStateFilterProperty : sealed class
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementInstanceStateEnum>? In { get; set; } [JsonPropertyName("$in")]
 
+TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.ElementIdFilterProperty? ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? RootProcessInstanceKey { get; set; } [JsonPropertyName("rootProcessInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.WaitStateElementTypeFilterProperty? ElementType { get; set; } [JsonPropertyName("elementType")]
+  PROP Camunda.Orchestration.Sdk.WaitStateTypeFilterProperty? WaitStateType { get; set; } [JsonPropertyName("waitStateType")]
+
+TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateQuery : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.ElementInstanceWaitStateFilter? Filter { get; set; } [JsonPropertyName("filter")]
+  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
+
+TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateQueryResult : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementInstanceWaitStateResult> Items { get; set; } [JsonPropertyName("items")]
+
+TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateResult : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.ElementId ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.JobWaitStateDetails? JobDetails { get; set; } [JsonPropertyName("jobDetails")]
+  PROP Camunda.Orchestration.Sdk.MessageWaitStateDetails? MessageDetails { get; set; } [JsonPropertyName("messageDetails")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? RootProcessInstanceKey { get; set; } [JsonPropertyName("rootProcessInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
+  PROP Camunda.Orchestration.Sdk.WaitStateElementTypeEnum ElementType { get; set; } [JsonPropertyName("elementType")]
+  PROP Camunda.Orchestration.Sdk.WaitStateTypeEnum WaitStateType { get; set; } [JsonPropertyName("waitStateType")]
+
 TYPE Camunda.Orchestration.Sdk.EndCursor : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.EndCursor>]
   PROP System.String Value { get; }
   METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.EndCursor other)
@@ -2649,6 +2758,7 @@ TYPE Camunda.Orchestration.Sdk.EventualConsistencyTimeoutException : sealed clas
 
 TYPE Camunda.Orchestration.Sdk.ExpressionEvaluationRequest : sealed class interfaces=[Camunda.Orchestration.Sdk.ITenantIdSettable]
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ScopeKey? ScopeKey { get; set; } [JsonPropertyName("scopeKey")]
   PROP System.Object? Variables { get; set; } [JsonPropertyName("variables")]
   PROP System.String Expression { get; set; } [JsonPropertyName("expression")]
   PROP System.String? TenantId { get; set; } [JsonPropertyName("tenantId")]
@@ -3286,6 +3396,7 @@ TYPE Camunda.Orchestration.Sdk.JobFilter : sealed class
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? EndTime { get; set; } [JsonPropertyName("endTime")]
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? LastUpdateTime { get; set; } [JsonPropertyName("lastUpdateTime")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? Priority { get; set; } [JsonPropertyName("priority")]
   PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? Retries { get; set; } [JsonPropertyName("retries")]
   PROP Camunda.Orchestration.Sdk.JobKeyFilterProperty? JobKey { get; set; } [JsonPropertyName("jobKey")]
   PROP Camunda.Orchestration.Sdk.JobKindFilterProperty? Kind { get; set; } [JsonPropertyName("kind")]
@@ -3366,13 +3477,14 @@ TYPE Camunda.Orchestration.Sdk.JobListenerEventTypeEnum : enum interfaces=[Syste
   underlying=System.Int32
   MEMBER ASSIGNING = 0 json="ASSIGNING"
   MEMBER BEFOREALL = 1 json="BEFORE_ALL"
-  MEMBER CANCELING = 2 json="CANCELING"
-  MEMBER COMPLETING = 3 json="COMPLETING"
-  MEMBER CREATING = 4 json="CREATING"
-  MEMBER END = 5 json="END"
-  MEMBER START = 6 json="START"
-  MEMBER UNSPECIFIED = 7 json="UNSPECIFIED"
-  MEMBER UPDATING = 8 json="UPDATING"
+  MEMBER CANCEL = 2 json="CANCEL"
+  MEMBER CANCELING = 3 json="CANCELING"
+  MEMBER COMPLETING = 4 json="COMPLETING"
+  MEMBER CREATING = 5 json="CREATING"
+  MEMBER END = 6 json="END"
+  MEMBER START = 7 json="START"
+  MEMBER UNSPECIFIED = 8 json="UNSPECIFIED"
+  MEMBER UPDATING = 9 json="UPDATING"
 
 TYPE Camunda.Orchestration.Sdk.JobListenerEventTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.JobListenerEventTypeExactMatch>]
   PROP System.String Value { get; }
@@ -3462,14 +3574,15 @@ TYPE Camunda.Orchestration.Sdk.JobSearchQuerySortRequestField : enum interfaces=
   MEMBER JobKey = 9 json="jobKey"
   MEMBER Kind = 10 json="kind"
   MEMBER ListenerEventType = 11 json="listenerEventType"
-  MEMBER ProcessDefinitionId = 12 json="processDefinitionId"
-  MEMBER ProcessDefinitionKey = 13 json="processDefinitionKey"
-  MEMBER ProcessInstanceKey = 14 json="processInstanceKey"
-  MEMBER Retries = 15 json="retries"
-  MEMBER State = 16 json="state"
-  MEMBER TenantId = 17 json="tenantId"
-  MEMBER Type = 18 json="type"
-  MEMBER Worker = 19 json="worker"
+  MEMBER Priority = 12 json="priority"
+  MEMBER ProcessDefinitionId = 13 json="processDefinitionId"
+  MEMBER ProcessDefinitionKey = 14 json="processDefinitionKey"
+  MEMBER ProcessInstanceKey = 15 json="processInstanceKey"
+  MEMBER Retries = 16 json="retries"
+  MEMBER State = 17 json="state"
+  MEMBER TenantId = 18 json="tenantId"
+  MEMBER Type = 19 json="type"
+  MEMBER Worker = 20 json="worker"
 
 TYPE Camunda.Orchestration.Sdk.JobSearchResult : sealed class
   CTOR ()
@@ -3491,6 +3604,7 @@ TYPE Camunda.Orchestration.Sdk.JobSearchResult : sealed class
   PROP System.DateTimeOffset? Deadline { get; set; } [JsonPropertyName("deadline")]
   PROP System.DateTimeOffset? EndTime { get; set; } [JsonPropertyName("endTime")]
   PROP System.DateTimeOffset? LastUpdateTime { get; set; } [JsonPropertyName("lastUpdateTime")]
+  PROP System.Int32 Priority { get; set; } [JsonPropertyName("priority")]
   PROP System.Int32 Retries { get; set; } [JsonPropertyName("retries")]
   PROP System.String Type { get; set; } [JsonPropertyName("type")]
   PROP System.String Worker { get; set; } [JsonPropertyName("worker")]
@@ -3579,6 +3693,14 @@ TYPE Camunda.Orchestration.Sdk.JobUpdateRequest : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.JobChangeset Changeset { get; set; } [JsonPropertyName("changeset")]
   PROP Camunda.Orchestration.Sdk.OperationReference? OperationReference { get; set; } [JsonPropertyName("operationReference")]
+
+TYPE Camunda.Orchestration.Sdk.JobWaitStateDetails : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.JobKey JobKey { get; set; } [JsonPropertyName("jobKey")]
+  PROP Camunda.Orchestration.Sdk.JobKindEnum JobKind { get; set; } [JsonPropertyName("jobKind")]
+  PROP Camunda.Orchestration.Sdk.JobListenerEventTypeEnum? ListenerEventType { get; set; } [JsonPropertyName("listenerEventType")]
+  PROP System.Int32? Retries { get; set; } [JsonPropertyName("retries")]
+  PROP System.String JobType { get; set; } [JsonPropertyName("jobType")]
 
 TYPE Camunda.Orchestration.Sdk.JobWorker : sealed class interfaces=[System.IAsyncDisposable,System.IDisposable]
   PROP System.Boolean IsRunning { get; }
@@ -3934,6 +4056,11 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionTypeFilterProperty : sealed cl
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.MessageWaitStateDetails : sealed class
+  CTOR ()
+  PROP System.String MessageName { get; set; } [JsonPropertyName("messageName")]
+  PROP System.String? CorrelationKey { get; set; } [JsonPropertyName("correlationKey")]
 
 TYPE Camunda.Orchestration.Sdk.MigrateProcessInstanceMappingInstruction : sealed class
   CTOR ()
@@ -5560,6 +5687,77 @@ TYPE Camunda.Orchestration.Sdk.VariableValueFilterProperty : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.StringFilterProperty Value { get; set; } [JsonPropertyName("value")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
+
+TYPE Camunda.Orchestration.Sdk.WaitStateElementTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER ADHOCSUBPROCESS = 0 json="AD_HOC_SUB_PROCESS"
+  MEMBER ADHOCSUBPROCESSINNERINSTANCE = 1 json="AD_HOC_SUB_PROCESS_INNER_INSTANCE"
+  MEMBER BOUNDARYEVENT = 2 json="BOUNDARY_EVENT"
+  MEMBER BUSINESSRULETASK = 3 json="BUSINESS_RULE_TASK"
+  MEMBER CALLACTIVITY = 4 json="CALL_ACTIVITY"
+  MEMBER ENDEVENT = 5 json="END_EVENT"
+  MEMBER EVENTBASEDGATEWAY = 6 json="EVENT_BASED_GATEWAY"
+  MEMBER EVENTSUBPROCESS = 7 json="EVENT_SUB_PROCESS"
+  MEMBER EXCLUSIVEGATEWAY = 8 json="EXCLUSIVE_GATEWAY"
+  MEMBER INCLUSIVEGATEWAY = 9 json="INCLUSIVE_GATEWAY"
+  MEMBER INTERMEDIATECATCHEVENT = 10 json="INTERMEDIATE_CATCH_EVENT"
+  MEMBER INTERMEDIATETHROWEVENT = 11 json="INTERMEDIATE_THROW_EVENT"
+  MEMBER MANUALTASK = 12 json="MANUAL_TASK"
+  MEMBER MULTIINSTANCEBODY = 13 json="MULTI_INSTANCE_BODY"
+  MEMBER PARALLELGATEWAY = 14 json="PARALLEL_GATEWAY"
+  MEMBER PROCESS = 15 json="PROCESS"
+  MEMBER RECEIVETASK = 16 json="RECEIVE_TASK"
+  MEMBER SCRIPTTASK = 17 json="SCRIPT_TASK"
+  MEMBER SENDTASK = 18 json="SEND_TASK"
+  MEMBER SEQUENCEFLOW = 19 json="SEQUENCE_FLOW"
+  MEMBER SERVICETASK = 20 json="SERVICE_TASK"
+  MEMBER STARTEVENT = 21 json="START_EVENT"
+  MEMBER SUBPROCESS = 22 json="SUB_PROCESS"
+  MEMBER TASK = 23 json="TASK"
+  MEMBER UNKNOWN = 24 json="UNKNOWN"
+  MEMBER UNSPECIFIED = 25 json="UNSPECIFIED"
+  MEMBER USERTASK = 26 json="USER_TASK"
+
+TYPE Camunda.Orchestration.Sdk.WaitStateElementTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.WaitStateElementTypeExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.WaitStateElementTypeExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.WaitStateElementTypeExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.WaitStateElementTypeFilterProperty : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP Camunda.Orchestration.Sdk.WaitStateElementTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.WaitStateElementTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.WaitStateElementTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.WaitStateTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER JOB = 0 json="JOB"
+  MEMBER MESSAGE = 1 json="MESSAGE"
+
+TYPE Camunda.Orchestration.Sdk.WaitStateTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.WaitStateTypeExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.WaitStateTypeExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.WaitStateTypeExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.WaitStateTypeFilterProperty : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP Camunda.Orchestration.Sdk.WaitStateTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.WaitStateTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.WaitStateTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
 
 TYPE Camunda.Orchestration.Sdk.WebappComponent : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -1824,12 +1824,12 @@ TYPE Camunda.Orchestration.Sdk.CreateProcessInstanceResult : sealed class
 
 TYPE Camunda.Orchestration.Sdk.CursorBackwardPagination : sealed class base=Camunda.Orchestration.Sdk.SearchQueryPageRequest
   CTOR ()
-  PROP Camunda.Orchestration.Sdk.StartCursor Before { get; set; } [JsonPropertyName("before")]
+  PROP Camunda.Orchestration.Sdk.StartCursor? Before { get; set; } [JsonPropertyName("before")]
   PROP System.Int32? Limit { get; set; } [JsonPropertyName("limit")]
 
 TYPE Camunda.Orchestration.Sdk.CursorForwardPagination : sealed class base=Camunda.Orchestration.Sdk.SearchQueryPageRequest
   CTOR ()
-  PROP Camunda.Orchestration.Sdk.EndCursor After { get; set; } [JsonPropertyName("after")]
+  PROP Camunda.Orchestration.Sdk.EndCursor? After { get; set; } [JsonPropertyName("after")]
   PROP System.Int32? Limit { get; set; } [JsonPropertyName("limit")]
 
 TYPE Camunda.Orchestration.Sdk.DateTimeFilterProperty : sealed class


### PR DESCRIPTION
Updates the bundled OpenAPI spec to latest `main`, regenerates the C# SDK, and bumps Docker to `8.10-SNAPSHOT`.

Changes:
- Fetched latest upstream spec from `camunda/camunda` main branch
- Updated `docker/docker-compose.yaml` from `8.9.0-alpha4` to `8.10-SNAPSHOT`
- Fixed `PolymorphicDeserializationTests` — `ancestorElementInstanceKey` is now a `CamundaKey` (string), not a number
- Updated `PublicApi.shipped.txt` baseline (new `Priority` property on job models)
- Regenerated SDK sources from updated spec