### PR TITLE
ci: add Vault-based org membership check for community notifications

### DIFF
--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -17,3 +17,6 @@ jobs:
       author-association: ${{ github.event.pull_request.author_association || github.event.issue.author_association }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}
+      vault-addr: ${{ secrets.VAULT_ADDR }}
+      vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+      vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -14,5 +14,6 @@ jobs:
     with:
       repo-name: orchestration-cluster-api-csharp
       mention-group: ${{ vars.SLACK_MENTION_GROUP }}
+      author-association: ${{ github.event.pull_request.author_association || github.event.issue.author_association }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}


### PR DESCRIPTION
## Summary

Adds Vault integration to the community notification workflow so it can reliably detect org members — including those with private membership — and skip false-positive community alerts.

## Background

GitHub's `author_association` field returns `CONTRIBUTOR` instead of `MEMBER` for org members who have base-permission-only access (no team/direct collaborator assignment). This caused org members like @emilyoram to be misclassified as community contributors, triggering unnecessary Slack notifications.

The upstream reusable workflow in `sdk-infra` ([`sdk-slack-community-notify.yml@v1`](https://github.com/camunda/sdk-infra/blob/main/.github/workflows/sdk-slack-community-notify.yml)) now:
1. Fetches the `camunda-sdk-automation` GitHub App credentials from Vault
2. Generates a short-lived App token
3. Uses the authenticated `GET /orgs/{org}/members/{username}` endpoint (detects both public and private memberships)

## Changes

- Pass `author-association` explicitly to the reusable workflow (defense-in-depth)
- Pass Vault secrets (`VAULT_ADDR`, `VAULT_ROLE_ID`, `VAULT_SECRET_ID`) to enable the authenticated org membership check

## Prerequisites

- [x] `camunda-sdk-automation` GitHub App installed on this repo (infra-core#13028)
- [x] Repo onboarded to Vault
- [x] `sdk-infra` v1 tag updated with Vault integration