### PR TITLE
feat: add SearchVariablesAsDtoAsync for typed variable maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ public record OrderVariables(string OrderId, decimal Amount, string? Notes);
 var map = await client.SearchVariablesAsDtoAsync<OrderVariables>(processInstanceKey);
 
 // Inspect individual values without materializing the whole DTO
-if (map.Contains("orderId"))
+if (map.Contains("amount"))
 {
     var amount = map.Get<decimal>("amount");
 }

--- a/README.md
+++ b/README.md
@@ -712,6 +712,37 @@ var output = result.Variables.DeserializeAs<OrderResult>();
 
 Custom `JsonSerializerOptions` can be passed for non-standard naming conventions.
 
+### Searching Variables as a DTO
+
+`SearchVariablesAsDtoAsync<T>()` queries a process instance for exactly the variables declared on your DTO, pages through all results, and collapses them into a typed [`VariableMap<T>`](src/Camunda.Orchestration.Sdk/Runtime/VariableMap.cs). Variable names are derived from the same `JsonSerializerOptions` used to deserialize (camelCase by default, overridable with `[JsonPropertyName]`), so the query filter, the raw keys, and DTO binding always agree.
+
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+SearchVariablesAsDto+SearchVariablesAsDtoBody -->
+```csharp
+using Camunda.Orchestration.Sdk;
+
+public record OrderVariables(string OrderId, decimal Amount, string? Notes);
+
+// Query only the variables declared on the DTO, across all pages, and
+// collapse them into a single typed object.
+var map = await client.SearchVariablesAsDtoAsync<OrderVariables>(processInstanceKey);
+
+// Inspect individual values without materializing the whole DTO
+if (map.Contains("orderId"))
+{
+    var amount = map.Get<decimal>("amount");
+}
+
+// Validate() enforces that every non-nullable DTO member is present,
+// throwing VariableValidationException if any required variable is missing.
+OrderVariables order = map.Validate();
+// order.OrderId, order.Amount — fully typed; order.Notes is optional
+```
+
+Behavior notes:
+- **Scope collision**: if the same variable name appears at more than one scope (e.g. a local and a parent scope), `SearchVariablesAsDtoAsync` throws `VariableScopeCollisionException` rather than guessing. Narrow the query with the optional `scopeKey` parameter.
+- **`Validate()`** throws `VariableValidationException` listing every missing required member; nullable members (`string?`, `int?`) are optional.
+- **`Get<TValue>(name)`** and **`Get(name)`** read individual values lazily and return `default`/`null` when absent.
+
 ## Job Workers
 
 Job workers subscribe to a specific job type and process jobs as they become available. The worker handles polling, concurrent dispatch, auto-completion, and error handling.

--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ Custom `JsonSerializerOptions` can be passed for non-standard naming conventions
 
 ### Searching Variables as a DTO
 
-`SearchVariablesAsDtoAsync<T>()` queries a process instance for exactly the variables declared on your DTO, pages through all results, and collapses them into a typed [`VariableMap<T>`](src/Camunda.Orchestration.Sdk/Runtime/VariableMap.cs). Variable names are derived from the same `JsonSerializerOptions` used to deserialize (camelCase by default, overridable with `[JsonPropertyName]`), so the query filter, the raw keys, and DTO binding always agree.
+`SearchVariablesAsDtoAsync<T>()` queries a process instance for exactly the variables declared on your DTO, pages through all results, and collapses them into a typed `VariableMap<T>`. Variable names are derived from the same `JsonSerializerOptions` used to deserialize (camelCase by default, overridable with `[JsonPropertyName]`), so the query filter, the raw keys, and DTO binding always agree.
 
 <!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: UsingDirective+SearchVariablesAsDto+SearchVariablesAsDtoBody -->
 ```csharp

--- a/docs/examples/ReadmeExamples.cs
+++ b/docs/examples/ReadmeExamples.cs
@@ -305,7 +305,7 @@ internal static class ReadmeExamples
         var map = await client.SearchVariablesAsDtoAsync<OrderVariables>(processInstanceKey);
 
         // Inspect individual values without materializing the whole DTO
-        if (map.Contains("orderId"))
+        if (map.Contains("amount"))
         {
             var amount = map.Get<decimal>("amount");
         }

--- a/docs/examples/ReadmeExamples.cs
+++ b/docs/examples/ReadmeExamples.cs
@@ -291,6 +291,32 @@ internal static class ReadmeExamples
         // </ReceivingVariablesBody>
     }
 
+    // <SearchVariablesAsDto>
+    public record OrderVariables(string OrderId, decimal Amount, string? Notes);
+    // </SearchVariablesAsDto>
+
+    private static async Task SearchVariablesAsDtoExample(ProcessInstanceKey processInstanceKey)
+    {
+        using var client = CamundaClient.Create();
+
+        // <SearchVariablesAsDtoBody>
+        // Query only the variables declared on the DTO, across all pages, and
+        // collapse them into a single typed object.
+        var map = await client.SearchVariablesAsDtoAsync<OrderVariables>(processInstanceKey);
+
+        // Inspect individual values without materializing the whole DTO
+        if (map.Contains("orderId"))
+        {
+            var amount = map.Get<decimal>("amount");
+        }
+
+        // Validate() enforces that every non-nullable DTO member is present,
+        // throwing VariableValidationException if any required variable is missing.
+        OrderVariables order = map.Validate();
+        // order.OrderId, order.Amount — fully typed; order.Notes is optional
+        // </SearchVariablesAsDtoBody>
+    }
+
     // <BasicWorker>
     // Define input/output DTOs
     public record OrderOutput(bool Processed, string InvoiceNumber);

--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -1693,6 +1693,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.SearchVariablesAsDtoAsync``1(Camunda.Orchestration.Sdk.ProcessInstanceKey,System.Nullable{Camunda.Orchestration.Sdk.ScopeKey},System.Nullable{Camunda.Orchestration.Sdk.TenantId},System.Int32,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/VariableElement.cs#SearchVariablesAsDto)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.SearchVariablesAsync(Camunda.Orchestration.Sdk.SearchVariablesRequest,System.Nullable{System.Boolean},Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.VariableSearchQueryResult},System.Threading.CancellationToken)
 example:
 - *content

--- a/examples/VariableElement.cs
+++ b/examples/VariableElement.cs
@@ -47,7 +47,7 @@ public static class VariableElementExamples
         var map = await client.SearchVariablesAsDtoAsync<OrderVariables>(processInstanceKey);
 
         // Read individual values lazily without materializing the whole DTO.
-        if (map.Contains("orderId"))
+        if (map.Contains("amount"))
         {
             var amount = map.Get<decimal>("amount");
             Console.WriteLine($"Amount: {amount}");

--- a/examples/VariableElement.cs
+++ b/examples/VariableElement.cs
@@ -33,6 +33,34 @@ public static class VariableElementExamples
     // </SearchVariables>
     #endregion SearchVariables
 
+    #region SearchVariablesAsDto
+
+    // <SearchVariablesAsDto>
+    public record OrderVariables(string OrderId, decimal Amount, string? Notes);
+
+    public static async Task SearchVariablesAsDtoExample(ProcessInstanceKey processInstanceKey)
+    {
+        using var client = CamundaClient.Create();
+
+        // Search a process instance for exactly the variables declared on the DTO,
+        // pages and all, and collapse them into a single typed object.
+        var map = await client.SearchVariablesAsDtoAsync<OrderVariables>(processInstanceKey);
+
+        // Read individual values lazily without materializing the whole DTO.
+        if (map.Contains("orderId"))
+        {
+            var amount = map.Get<decimal>("amount");
+            Console.WriteLine($"Amount: {amount}");
+        }
+
+        // Validate() enforces that every non-nullable member is present,
+        // throwing VariableValidationException if a required variable is missing.
+        OrderVariables order = map.Validate();
+        Console.WriteLine($"Order {order.OrderId}: {order.Amount}");
+    }
+    // </SearchVariablesAsDto>
+    #endregion SearchVariablesAsDto
+
     #region GetElementInstance
 
     // <GetElementInstance>

--- a/src/Camunda.Orchestration.Sdk/CamundaClient.Variables.cs
+++ b/src/Camunda.Orchestration.Sdk/CamundaClient.Variables.cs
@@ -118,7 +118,7 @@ public partial class CamundaClient
     }
 
     private static VariableSearchQuery BuildVariableQuery(
-        IReadOnlyList<string> queryNames,
+        List<string> queryNames,
         ProcessInstanceKey processInstanceKey,
         ScopeKey? scopeKey,
         TenantId? tenantId,
@@ -127,7 +127,9 @@ public partial class CamundaClient
     {
         var filter = new VariableFilter
         {
-            Name = new StringFilterProperty { In = queryNames.ToList() },
+            // queryNames is already materialized and never mutated here, so it is safe to
+            // share the same list reference across page queries.
+            Name = new StringFilterProperty { In = queryNames },
             ProcessInstanceKey = new ProcessInstanceKeyFilterProperty { Eq = processInstanceKey },
         };
 

--- a/src/Camunda.Orchestration.Sdk/CamundaClient.Variables.cs
+++ b/src/Camunda.Orchestration.Sdk/CamundaClient.Variables.cs
@@ -114,7 +114,7 @@ public partial class CamundaClient
             after = endCursor;
         }
 
-        return new VariableMap<T>(collector.Finalize(), _jsonOptions);
+        return new VariableMap<T>(collector.Build(), _jsonOptions);
     }
 
     private static VariableSearchQuery BuildVariableQuery(

--- a/src/Camunda.Orchestration.Sdk/CamundaClient.Variables.cs
+++ b/src/Camunda.Orchestration.Sdk/CamundaClient.Variables.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+
+namespace Camunda.Orchestration.Sdk;
+
+public partial class CamundaClient
+{
+    /// <summary>
+    /// Fetch the variables declared by a DTO type for a process instance, mapping them onto a
+    /// strongly-typed result.
+    ///
+    /// <para>
+    /// The query is derived from the DTO's members (honouring <c>[JsonPropertyName]</c>): only
+    /// the declared variable names are fetched via a <c>name $in [...]</c> filter, so memory is
+    /// bounded by the DTO shape rather than the total number of variables on the process
+    /// instance. Results are paged to exhaustion over the filtered set, collapsed by name, and
+    /// parsed into a <see cref="VariableMap{T}"/>.
+    /// </para>
+    ///
+    /// <para>
+    /// Access modes on the returned map:
+    /// <list type="bullet">
+    /// <item><description>
+    /// Lenient — <see cref="VariableMap{T}.Get(string)"/> /
+    /// <see cref="VariableMap{T}.Get{TValue}(string)"/> tolerate absent variables.
+    /// </description></item>
+    /// <item><description>
+    /// Strict — <see cref="VariableMap{T}.Validate"/> constructs the DTO and throws if a
+    /// required member is absent.
+    /// </description></item>
+    /// </list>
+    /// </para>
+    ///
+    /// <example>
+    /// <code>
+    /// public record OrderVars(string OrderId, decimal? Amount);
+    ///
+    /// var vars = await client.SearchVariablesAsDtoAsync&lt;OrderVars&gt;(processInstanceKey);
+    /// var amount = vars.Get&lt;decimal&gt;("amount");   // lenient
+    /// var typed = vars.Validate();                    // strict: throws if OrderId missing
+    /// </code>
+    /// </example>
+    /// </summary>
+    /// <typeparam name="T">The DTO type declaring the variables to fetch.</typeparam>
+    /// <param name="processInstanceKey">The process instance whose variables to search.</param>
+    /// <param name="scopeKey">
+    /// Optional scope key to disambiguate variables that exist at multiple scopes. When omitted
+    /// and a declared variable resolves to more than one scope, a
+    /// <see cref="VariableScopeCollisionException"/> is thrown.
+    /// </param>
+    /// <param name="tenantId">Optional tenant ID filter.</param>
+    /// <param name="pageSize">The page size used while paging the filtered result set.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="VariableMap{T}"/> over the declared variables.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">When <paramref name="pageSize"/> is less than 1.</exception>
+    /// <exception cref="VariableScopeCollisionException">
+    /// When a declared variable is found at more than one scope and no <paramref name="scopeKey"/>
+    /// was provided.
+    /// </exception>
+    /// <exception cref="VariableDeserializationException">
+    /// When a present variable value is not valid JSON.
+    /// </exception>
+    public async Task<VariableMap<T>> SearchVariablesAsDtoAsync<T>(
+        ProcessInstanceKey processInstanceKey,
+        ScopeKey? scopeKey = null,
+        TenantId? tenantId = null,
+        int pageSize = 100,
+        CancellationToken ct = default)
+        where T : class
+    {
+        if (pageSize < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "pageSize must be >= 1.");
+        }
+
+        var fields = TypedVariableSearch.ExtractFields(typeof(T), _jsonOptions);
+        if (fields.Count == 0)
+        {
+            return new VariableMap<T>(
+                new Dictionary<string, JsonElement>(StringComparer.Ordinal),
+                _jsonOptions);
+        }
+
+        var queryNames = fields.Select(field => field.VariableName).ToList();
+        var collector = new TypedVariableSearch.VariableCollector(queryNames);
+
+        EndCursor? after = null;
+        var seenCursors = new HashSet<string>(StringComparer.Ordinal);
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var query = BuildVariableQuery(
+                queryNames,
+                processInstanceKey,
+                scopeKey,
+                tenantId,
+                pageSize,
+                after);
+
+            var result = await SearchVariablesAsync(query, truncateValues: false, ct: ct)
+                .ConfigureAwait(false);
+
+            collector.Ingest(result.Items);
+
+            var endCursor = result.Page.EndCursor;
+            if (endCursor is null
+                || result.Items.Count == 0
+                || !seenCursors.Add(endCursor.Value.Value))
+            {
+                break;
+            }
+
+            after = endCursor;
+        }
+
+        return new VariableMap<T>(collector.Finalize(), _jsonOptions);
+    }
+
+    private static VariableSearchQuery BuildVariableQuery(
+        IReadOnlyList<string> queryNames,
+        ProcessInstanceKey processInstanceKey,
+        ScopeKey? scopeKey,
+        TenantId? tenantId,
+        int pageSize,
+        EndCursor? after)
+    {
+        var filter = new VariableFilter
+        {
+            Name = new StringFilterProperty { In = queryNames.ToList() },
+            ProcessInstanceKey = new ProcessInstanceKeyFilterProperty { Eq = processInstanceKey },
+        };
+
+        if (scopeKey is { } scope)
+        {
+            filter.ScopeKey = new ScopeKeyFilterProperty { Eq = scope };
+        }
+
+        if (tenantId is { } tenant)
+        {
+            filter.TenantId = tenant;
+        }
+
+        SearchQueryPageRequest page = after is { } cursor
+            ? new CursorForwardPagination { After = cursor, Limit = pageSize }
+            : new LimitPagination { Limit = pageSize };
+
+        return new VariableSearchQuery
+        {
+            Filter = filter,
+            Page = page,
+        };
+    }
+}

--- a/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableExceptions.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableExceptions.cs
@@ -49,12 +49,13 @@ public sealed class VariableScopeCollisionException : TypedVariablesException
 }
 
 /// <summary>
-/// Raised when a present variable value is not parseable as JSON.
+/// Raised when a present variable value cannot be deserialized.
 ///
 /// <para>
-/// A <em>missing</em> variable is not an error (it simply does not appear in the map);
-/// a <em>present but malformed</em> value is, and is surfaced here rather than silently
-/// dropped.
+/// This covers both a value that is not parseable as JSON and a syntactically valid value
+/// that cannot be bound to the requested CLR type. A <em>missing</em> variable is not an
+/// error (it simply does not appear in the map); a <em>present but undeserializable</em>
+/// value is, and is surfaced here rather than silently dropped.
 /// </para>
 /// </summary>
 public sealed class VariableDeserializationException : TypedVariablesException
@@ -65,7 +66,7 @@ public sealed class VariableDeserializationException : TypedVariablesException
     /// <summary>Create a new <see cref="VariableDeserializationException"/>.</summary>
     public VariableDeserializationException(string variableName, Exception innerException)
         : base(
-            $"Variable '{variableName}' has a value that is not valid JSON and cannot be deserialized.",
+            $"Variable '{variableName}' has a value that could not be deserialized.",
             innerException)
     {
         VariableName = variableName;

--- a/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableExceptions.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableExceptions.cs
@@ -1,0 +1,97 @@
+namespace Camunda.Orchestration.Sdk;
+
+/// <summary>
+/// Base class for all errors raised by the DTO-driven typed variable map feature
+/// (<see cref="CamundaClient.SearchVariablesAsDtoAsync{T}"/>).
+/// </summary>
+public class TypedVariablesException : Exception
+{
+    /// <summary>Create a new <see cref="TypedVariablesException"/>.</summary>
+    public TypedVariablesException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Create a new <see cref="TypedVariablesException"/> with an inner cause.</summary>
+    public TypedVariablesException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Raised when a declared variable name is returned at more than one scope.
+///
+/// <para>
+/// The DTO is a flat name-to-value map, but BPMN variables are scoped (process-level
+/// vs. local element scopes). When a declared variable resolves to multiple scopes the
+/// SDK cannot deterministically choose one, so it raises rather than guessing. Pass
+/// <c>scopeKey</c> to the search call to disambiguate.
+/// </para>
+/// </summary>
+public sealed class VariableScopeCollisionException : TypedVariablesException
+{
+    /// <summary>The variable name that was found at multiple scopes.</summary>
+    public string VariableName { get; }
+
+    /// <summary>The distinct scope keys the variable was observed at, sorted ascending.</summary>
+    public IReadOnlyList<string> ScopeKeys { get; }
+
+    /// <summary>Create a new <see cref="VariableScopeCollisionException"/>.</summary>
+    public VariableScopeCollisionException(string variableName, IReadOnlyList<string> scopeKeys)
+        : base(
+            $"Variable '{variableName}' was found at multiple scopes ({string.Join(", ", scopeKeys)}). "
+            + "Pass scopeKey to the search to select a single scope.")
+    {
+        VariableName = variableName;
+        ScopeKeys = scopeKeys;
+    }
+}
+
+/// <summary>
+/// Raised when a present variable value is not parseable as JSON.
+///
+/// <para>
+/// A <em>missing</em> variable is not an error (it simply does not appear in the map);
+/// a <em>present but malformed</em> value is, and is surfaced here rather than silently
+/// dropped.
+/// </para>
+/// </summary>
+public sealed class VariableDeserializationException : TypedVariablesException
+{
+    /// <summary>The variable name whose value could not be parsed.</summary>
+    public string VariableName { get; }
+
+    /// <summary>Create a new <see cref="VariableDeserializationException"/>.</summary>
+    public VariableDeserializationException(string variableName, Exception innerException)
+        : base(
+            $"Variable '{variableName}' has a value that is not valid JSON and cannot be deserialized.",
+            innerException)
+    {
+        VariableName = variableName;
+    }
+}
+
+/// <summary>
+/// Raised by <see cref="VariableMap{T}.Validate"/> when one or more required DTO members
+/// (non-nullable members, or members marked with the <c>required</c> modifier) are absent
+/// from the search result.
+/// </summary>
+public sealed class VariableValidationException : TypedVariablesException
+{
+    /// <summary>The DTO type that failed validation.</summary>
+    public Type DtoType { get; }
+
+    /// <summary>The variable names of the required members that were missing.</summary>
+    public IReadOnlyList<string> MissingVariableNames { get; }
+
+    /// <summary>Create a new <see cref="VariableValidationException"/>.</summary>
+    public VariableValidationException(Type dtoType, IReadOnlyList<string> missingVariableNames)
+        : base(
+            $"Validation of '{dtoType.Name}' failed: required variable(s) "
+            + $"[{string.Join(", ", missingVariableNames)}] were not present in the search result.")
+    {
+        DtoType = dtoType;
+        MissingVariableNames = missingVariableNames;
+    }
+}

--- a/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableSearch.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableSearch.cs
@@ -114,7 +114,7 @@ internal static class TypedVariableSearch
     /// Parse a serialized variable value into a self-contained <see cref="JsonElement"/>.
     /// </summary>
     /// <exception cref="VariableDeserializationException">
-    /// When <paramref name="value"/> is not valid JSON.
+    /// When <paramref name="value"/> is null or not valid JSON.
     /// </exception>
     public static JsonElement ParseValue(string variableName, string value)
     {
@@ -123,7 +123,7 @@ internal static class TypedVariableSearch
             using var document = JsonDocument.Parse(value);
             return document.RootElement.Clone();
         }
-        catch (JsonException exception)
+        catch (Exception exception) when (exception is JsonException or ArgumentNullException)
         {
             throw new VariableDeserializationException(variableName, exception);
         }

--- a/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableSearch.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableSearch.cs
@@ -1,0 +1,204 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Camunda.Orchestration.Sdk;
+
+/// <summary>
+/// A single declared variable derived from a DTO member.
+/// </summary>
+/// <param name="MemberName">The CLR member (property) name on the DTO.</param>
+/// <param name="VariableName">
+/// The variable name to query for and key the result by. This is the member's
+/// <see cref="JsonPropertyNameAttribute"/> value when present, otherwise the member name
+/// transformed by the serializer's naming policy (camelCase by default).
+/// </param>
+/// <param name="Required">
+/// Whether the member is required for <see cref="VariableMap{T}.Validate"/>: <c>true</c> for
+/// non-nullable members or members marked with the <c>required</c> modifier.
+/// </param>
+internal readonly record struct TypedVariableField(string MemberName, string VariableName, bool Required);
+
+/// <summary>
+/// Pure (I/O-free) core of the DTO-driven typed variable map feature.
+///
+/// <para>
+/// Holds the reflection that derives the query from a DTO and the incremental collector that
+/// collapses paged results into a bounded per-name map. Keeping this logic free of HTTP makes
+/// the memory-bound and scope-collision behaviour directly unit-testable.
+/// </para>
+/// </summary>
+internal static class TypedVariableSearch
+{
+    /// <summary>
+    /// Derive the declared variables from a DTO type.
+    /// </summary>
+    /// <param name="dtoType">The DTO type to introspect.</param>
+    /// <param name="options">
+    /// The serializer options whose naming policy is used to resolve member names that do not
+    /// carry an explicit <see cref="JsonPropertyNameAttribute"/>. The same options are used to
+    /// deserialize the result, so the derived names bind cleanly back onto the DTO.
+    /// </param>
+    public static IReadOnlyList<TypedVariableField> ExtractFields(Type dtoType, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(dtoType);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var nullabilityContext = new NullabilityInfoContext();
+        var fields = new List<TypedVariableField>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var property in dtoType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            // Only consider readable members the serializer would round-trip.
+            if (property.GetIndexParameters().Length > 0)
+            {
+                continue;
+            }
+
+            if (property.GetCustomAttribute<JsonIgnoreAttribute>() is { Condition: JsonIgnoreCondition.Always })
+            {
+                continue;
+            }
+
+            var variableName = ResolveVariableName(property, options);
+            if (!seen.Add(variableName))
+            {
+                throw new TypedVariablesException(
+                    $"DTO '{dtoType.Name}' maps more than one member to the variable name "
+                    + $"'{variableName}'. Use [JsonPropertyName] to disambiguate.");
+            }
+
+            var required = IsRequired(property, nullabilityContext);
+            fields.Add(new TypedVariableField(property.Name, variableName, required));
+        }
+
+        return fields;
+    }
+
+    private static string ResolveVariableName(PropertyInfo property, JsonSerializerOptions options)
+    {
+        var explicitName = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name;
+        if (!string.IsNullOrEmpty(explicitName))
+        {
+            return explicitName;
+        }
+
+        return options.PropertyNamingPolicy?.ConvertName(property.Name) ?? property.Name;
+    }
+
+    private static bool IsRequired(PropertyInfo property, NullabilityInfoContext nullabilityContext)
+    {
+        // The `required` modifier is an unconditional presence contract.
+        if (property.GetCustomAttribute<RequiredMemberAttribute>() is not null)
+        {
+            return true;
+        }
+
+        var propertyType = property.PropertyType;
+        if (propertyType.IsValueType)
+        {
+            // A non-nullable value type cannot represent "absent"; Nullable<T> can.
+            return Nullable.GetUnderlyingType(propertyType) is null;
+        }
+
+        // Reference type: required only when the nullable annotation says non-nullable.
+        return nullabilityContext.Create(property).WriteState == NullabilityState.NotNull;
+    }
+
+    /// <summary>
+    /// Parse a serialized variable value into a self-contained <see cref="JsonElement"/>.
+    /// </summary>
+    /// <exception cref="VariableDeserializationException">
+    /// When <paramref name="value"/> is not valid JSON.
+    /// </exception>
+    public static JsonElement ParseValue(string variableName, string value)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            return document.RootElement.Clone();
+        }
+        catch (JsonException exception)
+        {
+            throw new VariableDeserializationException(variableName, exception);
+        }
+    }
+
+    /// <summary>
+    /// Incrementally collapses paged variable items into a parsed name-to-value map.
+    ///
+    /// <para>
+    /// Memory stays bounded by the DTO shape rather than the total number of paged items: only
+    /// the first value seen per requested name is retained, alongside the set of scope keys
+    /// observed for that name (used for collision detection). Pages are ingested as they arrive
+    /// and discarded, so large values for undeclared variables are never accumulated.
+    /// </para>
+    /// </summary>
+    public sealed class VariableCollector
+    {
+        private readonly HashSet<string> _queryNames;
+        private readonly Dictionary<string, string> _chosenValues = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, HashSet<string>> _scopesSeen = new(StringComparer.Ordinal);
+
+        /// <summary>Create a collector scoped to the declared query names.</summary>
+        public VariableCollector(IEnumerable<string> queryNames)
+        {
+            ArgumentNullException.ThrowIfNull(queryNames);
+            _queryNames = new HashSet<string>(queryNames, StringComparer.Ordinal);
+        }
+
+        /// <summary>Fold one page of results into the retained per-name state.</summary>
+        public void Ingest(IEnumerable<VariableSearchResult> items)
+        {
+            ArgumentNullException.ThrowIfNull(items);
+
+            foreach (var item in items)
+            {
+                var name = item.Name;
+                if (name is null || !_queryNames.Contains(name))
+                {
+                    continue;
+                }
+
+                if (!_scopesSeen.TryGetValue(name, out var scopes))
+                {
+                    scopes = new HashSet<string>(StringComparer.Ordinal);
+                    _scopesSeen[name] = scopes;
+                }
+
+                scopes.Add(item.ScopeKey.ToString());
+                _chosenValues.TryAdd(name, item.Value);
+            }
+        }
+
+        /// <summary>
+        /// Parse retained values, raising on scope collisions or malformed JSON.
+        /// </summary>
+        /// <exception cref="VariableScopeCollisionException">
+        /// When a name was observed at more than one scope.
+        /// </exception>
+        /// <exception cref="VariableDeserializationException">
+        /// When a retained value is not valid JSON.
+        /// </exception>
+        public IReadOnlyDictionary<string, JsonElement> Finalize()
+        {
+            var raw = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+            foreach (var (name, value) in _chosenValues)
+            {
+                var scopes = _scopesSeen[name];
+                if (scopes.Count > 1)
+                {
+                    var sorted = scopes.OrderBy(static s => s, StringComparer.Ordinal).ToList();
+                    throw new VariableScopeCollisionException(name, sorted);
+                }
+
+                raw[name] = ParseValue(name, value);
+            }
+
+            return raw;
+        }
+    }
+}

--- a/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableSearch.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableSearch.cs
@@ -104,7 +104,10 @@ internal static class TypedVariableSearch
         }
 
         // Reference type: required only when the nullable annotation says non-nullable.
-        return nullabilityContext.Create(property).WriteState == NullabilityState.NotNull;
+        // ReadState reflects the declared nullability of the value consumers read; WriteState
+        // can be Unknown for get-only members (common in immutable DTOs), which would wrongly
+        // treat a non-nullable member as optional.
+        return nullabilityContext.Create(property).ReadState == NullabilityState.NotNull;
     }
 
     /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableSearch.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableSearch.cs
@@ -185,7 +185,7 @@ internal static class TypedVariableSearch
         /// <exception cref="VariableDeserializationException">
         /// When a retained value is not valid JSON.
         /// </exception>
-        public IReadOnlyDictionary<string, JsonElement> Finalize()
+        public IReadOnlyDictionary<string, JsonElement> Build()
         {
             var raw = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
 

--- a/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableSearch.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/TypedVariableSearch.cs
@@ -57,6 +57,13 @@ internal static class TypedVariableSearch
                 continue;
             }
 
+            // Skip write-only properties (setter, no getter): they never round-trip
+            // through serialization and must not be treated as required.
+            if (!property.CanRead)
+            {
+                continue;
+            }
+
             if (property.GetCustomAttribute<JsonIgnoreAttribute>() is { Condition: JsonIgnoreCondition.Always })
             {
                 continue;

--- a/src/Camunda.Orchestration.Sdk/Runtime/VariableMap.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/VariableMap.cs
@@ -81,7 +81,7 @@ public sealed class VariableMap<T>
         var fields = TypedVariableSearch.ExtractFields(typeof(T), _options);
 
         var missing = fields
-            .Where(field => field.Required && !_raw.ContainsKey(field.VariableName))
+            .Where(field => field.Required && IsAbsent(field.VariableName))
             .Select(field => field.VariableName)
             .ToList();
 
@@ -107,5 +107,17 @@ public sealed class VariableMap<T>
 
         return result
             ?? throw new VariableValidationException(typeof(T), fields.Select(f => f.VariableName).ToList());
+    }
+
+    // A required member is satisfied only by a non-null present value. A JSON null (or an
+    // absent key) cannot honor a non-nullable DTO member, so both count as missing.
+    private bool IsAbsent(string variableName)
+    {
+        if (!_raw.TryGetValue(variableName, out var value))
+        {
+            return true;
+        }
+
+        return value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined;
     }
 }

--- a/src/Camunda.Orchestration.Sdk/Runtime/VariableMap.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/VariableMap.cs
@@ -92,8 +92,18 @@ public sealed class VariableMap<T>
 
         // Keys in `_raw` are already the resolved variable names, which match what the
         // serializer expects for binding, so a round-trip through JSON reconstructs the DTO.
-        var json = JsonSerializer.SerializeToUtf8Bytes(_raw, _options);
-        var result = JsonSerializer.Deserialize<T>(json, _options);
+        T? result;
+        try
+        {
+            var json = JsonSerializer.SerializeToUtf8Bytes(_raw, _options);
+            result = JsonSerializer.Deserialize<T>(json, _options);
+        }
+        catch (Exception exception) when (exception is JsonException or NotSupportedException)
+        {
+            throw new TypedVariablesException(
+                $"Variables could not be bound to '{typeof(T).Name}'.",
+                exception);
+        }
 
         return result
             ?? throw new VariableValidationException(typeof(T), fields.Select(f => f.VariableName).ToList());

--- a/src/Camunda.Orchestration.Sdk/Runtime/VariableMap.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/VariableMap.cs
@@ -57,7 +57,7 @@ public sealed class VariableMap<T>
         {
             return value.Deserialize<TValue>(_options);
         }
-        catch (JsonException exception)
+        catch (Exception exception) when (exception is JsonException or NotSupportedException)
         {
             throw new VariableDeserializationException(variableName, exception);
         }

--- a/src/Camunda.Orchestration.Sdk/Runtime/VariableMap.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/VariableMap.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+
+namespace Camunda.Orchestration.Sdk;
+
+/// <summary>
+/// Result of a DTO-driven variable search (<see cref="CamundaClient.SearchVariablesAsDtoAsync{T}"/>).
+///
+/// <para>
+/// Holds the parsed variable values keyed by their query name (the DTO member's
+/// <c>[JsonPropertyName]</c> value, or the member name transformed by the serializer's naming
+/// policy). Provides lenient, defensive access via <see cref="Get(string)"/> /
+/// <see cref="Get{TValue}(string)"/> and a strict <see cref="Validate"/> that constructs the
+/// declared DTO and enforces required members.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The DTO type that declared the variables to fetch.</typeparam>
+public sealed class VariableMap<T>
+    where T : class
+{
+    private readonly IReadOnlyDictionary<string, JsonElement> _raw;
+    private readonly JsonSerializerOptions _options;
+
+    internal VariableMap(IReadOnlyDictionary<string, JsonElement> raw, JsonSerializerOptions options)
+    {
+        _raw = raw;
+        _options = options;
+    }
+
+    /// <summary>The parsed variable values, keyed by variable name.</summary>
+    public IReadOnlyDictionary<string, JsonElement> Raw => _raw;
+
+    /// <summary>Whether a variable with the given name is present in the result.</summary>
+    public bool Contains(string variableName) => _raw.ContainsKey(variableName);
+
+    /// <summary>
+    /// Lenient access. Returns the parsed value as a <see cref="JsonElement"/>, or <c>null</c>
+    /// when the variable is absent from the result.
+    /// </summary>
+    public JsonElement? Get(string variableName)
+        => _raw.TryGetValue(variableName, out var value) ? value : null;
+
+    /// <summary>
+    /// Lenient, typed access. Deserializes the variable's value into <typeparamref name="TValue"/>,
+    /// or returns <c>default</c> when the variable is absent.
+    /// </summary>
+    /// <exception cref="VariableDeserializationException">
+    /// When the present value cannot be deserialized into <typeparamref name="TValue"/>.
+    /// </exception>
+    public TValue? Get<TValue>(string variableName)
+    {
+        if (!_raw.TryGetValue(variableName, out var value))
+        {
+            return default;
+        }
+
+        try
+        {
+            return value.Deserialize<TValue>(_options);
+        }
+        catch (JsonException exception)
+        {
+            throw new VariableDeserializationException(variableName, exception);
+        }
+    }
+
+    /// <summary>
+    /// Strict access. Constructs and returns the declared DTO.
+    ///
+    /// <para>
+    /// Required members (non-nullable members, or members marked with the <c>required</c>
+    /// modifier) must be present, otherwise a <see cref="VariableValidationException"/> is
+    /// thrown listing the missing variables. Optional members are left at their default when
+    /// absent.
+    /// </para>
+    /// </summary>
+    /// <exception cref="VariableValidationException">
+    /// When one or more required members are absent from the result.
+    /// </exception>
+    public T Validate()
+    {
+        var fields = TypedVariableSearch.ExtractFields(typeof(T), _options);
+
+        var missing = fields
+            .Where(field => field.Required && !_raw.ContainsKey(field.VariableName))
+            .Select(field => field.VariableName)
+            .ToList();
+
+        if (missing.Count > 0)
+        {
+            throw new VariableValidationException(typeof(T), missing);
+        }
+
+        // Keys in `_raw` are already the resolved variable names, which match what the
+        // serializer expects for binding, so a round-trip through JSON reconstructs the DTO.
+        var json = JsonSerializer.SerializeToUtf8Bytes(_raw, _options);
+        var result = JsonSerializer.Deserialize<T>(json, _options);
+
+        return result
+            ?? throw new VariableValidationException(typeof(T), fields.Select(f => f.VariableName).ToList());
+    }
+}

--- a/test/Camunda.Orchestration.Sdk.IntegrationTests/SearchVariablesAsDtoTests.cs
+++ b/test/Camunda.Orchestration.Sdk.IntegrationTests/SearchVariablesAsDtoTests.cs
@@ -1,0 +1,138 @@
+using FluentAssertions;
+
+namespace Camunda.Orchestration.Sdk.IntegrationTests;
+
+/// <summary>
+/// Integration tests for <see cref="CamundaClient.SearchVariablesAsDtoAsync{T}"/> against a live
+/// cluster.
+///
+/// <para>
+/// Mirrors the Python and TypeScript SDK coverage: a freshly-created process instance's variables
+/// are not immediately visible to the variable index (eventual consistency), so the search is
+/// polled until every declared variable becomes visible. The test process waits at an
+/// unactivated service task, keeping the instance — and its variables — alive for the duration of
+/// the search.
+/// </para>
+/// </summary>
+[Collection("Camunda")]
+[Trait("Category", "Integration")]
+public class SearchVariablesAsDtoTests(CamundaFixture fixture)
+{
+    // Variable names resolve through the client's camelCase serializer options, so the DTO member
+    // `OrderId` maps to the variable `orderId`, and `Amount` to `amount`.
+    public record OrderVars(string OrderId, decimal? Amount);
+
+    // A DTO that declares a required variable which is never set on the instance, so strict
+    // validation must fail while lenient access tolerates the absence.
+    public record StrictOrderVars(string OrderId, string CustomerId);
+
+    [Fact]
+    public async Task SearchVariablesAsDto_FindsDeclaredVariables()
+    {
+        await fixture.DeployResourceAsync("test-process.bpmn");
+
+        var createResult = await fixture.CreateProcessInstanceAsync(
+            "integration-test-process",
+            new Dictionary<string, object>
+            {
+                ["orderId"] = "ord-1",
+                ["amount"] = 42.5m,
+                // An extra variable that is not declared on the DTO and must be ignored.
+                ["internalSecret"] = "do-not-leak",
+            });
+
+        var processInstanceKey = createResult.ProcessInstanceKey;
+
+        try
+        {
+            // Variables are eventually consistent on a freshly-created instance, so poll the
+            // declared-variable search until both declared variables are visible.
+            var map = await PollUntilAsync<OrderVars>(
+                processInstanceKey,
+                result => result.Contains("orderId") && result.Contains("amount"));
+
+            map.Should().NotBeNull("both declared variables should become visible within the deadline");
+
+            map!.Contains("orderId").Should().BeTrue();
+            map.Contains("amount").Should().BeTrue();
+            map.Get<string>("orderId").Should().Be("ord-1");
+            map.Get<decimal>("amount").Should().Be(42.5m);
+
+            // Only the declared variables are queried — the extra one is never fetched.
+            map.Contains("internalSecret").Should().BeFalse();
+            map.Raw.Keys.OrderBy(k => k, StringComparer.Ordinal)
+                .Should().Equal("amount", "orderId");
+
+            // Strict access returns a fully-typed, validated DTO.
+            var order = map.Validate();
+            order.OrderId.Should().Be("ord-1");
+            order.Amount.Should().Be(42.5m);
+        }
+        finally
+        {
+            await fixture.CancelProcessInstanceAsync(processInstanceKey);
+        }
+    }
+
+    [Fact]
+    public async Task SearchVariablesAsDto_ValidateThrowsOnMissingRequired()
+    {
+        await fixture.DeployResourceAsync("test-process.bpmn");
+
+        var createResult = await fixture.CreateProcessInstanceAsync(
+            "integration-test-process",
+            new Dictionary<string, object>
+            {
+                ["orderId"] = "ord-1",
+                // `customerId` is declared on StrictOrderVars but never set on the instance.
+            });
+
+        var processInstanceKey = createResult.ProcessInstanceKey;
+
+        try
+        {
+            // Wait until the one variable that does exist becomes visible.
+            var map = await PollUntilAsync<StrictOrderVars>(
+                processInstanceKey,
+                result => result.Contains("orderId"));
+
+            map.Should().NotBeNull("the set variable should become visible within the deadline");
+
+            // The declared-but-absent variable is simply missing — lenient access never throws.
+            map!.Contains("orderId").Should().BeTrue();
+            map.Contains("customerId").Should().BeFalse();
+
+            // Strict validation fails because a required variable is missing.
+            map.Invoking(m => m.Validate())
+                .Should().Throw<VariableValidationException>();
+        }
+        finally
+        {
+            await fixture.CancelProcessInstanceAsync(processInstanceKey);
+        }
+    }
+
+    /// <summary>
+    /// Polls <see cref="CamundaClient.SearchVariablesAsDtoAsync{T}"/> until <paramref name="isReady"/>
+    /// is satisfied or the deadline elapses, returning the last result (or <c>null</c> if the
+    /// predicate was never satisfied).
+    /// </summary>
+    private async Task<VariableMap<T>?> PollUntilAsync<T>(
+        ProcessInstanceKey processInstanceKey,
+        Func<VariableMap<T>, bool> isReady)
+        where T : class
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        VariableMap<T>? last = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            last = await fixture.Client.SearchVariablesAsDtoAsync<T>(processInstanceKey);
+            if (isReady(last))
+                return last;
+
+            await Task.Delay(500);
+        }
+
+        return isReady(last!) ? last : null;
+    }
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -1473,6 +1473,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UserTaskResult> GetUserTaskAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.UserTaskResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UserTaskSearchQueryResult> SearchUserTasksAsync(Camunda.Orchestration.Sdk.UserTaskSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.UserTaskSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.UserUpdateResult> UpdateUserAsync(Camunda.Orchestration.Sdk.Username username, Camunda.Orchestration.Sdk.UserUpdateRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableMap<T>> SearchVariablesAsDtoAsync<T>(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ScopeKey? scopeKey = null, Camunda.Orchestration.Sdk.TenantId? tenantId = null, System.Int32 pageSize = 100, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableResult> GetVariableAsync(Camunda.Orchestration.Sdk.VariableKey variableKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchUserTaskEffectiveVariablesAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskEffectiveVariableSearchQueryRequest body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.VariableSearchQueryResult> SearchUserTaskVariablesAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskVariableSearchQueryRequest body, System.Boolean? truncateValues = null, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.VariableSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -5291,6 +5292,10 @@ TYPE Camunda.Orchestration.Sdk.TopologyResponse : sealed class
 TYPE Camunda.Orchestration.Sdk.TypedVariables : static class
   METHOD static T? DeserializeAs<T>(System.Object? payload, System.Text.Json.JsonSerializerOptions? options = null)
 
+TYPE Camunda.Orchestration.Sdk.TypedVariablesException : class base=System.Exception interfaces=[System.Runtime.Serialization.ISerializable]
+  CTOR (System.String message)
+  CTOR (System.String message, System.Exception innerException)
+
 TYPE Camunda.Orchestration.Sdk.UpdateClusterVariableRequest : sealed class
   CTOR ()
   PROP System.Object Value { get; set; } [JsonPropertyName("value")]
@@ -5591,6 +5596,10 @@ TYPE Camunda.Orchestration.Sdk.ValidationMode : enum interfaces=[System.ICompara
   MEMBER Strict = 2
   MEMBER Fanatical = 3
 
+TYPE Camunda.Orchestration.Sdk.VariableDeserializationException : sealed class base=Camunda.Orchestration.Sdk.TypedVariablesException interfaces=[System.Runtime.Serialization.ISerializable]
+  CTOR (System.String variableName, System.Exception innerException)
+  PROP System.String VariableName { get; }
+
 TYPE Camunda.Orchestration.Sdk.VariableFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
@@ -5627,6 +5636,13 @@ TYPE Camunda.Orchestration.Sdk.VariableKeyFilterProperty : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableKey>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
+TYPE Camunda.Orchestration.Sdk.VariableMap<T> : sealed class
+  PROP System.Collections.Generic.IReadOnlyDictionary<System.String,System.Text.Json.JsonElement> Raw { get; }
+  METHOD System.Boolean Contains(System.String variableName)
+  METHOD System.Text.Json.JsonElement? Get(System.String variableName)
+  METHOD T Validate()
+  METHOD TValue? Get<TValue>(System.String variableName)
+
 TYPE Camunda.Orchestration.Sdk.VariableResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
@@ -5645,6 +5661,11 @@ TYPE Camunda.Orchestration.Sdk.VariableResultBase : sealed class
   PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP Camunda.Orchestration.Sdk.VariableKey VariableKey { get; set; } [JsonPropertyName("variableKey")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
+
+TYPE Camunda.Orchestration.Sdk.VariableScopeCollisionException : sealed class base=Camunda.Orchestration.Sdk.TypedVariablesException interfaces=[System.Runtime.Serialization.ISerializable]
+  CTOR (System.String variableName, System.Collections.Generic.IReadOnlyList<System.String> scopeKeys)
+  PROP System.Collections.Generic.IReadOnlyList<System.String> ScopeKeys { get; }
+  PROP System.String VariableName { get; }
 
 TYPE Camunda.Orchestration.Sdk.VariableSearchQuery : sealed class
   CTOR ()
@@ -5682,6 +5703,11 @@ TYPE Camunda.Orchestration.Sdk.VariableSearchResult : sealed class
   PROP System.Boolean IsTruncated { get; set; } [JsonPropertyName("isTruncated")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
   PROP System.String Value { get; set; } [JsonPropertyName("value")]
+
+TYPE Camunda.Orchestration.Sdk.VariableValidationException : sealed class base=Camunda.Orchestration.Sdk.TypedVariablesException interfaces=[System.Runtime.Serialization.ISerializable]
+  CTOR (System.Type dtoType, System.Collections.Generic.IReadOnlyList<System.String> missingVariableNames)
+  PROP System.Collections.Generic.IReadOnlyList<System.String> MissingVariableNames { get; }
+  PROP System.Type DtoType { get; }
 
 TYPE Camunda.Orchestration.Sdk.VariableValueFilterProperty : sealed class
   CTOR ()

--- a/test/Camunda.Orchestration.Sdk.Tests/SearchVariablesAsDtoTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/SearchVariablesAsDtoTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// End-to-end tests for <see cref="CamundaClient.SearchVariablesAsDtoAsync{T}"/>, exercising the
+/// paging loop and request shape against a faked HTTP transport.
+/// </summary>
+public class SearchVariablesAsDtoTests : IDisposable
+{
+    private readonly MockHttpMessageHandler _handler;
+    private readonly CamundaClient _client;
+
+    private static readonly JsonSerializerOptions s_payloadOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public SearchVariablesAsDtoTests()
+    {
+        _handler = new MockHttpMessageHandler();
+        _client = new CamundaClient(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            },
+            HttpMessageHandler = _handler,
+        });
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    public record OrderVars(string OrderId, decimal? Amount);
+
+    [Fact]
+    public async Task SearchVariablesAsDto_CollapsesAcrossPages()
+    {
+        EnqueuePage(items: [("orderId", "\"ord-1\"", "100")], endCursor: "Y3Vyc29yMQ==");
+        EnqueuePage(items: [("amount", "42.5", "100")], endCursor: null);
+
+        var map = await _client.SearchVariablesAsDtoAsync<OrderVars>(
+            ProcessInstanceKey.AssumeExists("100"));
+
+        var dto = map.Validate();
+        Assert.Equal("ord-1", dto.OrderId);
+        Assert.Equal(42.5m, dto.Amount);
+    }
+
+    [Fact]
+    public async Task SearchVariablesAsDto_SendsNameInFilter()
+    {
+        string? capturedBody = null;
+        _handler.Enqueue(async request =>
+        {
+            capturedBody = await request.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    PageJson(items: [("orderId", "\"ord-1\"", "100")], endCursor: null),
+                    System.Text.Encoding.UTF8,
+                    "application/json"),
+            };
+        });
+
+        await _client.SearchVariablesAsDtoAsync<OrderVars>(ProcessInstanceKey.AssumeExists("100"));
+
+        using var doc = JsonDocument.Parse(capturedBody!);
+
+        var inValues = doc.RootElement
+            .GetProperty("filter").GetProperty("name").GetProperty("$in")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Equal(["orderId", "amount"], inValues);
+
+        var processInstanceKey = doc.RootElement
+            .GetProperty("filter").GetProperty("processInstanceKey").GetProperty("$eq").GetString();
+        Assert.Equal("100", processInstanceKey);
+    }
+
+    [Fact]
+    public async Task SearchVariablesAsDto_StopsWhenCursorRepeats()
+    {
+        // A server that keeps returning the same cursor must not loop forever.
+        EnqueuePage(items: [("orderId", "\"ord-1\"", "100")], endCursor: "c2FtZQ==");
+        EnqueuePage(items: [("orderId", "\"ord-1\"", "100")], endCursor: "c2FtZQ==");
+
+        var map = await _client.SearchVariablesAsDtoAsync<OrderVars>(
+            ProcessInstanceKey.AssumeExists("100"));
+
+        Assert.Equal("ord-1", map.Validate().OrderId);
+        Assert.Equal(2, _handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task SearchVariablesAsDto_ScopeCollisionThrows()
+    {
+        EnqueuePage(
+            items: [("orderId", "\"a\"", "100"), ("orderId", "\"b\"", "200")],
+            endCursor: null);
+
+        await Assert.ThrowsAsync<VariableScopeCollisionException>(() =>
+            _client.SearchVariablesAsDtoAsync<OrderVars>(ProcessInstanceKey.AssumeExists("100")));
+    }
+
+    [Fact]
+    public async Task SearchVariablesAsDto_InvalidPageSizeThrows()
+    {
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            _client.SearchVariablesAsDtoAsync<OrderVars>(
+                ProcessInstanceKey.AssumeExists("100"),
+                pageSize: 0));
+    }
+
+    private void EnqueuePage(
+        (string Name, string Value, string ScopeKey)[] items,
+        string? endCursor)
+    {
+        _handler.Enqueue(HttpStatusCode.OK, PageJson(items, endCursor));
+    }
+
+    private static string PageJson(
+        (string Name, string Value, string ScopeKey)[] items,
+        string? endCursor)
+    {
+        var payload = new
+        {
+            items = items.Select(i => new
+            {
+                value = i.Value,
+                name = i.Name,
+                tenantId = "<default>",
+                variableKey = "1",
+                scopeKey = i.ScopeKey,
+                processInstanceKey = "100",
+                isTruncated = false,
+            }).ToArray(),
+            page = new
+            {
+                totalItems = items.Length,
+                hasMoreTotalItems = false,
+                endCursor,
+            },
+        };
+
+        return JsonSerializer.Serialize(payload, s_payloadOptions);
+    }
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/SearchVariablesAsDtoTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/SearchVariablesAsDtoTests.cs
@@ -75,8 +75,9 @@ public class SearchVariablesAsDtoTests : IDisposable
 
         var inValues = doc.RootElement
             .GetProperty("filter").GetProperty("name").GetProperty("$in")
-            .EnumerateArray().Select(e => e.GetString()!).ToArray();
-        Assert.Equal(["orderId", "amount"], inValues);
+            .EnumerateArray().Select(e => e.GetString()!)
+            .OrderBy(n => n, StringComparer.Ordinal).ToArray();
+        Assert.Equal(["amount", "orderId"], inValues);
 
         var processInstanceKey = doc.RootElement
             .GetProperty("filter").GetProperty("processInstanceKey").GetProperty("$eq").GetString();

--- a/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
@@ -35,7 +35,9 @@ public class TypedVariableSearchTests
     {
         var fields = TypedVariableSearch.ExtractFields(typeof(OrderVars), s_options);
 
-        Assert.Equal(["orderId", "amount"], fields.Select(f => f.VariableName).ToArray());
+        Assert.Equal(
+            ["amount", "orderId"],
+            fields.Select(f => f.VariableName).OrderBy(n => n, StringComparer.Ordinal).ToArray());
     }
 
     [Fact]
@@ -95,7 +97,7 @@ public class TypedVariableSearchTests
             Result("undeclared", "\"junk\"", "100"),
         });
 
-        var raw = collector.Finalize();
+        var raw = collector.Build();
 
         Assert.True(raw.ContainsKey("orderId"));
         Assert.False(raw.ContainsKey("undeclared"));
@@ -108,7 +110,7 @@ public class TypedVariableSearchTests
         collector.Ingest(new[] { Result("orderId", "\"first\"", "100") });
         collector.Ingest(new[] { Result("orderId", "\"second\"", "100") });
 
-        var raw = collector.Finalize();
+        var raw = collector.Build();
 
         Assert.Equal("first", raw["orderId"].GetString());
     }
@@ -123,7 +125,7 @@ public class TypedVariableSearchTests
             Result("orderId", "\"b\"", "200"),
         });
 
-        var ex = Assert.Throws<VariableScopeCollisionException>(() => collector.Finalize());
+        var ex = Assert.Throws<VariableScopeCollisionException>(() => collector.Build());
         Assert.Equal("orderId", ex.VariableName);
         Assert.Equal(["100", "200"], ex.ScopeKeys.ToArray());
     }
@@ -134,7 +136,7 @@ public class TypedVariableSearchTests
         var collector = new TypedVariableSearch.VariableCollector(s_orderIdOnly);
         collector.Ingest(new[] { Result("orderId", "not-json", "100") });
 
-        var ex = Assert.Throws<VariableDeserializationException>(() => collector.Finalize());
+        var ex = Assert.Throws<VariableDeserializationException>(() => collector.Build());
         Assert.Equal("orderId", ex.VariableName);
     }
 
@@ -145,7 +147,7 @@ public class TypedVariableSearchTests
         collector.Ingest(new[] { Result("orderId", "\"a\"", "100") });
         collector.Ingest(new[] { Result("orderId", "\"a\"", "100") });
 
-        var raw = collector.Finalize();
+        var raw = collector.Build();
 
         Assert.Equal("a", raw["orderId"].GetString());
     }

--- a/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
@@ -208,9 +208,15 @@ public class TypedVariableSearchTests
     {
         var raw = entries.ToDictionary(
             e => e.Name,
-            e => JsonDocument.Parse(e.Json).RootElement.Clone(),
+            e => CloneJson(e.Json),
             StringComparer.Ordinal);
         return new VariableMap<OrderVars>(raw, s_options);
+    }
+
+    private static JsonElement CloneJson(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
     }
 
     private static VariableSearchResult Result(string name, string value, string scopeKey) => new()

--- a/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
@@ -141,6 +141,16 @@ public class TypedVariableSearchTests
     }
 
     [Fact]
+    public void Collector_NullValue_ThrowsVariableDeserialization()
+    {
+        var collector = new TypedVariableSearch.VariableCollector(s_orderIdOnly);
+        collector.Ingest(new[] { Result("orderId", null!, "100") });
+
+        var ex = Assert.Throws<VariableDeserializationException>(() => collector.Build());
+        Assert.Equal("orderId", ex.VariableName);
+    }
+
+    [Fact]
     public void Collector_SameNameSameScopeAcrossPages_IsNotACollision()
     {
         var collector = new TypedVariableSearch.VariableCollector(s_orderIdOnly);

--- a/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
@@ -214,6 +214,16 @@ public class TypedVariableSearchTests
         Assert.Contains("orderId", ex.MissingVariableNames);
     }
 
+    [Fact]
+    public void VariableMap_Validate_UndeserializableValueThrowsTypedVariables()
+    {
+        // amount is present but its JSON value cannot bind to decimal.
+        var map = MapOf(("orderId", "\"ord-1\""), ("amount", "\"not-a-number\""));
+
+        var ex = Assert.Throws<TypedVariablesException>(() => map.Validate());
+        Assert.NotNull(ex.InnerException);
+    }
+
     // ---- helpers ----
 
     private static VariableMap<OrderVars> MapOf(params (string Name, string Json)[] entries)

--- a/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
@@ -1,0 +1,225 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Unit tests for the pure (I/O-free) core of the DTO-driven typed variable map feature:
+/// DTO field extraction, the incremental collector, value parsing, and <see cref="VariableMap{T}"/>.
+/// </summary>
+public class TypedVariableSearchTests
+{
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static readonly string[] s_orderIdOnly = ["orderId"];
+
+    // ---- Sample DTOs ----
+
+    public record OrderVars(string OrderId, decimal? Amount);
+
+    public record AliasedVars([property: JsonPropertyName("order_id")] string OrderId);
+
+    public record AllOptional(string? Note, int? Count);
+
+    public record RequiredValueType(int Quantity, string? Label);
+
+    // ---- ExtractFields: naming ----
+
+    [Fact]
+    public void ExtractFields_AppliesCamelCaseNamingPolicy()
+    {
+        var fields = TypedVariableSearch.ExtractFields(typeof(OrderVars), s_options);
+
+        Assert.Equal(["orderId", "amount"], fields.Select(f => f.VariableName).ToArray());
+    }
+
+    [Fact]
+    public void ExtractFields_HonorsJsonPropertyName()
+    {
+        var fields = TypedVariableSearch.ExtractFields(typeof(AliasedVars), s_options);
+
+        Assert.Equal("order_id", Assert.Single(fields).VariableName);
+    }
+
+    // ---- ExtractFields: required detection (nullability-driven) ----
+
+    [Fact]
+    public void ExtractFields_NonNullableReferenceIsRequired()
+    {
+        var fields = TypedVariableSearch.ExtractFields(typeof(OrderVars), s_options);
+
+        var orderId = fields.Single(f => f.VariableName == "orderId");
+        Assert.True(orderId.Required);
+    }
+
+    [Fact]
+    public void ExtractFields_NullableMemberIsOptional()
+    {
+        var fields = TypedVariableSearch.ExtractFields(typeof(OrderVars), s_options);
+
+        var amount = fields.Single(f => f.VariableName == "amount");
+        Assert.False(amount.Required);
+    }
+
+    [Fact]
+    public void ExtractFields_NonNullableValueTypeIsRequired()
+    {
+        var fields = TypedVariableSearch.ExtractFields(typeof(RequiredValueType), s_options);
+
+        Assert.True(fields.Single(f => f.VariableName == "quantity").Required);
+        Assert.False(fields.Single(f => f.VariableName == "label").Required);
+    }
+
+    [Fact]
+    public void ExtractFields_AllOptionalDtoHasNoRequiredFields()
+    {
+        var fields = TypedVariableSearch.ExtractFields(typeof(AllOptional), s_options);
+
+        Assert.All(fields, f => Assert.False(f.Required));
+    }
+
+    // ---- VariableCollector: incremental folding ----
+
+    [Fact]
+    public void Collector_RetainsOnlyDeclaredNames()
+    {
+        var collector = new TypedVariableSearch.VariableCollector(s_orderIdOnly);
+        collector.Ingest(new[]
+        {
+            Result("orderId", "\"ord-1\"", "100"),
+            Result("undeclared", "\"junk\"", "100"),
+        });
+
+        var raw = collector.Finalize();
+
+        Assert.True(raw.ContainsKey("orderId"));
+        Assert.False(raw.ContainsKey("undeclared"));
+    }
+
+    [Fact]
+    public void Collector_FirstValuePerNameWins_AcrossPages()
+    {
+        var collector = new TypedVariableSearch.VariableCollector(s_orderIdOnly);
+        collector.Ingest(new[] { Result("orderId", "\"first\"", "100") });
+        collector.Ingest(new[] { Result("orderId", "\"second\"", "100") });
+
+        var raw = collector.Finalize();
+
+        Assert.Equal("first", raw["orderId"].GetString());
+    }
+
+    [Fact]
+    public void Collector_SameNameAtMultipleScopes_Throws()
+    {
+        var collector = new TypedVariableSearch.VariableCollector(s_orderIdOnly);
+        collector.Ingest(new[]
+        {
+            Result("orderId", "\"a\"", "100"),
+            Result("orderId", "\"b\"", "200"),
+        });
+
+        var ex = Assert.Throws<VariableScopeCollisionException>(() => collector.Finalize());
+        Assert.Equal("orderId", ex.VariableName);
+        Assert.Equal(["100", "200"], ex.ScopeKeys.ToArray());
+    }
+
+    [Fact]
+    public void Collector_MalformedJsonValue_Throws()
+    {
+        var collector = new TypedVariableSearch.VariableCollector(s_orderIdOnly);
+        collector.Ingest(new[] { Result("orderId", "not-json", "100") });
+
+        var ex = Assert.Throws<VariableDeserializationException>(() => collector.Finalize());
+        Assert.Equal("orderId", ex.VariableName);
+    }
+
+    [Fact]
+    public void Collector_SameNameSameScopeAcrossPages_IsNotACollision()
+    {
+        var collector = new TypedVariableSearch.VariableCollector(s_orderIdOnly);
+        collector.Ingest(new[] { Result("orderId", "\"a\"", "100") });
+        collector.Ingest(new[] { Result("orderId", "\"a\"", "100") });
+
+        var raw = collector.Finalize();
+
+        Assert.Equal("a", raw["orderId"].GetString());
+    }
+
+    // ---- VariableMap: lenient + strict access ----
+
+    [Fact]
+    public void VariableMap_Get_ReturnsNullForAbsentVariable()
+    {
+        var map = MapOf(("orderId", "\"ord-1\""));
+
+        Assert.Null(map.Get("missing"));
+        Assert.NotNull(map.Get("orderId"));
+    }
+
+    [Fact]
+    public void VariableMap_GetTyped_DeserializesPresentValue()
+    {
+        var map = MapOf(("amount", "9.99"));
+
+        Assert.Equal(9.99m, map.Get<decimal>("amount"));
+        Assert.Equal(default, map.Get<decimal>("missing"));
+    }
+
+    [Fact]
+    public void VariableMap_Validate_ConstructsDtoWhenRequiredPresent()
+    {
+        var map = MapOf(("orderId", "\"ord-1\""), ("amount", "9.99"));
+
+        var dto = map.Validate();
+
+        Assert.Equal("ord-1", dto.OrderId);
+        Assert.Equal(9.99m, dto.Amount);
+    }
+
+    [Fact]
+    public void VariableMap_Validate_OptionalAbsentIsAllowed()
+    {
+        var map = MapOf(("orderId", "\"ord-1\""));
+
+        var dto = map.Validate();
+
+        Assert.Equal("ord-1", dto.OrderId);
+        Assert.Null(dto.Amount);
+    }
+
+    [Fact]
+    public void VariableMap_Validate_MissingRequiredThrows()
+    {
+        var map = MapOf(("amount", "9.99"));
+
+        var ex = Assert.Throws<VariableValidationException>(() => map.Validate());
+        Assert.Equal(typeof(OrderVars), ex.DtoType);
+        Assert.Contains("orderId", ex.MissingVariableNames);
+    }
+
+    // ---- helpers ----
+
+    private static VariableMap<OrderVars> MapOf(params (string Name, string Json)[] entries)
+    {
+        var raw = entries.ToDictionary(
+            e => e.Name,
+            e => JsonDocument.Parse(e.Json).RootElement.Clone(),
+            StringComparer.Ordinal);
+        return new VariableMap<OrderVars>(raw, s_options);
+    }
+
+    private static VariableSearchResult Result(string name, string value, string scopeKey) => new()
+    {
+        Name = name,
+        Value = value,
+        ScopeKey = ScopeKey.AssumeExists(scopeKey),
+        VariableKey = VariableKey.AssumeExists("1"),
+        ProcessInstanceKey = ProcessInstanceKey.AssumeExists("999"),
+        TenantId = TenantId.AssumeExists("<default>"),
+    };
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
@@ -239,6 +239,18 @@ public class TypedVariableSearchTests
     }
 
     [Fact]
+    public void VariableMap_Validate_RequiredPresentButNullIsMissing()
+    {
+        // orderId is present but carries a JSON null, which cannot honor the
+        // non-nullable DTO member, so it must be reported as missing.
+        var map = MapOf(("orderId", "null"), ("amount", "9.99"));
+
+        var ex = Assert.Throws<VariableValidationException>(() => map.Validate());
+        Assert.Equal(typeof(OrderVars), ex.DtoType);
+        Assert.Contains("orderId", ex.MissingVariableNames);
+    }
+
+    [Fact]
     public void VariableMap_Validate_UndeserializableValueThrowsTypedVariables()
     {
         // amount is present but its JSON value cannot bind to decimal.

--- a/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/TypedVariableSearchTests.cs
@@ -28,6 +28,20 @@ public class TypedVariableSearchTests
 
     public record RequiredValueType(int Quantity, string? Label);
 
+    public class WriteOnlyVars
+    {
+        private string _secret = string.Empty;
+
+        public string OrderId { get; set; } = string.Empty;
+
+        // Write-only: setter, no getter. Must be skipped by ExtractFields.
+        public string Secret
+        {
+            set => _secret = value;
+        }
+    }
+
+
     // ---- ExtractFields: naming ----
 
     [Fact]
@@ -83,6 +97,16 @@ public class TypedVariableSearchTests
         var fields = TypedVariableSearch.ExtractFields(typeof(AllOptional), s_options);
 
         Assert.All(fields, f => Assert.False(f.Required));
+    }
+
+    [Fact]
+    public void ExtractFields_SkipsWriteOnlyProperties()
+    {
+        var fields = TypedVariableSearch.ExtractFields(typeof(WriteOnlyVars), s_options);
+
+        // Only the readable property is derived; the write-only member is ignored
+        // and must not be treated as a required variable.
+        Assert.Equal("orderId", Assert.Single(fields).VariableName);
     }
 
     // ---- VariableCollector: incremental folding ----


### PR DESCRIPTION
## What

Adds `SearchVariablesAsDtoAsync<T>()` — an ergonomic client helper that searches a process instance for exactly the variables declared on a DTO, pages through all results, and collapses them into a strongly-typed `VariableMap<T>`.

This ports the Python SDK's typed-variable-map feature (camunda/orchestration-cluster-api-python#144) to the C# SDK, following the flat client-method shape used across the other SDKs.

## Why

Reading process variables today returns an untyped, paginated, per-scope result. Callers must page manually, de-duplicate across scopes, and hand-bind JSON. This helper does all three and gives back a typed object whose field names are guaranteed to line up with the wire variable names.

## How it works

- **Naming consistency by construction**: variable names are derived from the *same* `JsonSerializerOptions` used to deserialize. Property `OrderId` → variable `orderId` (camelCase) by default, overridable with `[JsonPropertyName]`. The search `$in` filter, the raw map keys, and `System.Text.Json` binding therefore always agree.
- **Paging**: loops with cursor pagination until the cursor is null, a page is empty, or the cursor repeats (infinite-loop guard).
- **Scope collisions fail loudly**: if a variable name is seen at more than one scope, it throws `VariableScopeCollisionException` rather than guessing. Narrow with the optional `scopeKey` parameter.
- **Validation**: `VariableMap<T>.Validate()` enforces that every non-nullable DTO member is present (via `NullabilityInfoContext` + `required` modifier reflection — no new dependency), throwing `VariableValidationException` listing all missing members. Nullable members are optional.
- **Lazy access**: `Contains(name)`, `Get(name)`, and `Get<TValue>(name)` read individual values without materializing the whole DTO.

## Public API surface

New public types (baseline refreshed in `PublicApi.shipped.txt`):

- `CamundaClient.SearchVariablesAsDtoAsync<T>(...)`
- `VariableMap<T>`
- `TypedVariablesException` (base) + `VariableScopeCollisionException`, `VariableDeserializationException`, `VariableValidationException`

## Tests

- **`TypedVariableSearchTests`** — pure (I/O-free) core: camelCase naming, `[JsonPropertyName]` honored, required-member detection, collector retention / first-value-wins / scope collision / malformed JSON, and `VariableMap` `Get`/`Get<T>`/`Validate`.
- **`SearchVariablesAsDtoTests`** — end-to-end paging via the mock HTTP handler: cross-page collapse, the `$in` filter shape, cursor-repeat termination, scope-collision propagation, and page-size validation.

Full suite green locally: **1017 passed, 0 failed**.

## Docs

- README "Typed Variables with DTOs" gains a **Searching Variables as a DTO** subsection, injected from the compilable `docs/examples/ReadmeExamples.cs` region (sync gate passes).

## Notes for reviewers

- No generated code is touched — this is entirely hand-written runtime + tests, so the generator/output split-commit rule does not apply.
- `operation-map.json` is intentionally left unchanged: `searchVariables` already has example coverage, and this helper is an opinionated wrapper documented in the typed-variables README section.
