### PR TITLE
fix(deps): bump camunda-schema-bundler to 2.4.3

### DIFF
--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -239,6 +239,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.CreateAgentInstanceHistoryItemAsync(Camunda.Orchestration.Sdk.AgentInstanceKey,Camunda.Orchestration.Sdk.AgentInstanceHistoryItemRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/AgentInstance.cs#CreateAgentInstanceHistoryItem)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.CreateAuthorizationAsync(Camunda.Orchestration.Sdk.AuthorizationRequest,System.Threading.CancellationToken)
 example:
 - *content
@@ -1290,6 +1300,16 @@ example:
 
 
 [!code-csharp[](../../examples/AgentInstance.cs#SearchAgentInstances)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.SearchAgentInstanceHistoryAsync(Camunda.Orchestration.Sdk.AgentInstanceKey,Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQuery,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQueryResult},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/AgentInstance.cs#SearchAgentInstanceHistory)]
 
 
 ---

--- a/examples/AgentInstance.cs
+++ b/examples/AgentInstance.cs
@@ -81,4 +81,65 @@ public static class AgentInstanceExamples
     }
     // </UpdateAgentInstance>
     #endregion UpdateAgentInstance
+
+    #region CreateAgentInstanceHistoryItem
+
+    // <CreateAgentInstanceHistoryItem>
+    public static async Task CreateAgentInstanceHistoryItemExample(
+        AgentInstanceKey agentInstanceKey,
+        ElementInstanceKey elementInstanceKey,
+        JobKey jobKey,
+        string jobLease)
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.CreateAgentInstanceHistoryItemAsync(
+            agentInstanceKey,
+            new AgentInstanceHistoryItemRequest
+            {
+                ElementInstanceKey = elementInstanceKey,
+                JobKey = jobKey,
+                JobLease = jobLease,
+                Role = AgentInstanceHistoryRoleEnum.ASSISTANT,
+                Content = new List<AgentInstanceMessageContent>
+                {
+                    new AgentInstanceTextContent { Text = "How can I help you today?" },
+                },
+                ProducedAt = DateTimeOffset.UtcNow,
+            });
+
+        Console.WriteLine($"Created history item: {result.HistoryItemKey}");
+    }
+    // </CreateAgentInstanceHistoryItem>
+    #endregion CreateAgentInstanceHistoryItem
+
+    #region SearchAgentInstanceHistory
+
+    // <SearchAgentInstanceHistory>
+    public static async Task SearchAgentInstanceHistoryExample(AgentInstanceKey agentInstanceKey)
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.SearchAgentInstanceHistoryAsync(
+            agentInstanceKey,
+            new AgentInstanceHistorySearchQuery
+            {
+                Sort = new List<AgentInstanceHistorySearchQuerySortRequest>
+                {
+                    new AgentInstanceHistorySearchQuerySortRequest
+                    {
+                        Field = AgentInstanceHistorySearchQuerySortRequestField.ProducedAt,
+                        Order = SortOrderEnum.ASC,
+                    },
+                },
+                Page = new LimitPagination { Limit = 20 },
+            });
+
+        foreach (var item in result.Items)
+        {
+            Console.WriteLine($"{item.HistoryItemKey} ({item.Role})");
+        }
+    }
+    // </SearchAgentInstanceHistory>
+    #endregion SearchAgentInstanceHistory
 }

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -27,6 +27,20 @@
       "label": "Update an agent instance"
     }
   ],
+  "createAgentInstanceHistoryItem": [
+    {
+      "file": "AgentInstance.cs",
+      "region": "CreateAgentInstanceHistoryItem",
+      "label": "Append an agent instance history item"
+    }
+  ],
+  "searchAgentInstanceHistory": [
+    {
+      "file": "AgentInstance.cs",
+      "region": "SearchAgentInstanceHistory",
+      "label": "Search agent instance history"
+    }
+  ],
   "getTopology": [
     {
       "file": "Client.cs",

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -559,6 +559,246 @@
         "x-added-in-version": "8.10"
       }
     },
+    "/agent-instances/{agentInstanceKey}/history": {
+      "post": {
+        "x-eventually-consistent": false,
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "tags": [
+          "Agent instance"
+        ],
+        "operationId": "createAgentInstanceHistoryItem",
+        "summary": "Create agent instance history item",
+        "description": "Appends a single history item to an agent instance's conversation history.\nThe created item has commitStatus PENDING until the job identified by jobLease\ncompletes successfully, at which point it transitions to COMMITTED. If the job\nfails or is superseded by a retry, the item is marked DISCARDED.\n",
+        "x-semantic-establishes": {
+          "kind": "AgentInstanceIteration",
+          "identifiedBy": [
+            {
+              "in": "body",
+              "name": "iteration",
+              "semanticType": "IterationId"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "agentInstanceKey",
+            "in": "path",
+            "required": true,
+            "description": "The key of the agent instance to append the history item to.",
+            "schema": {
+              "$ref": "#/components/schemas/AgentInstanceKey"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstanceHistoryItemRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The history item was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstanceHistoryItemCreationResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The agent instance with the given key was not found, or the specified\njobKey does not correspond to an active job.\nMore details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
+    "/agent-instances/{agentInstanceKey}/history/search": {
+      "post": {
+        "x-eventually-consistent": true,
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "tags": [
+          "Agent instance"
+        ],
+        "operationId": "searchAgentInstanceHistory",
+        "summary": "Search agent instance history",
+        "description": "Searches the conversation history of an agent instance. Committed items\nare returned by default.\n",
+        "parameters": [
+          {
+            "name": "agentInstanceKey",
+            "in": "path",
+            "required": true,
+            "description": "The key of the agent instance whose history to search.",
+            "schema": {
+              "$ref": "#/components/schemas/AgentInstanceKey"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstanceHistorySearchQuery"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The agent instance history search result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstanceHistorySearchQueryResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The agent instance with the given key was not found.\nMore details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/audit-logs/search": {
       "post": {
         "x-eventually-consistent": true,
@@ -18747,10 +18987,16 @@
             "description": "The field to sort by.",
             "type": "string",
             "enum": [
+              "agentInstanceKey",
+              "status",
+              "elementId",
+              "processInstanceKey",
+              "rootProcessInstanceKey",
+              "processDefinitionKey",
+              "tenantId",
               "creationDate",
               "lastUpdatedDate",
-              "completionDate",
-              "status"
+              "completionDate"
             ]
           },
           "order": {
@@ -18815,6 +19061,14 @@
           },
           "processInstanceKey": {
             "description": "The key of the process instance that owns this agent instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessInstanceKeyFilterProperty"
+              }
+            ]
+          },
+          "rootProcessInstanceKey": {
+            "description": "The key of the root process instance. Filters agent instances belonging to a specific\ncall hierarchy. The root process instance is the top-level ancestor in the process\ninstance hierarchy.\n",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ProcessInstanceKeyFilterProperty"
@@ -18923,23 +19177,23 @@
         "type": "object",
         "required": [
           "agentInstanceKey",
-          "status",
+          "completionDate",
+          "creationDate",
           "definition",
-          "metrics",
-          "limits",
-          "tools",
           "elementId",
-          "processInstanceKey",
-          "rootProcessInstanceKey",
-          "processDefinitionKey",
+          "elementInstanceKeys",
+          "lastUpdatedDate",
+          "limits",
+          "metrics",
           "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionVersion",
           "processDefinitionVersionTag",
+          "processInstanceKey",
+          "rootProcessInstanceKey",
+          "status",
           "tenantId",
-          "creationDate",
-          "lastUpdatedDate",
-          "completionDate",
-          "elementInstanceKeys"
+          "tools"
         ],
         "properties": {
           "agentInstanceKey": {
@@ -19098,9 +19352,9 @@
         "description": "A tool available to the agent.",
         "type": "object",
         "required": [
-          "name",
           "description",
-          "elementId"
+          "elementId",
+          "name"
         ],
         "properties": {
           "name": {
@@ -19124,8 +19378,8 @@
         "type": "object",
         "required": [
           "inputTokens",
-          "outputTokens",
           "modelCalls",
+          "outputTokens",
           "toolCalls"
         ],
         "properties": {
@@ -19204,8 +19458,8 @@
         "description": "Request to create a new agent instance.",
         "type": "object",
         "required": [
-          "elementInstanceKey",
-          "definition"
+          "definition",
+          "elementInstanceKey"
         ],
         "properties": {
           "elementInstanceKey": {
@@ -19374,41 +19628,645 @@
           }
         }
       },
+      "AgentInstanceHistoryItemRequest": {
+        "description": "Request to append a single history item to an agent instance's conversation history.",
+        "type": "object",
+        "required": [
+          "content",
+          "elementInstanceKey",
+          "jobKey",
+          "jobLease",
+          "producedAt",
+          "role"
+        ],
+        "properties": {
+          "elementInstanceKey": {
+            "description": "The key of the currently-active element instance.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementInstanceKey"
+              }
+            ]
+          },
+          "jobKey": {
+            "description": "The key of the current job activation during which this history item was produced.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobKey"
+              }
+            ]
+          },
+          "jobLease": {
+            "description": "Opaque lease token received from the job activation response.",
+            "type": "string"
+          },
+          "iteration": {
+            "description": "Sequential iteration number this item belongs to. Omit if not grouping items into iterations.",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IterationId"
+              }
+            ]
+          },
+          "role": {
+            "description": "The role of this history item in the conversation.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryRoleEnum"
+              }
+            ]
+          },
+          "content": {
+            "description": "The content blocks of this history item.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceMessageContent"
+            }
+          },
+          "toolCalls": {
+            "description": "Tool calls associated with this history item.\nFor ASSISTANT items: tool calls dispatched by this LLM response, with arguments populated.\nFor TOOL_RESULT items: single-entry array referencing the originating tool call, with arguments null.\nOmit for USER items.\n",
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceToolCall"
+            }
+          },
+          "metrics": {
+            "description": "Per-call token and latency metrics. Present on ASSISTANT items only.",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryItemMetrics"
+              }
+            ]
+          },
+          "producedAt": {
+            "description": "The connector-side timestamp of when this message was produced.",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AgentInstanceHistoryItemCreationResult": {
+        "description": "Response returned after successfully appending a history item.",
+        "type": "object",
+        "x-semantic-provider": [
+          "historyItemKey"
+        ],
+        "required": [
+          "historyItemKey"
+        ],
+        "properties": {
+          "historyItemKey": {
+            "description": "The system-generated key for the created history item.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentHistoryItemKey"
+              }
+            ]
+          }
+        }
+      },
+      "AgentInstanceHistorySearchQuerySortRequest": {
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "field": {
+            "description": "The field to sort by.",
+            "type": "string",
+            "enum": [
+              "producedAt",
+              "historyItemKey",
+              "iteration"
+            ]
+          },
+          "order": {
+            "$ref": "#/components/schemas/SortOrderEnum"
+          }
+        }
+      },
+      "AgentInstanceHistorySearchQuery": {
+        "description": "Agent instance history search request.",
+        "type": "object",
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SearchQueryRequest"
+          }
+        ],
+        "properties": {
+          "sort": {
+            "description": "Sort field criteria.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceHistorySearchQuerySortRequest"
+            }
+          },
+          "filter": {
+            "description": "The history item search filters.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryFilter"
+              }
+            ]
+          }
+        }
+      },
+      "AgentInstanceHistoryFilter": {
+        "description": "Agent instance history item search filter.",
+        "type": "object",
+        "properties": {
+          "historyItemKey": {
+            "description": "The unique key of the history item.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentHistoryItemKeyFilterProperty"
+              }
+            ]
+          },
+          "role": {
+            "description": "The role of the history item.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryRoleFilterProperty"
+              }
+            ]
+          },
+          "elementInstanceKey": {
+            "description": "The key of the element instance under which the history item was produced.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementInstanceKeyFilterProperty"
+              }
+            ]
+          },
+          "jobKey": {
+            "description": "The key of the job activation that produced the history item.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobKeyFilterProperty"
+              }
+            ]
+          },
+          "iteration": {
+            "description": "The iteration number.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IntegerFilterProperty"
+              }
+            ]
+          },
+          "commitStatus": {
+            "description": "The commit status of the history item. Defaults to COMMITTED only.\nInclude PENDING or DISCARDED explicitly to debug in-flight or failed activations.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryCommitStatusFilterProperty"
+              }
+            ]
+          },
+          "producedAt": {
+            "description": "The timestamp when the history item was produced.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTimeFilterProperty"
+              }
+            ]
+          }
+        }
+      },
+      "AgentInstanceHistorySearchQueryResult": {
+        "description": "Agent instance history search response.",
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SearchQueryResponse"
+          }
+        ],
+        "properties": {
+          "items": {
+            "description": "The matching history items.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceHistoryItemResult"
+            }
+          }
+        }
+      },
+      "AgentInstanceHistoryItemResult": {
+        "description": "A single conversation history item belonging to an agent instance.",
+        "type": "object",
+        "required": [
+          "agentInstanceKey",
+          "commitStatus",
+          "content",
+          "elementInstanceKey",
+          "historyItemKey",
+          "iteration",
+          "jobKey",
+          "jobLease",
+          "metrics",
+          "producedAt",
+          "role",
+          "toolCalls"
+        ],
+        "properties": {
+          "historyItemKey": {
+            "description": "The unique key for this history item. Stable and sortable by creation order.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentHistoryItemKey"
+              }
+            ]
+          },
+          "agentInstanceKey": {
+            "description": "The key of the agent instance this item belongs to.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceKey"
+              }
+            ]
+          },
+          "elementInstanceKey": {
+            "description": "The key of the AI Agent Task or ad-hoc sub-process element instance under which this item was produced.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementInstanceKey"
+              }
+            ]
+          },
+          "jobKey": {
+            "description": "The key of the job activation during which this item was produced.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobKey"
+              }
+            ]
+          },
+          "jobLease": {
+            "description": "The lease token of the activation that produced this item.",
+            "type": "string"
+          },
+          "iteration": {
+            "description": "The sequential iteration number this item belongs to. Null if not provided by the connector.",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IterationId"
+              }
+            ]
+          },
+          "role": {
+            "description": "The role of this history item in the conversation.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryRoleEnum"
+              }
+            ]
+          },
+          "content": {
+            "description": "The content blocks of this history item.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceMessageContent"
+            }
+          },
+          "toolCalls": {
+            "description": "Tool calls for this item. Empty for USER items and ASSISTANT items with no tool dispatches.\nASSISTANT items: dispatched tool calls with arguments populated.\nTOOL_RESULT items: single-entry array referencing the originating tool call (arguments null).\n",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceToolCall"
+            }
+          },
+          "metrics": {
+            "description": "Per-call token and latency metrics. Present on ASSISTANT items only.",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryItemMetrics"
+              }
+            ]
+          },
+          "commitStatus": {
+            "description": "The commit status of this history item.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryCommitStatusEnum"
+              }
+            ]
+          },
+          "producedAt": {
+            "description": "The connector-side timestamp of when this message was produced.",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AgentInstanceHistoryRoleEnum": {
+        "description": "The role of a history item in the agent conversation.",
+        "type": "string",
+        "enum": [
+          "USER",
+          "ASSISTANT",
+          "TOOL_RESULT"
+        ]
+      },
+      "AgentInstanceHistoryCommitStatusEnum": {
+        "description": "The commit status of a history item.\nCOMMITTED: the producing job completed successfully.\nPENDING: the producing job is still active (in-flight).\nDISCARDED: the producing job failed; this item was superseded by a later activation.\n",
+        "type": "string",
+        "enum": [
+          "COMMITTED",
+          "PENDING",
+          "DISCARDED"
+        ]
+      },
+      "AgentInstanceMessageContent": {
+        "x-polymorphic-schema": true,
+        "description": "A single content block within a history item. Discriminated by `contentType`.",
+        "discriminator": {
+          "propertyName": "contentType",
+          "mapping": {
+            "TEXT": "#/components/schemas/AgentInstanceTextContent",
+            "DOCUMENT": "#/components/schemas/AgentInstanceDocumentContent",
+            "OBJECT": "#/components/schemas/AgentInstanceObjectContent"
+          }
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AgentInstanceTextContent"
+          },
+          {
+            "$ref": "#/components/schemas/AgentInstanceDocumentContent"
+          },
+          {
+            "$ref": "#/components/schemas/AgentInstanceObjectContent"
+          }
+        ]
+      },
+      "AgentInstanceTextContent": {
+        "type": "object",
+        "title": "Text content",
+        "description": "A plain-text content block.",
+        "additionalProperties": false,
+        "required": [
+          "contentType",
+          "text"
+        ],
+        "properties": {
+          "contentType": {
+            "description": "The content type discriminator.",
+            "type": "string",
+            "example": "TEXT"
+          },
+          "text": {
+            "description": "The text content.",
+            "type": "string"
+          }
+        }
+      },
+      "AgentInstanceDocumentContent": {
+        "type": "object",
+        "title": "Document content",
+        "description": "A Camunda Document Store reference content block.",
+        "additionalProperties": false,
+        "required": [
+          "contentType",
+          "documentReference"
+        ],
+        "properties": {
+          "contentType": {
+            "description": "The content type discriminator.",
+            "type": "string",
+            "example": "DOCUMENT"
+          },
+          "documentReference": {
+            "description": "A reference to a document stored in the Camunda Document Store.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DocumentReference"
+              }
+            ]
+          }
+        }
+      },
+      "AgentInstanceObjectContent": {
+        "type": "object",
+        "title": "Object content",
+        "description": "An arbitrary structured content block.",
+        "additionalProperties": false,
+        "required": [
+          "contentType",
+          "object"
+        ],
+        "properties": {
+          "contentType": {
+            "description": "The content type discriminator.",
+            "type": "string",
+            "example": "OBJECT"
+          },
+          "object": {
+            "description": "Arbitrary structured content.",
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "AgentInstanceMessageContentTypeEnum": {
+        "description": "The content type discriminator for a history item content block.",
+        "type": "string",
+        "enum": [
+          "TEXT",
+          "DOCUMENT",
+          "OBJECT"
+        ]
+      },
+      "AgentInstanceToolCall": {
+        "description": "A tool call associated with a history item. Used in both ASSISTANT and TOOL_RESULT items.\nASSISTANT items carry arguments; TOOL_RESULT items carry arguments as null.\n",
+        "type": "object",
+        "required": [
+          "arguments",
+          "elementId",
+          "toolCallId",
+          "toolName"
+        ],
+        "properties": {
+          "toolCallId": {
+            "description": "The LLM-assigned tool call ID. Correlates ASSISTANT items to their matching TOOL_RESULT items.",
+            "type": "string"
+          },
+          "toolName": {
+            "description": "The LLM-visible tool name.",
+            "type": "string"
+          },
+          "elementId": {
+            "description": "The BPMN element ID handling this tool.",
+            "type": "string",
+            "nullable": true
+          },
+          "arguments": {
+            "description": "The tool call arguments as provided by the LLM. Null on TOOL_RESULT items.",
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true
+          }
+        }
+      },
+      "AgentInstanceHistoryItemMetrics": {
+        "description": "Per-call token and latency metrics for an ASSISTANT history item.",
+        "type": "object",
+        "required": [
+          "durationMs",
+          "inputTokens",
+          "outputTokens"
+        ],
+        "properties": {
+          "inputTokens": {
+            "description": "Input tokens consumed by this LLM call.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "outputTokens": {
+            "description": "Output tokens produced by this LLM call.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "durationMs": {
+            "description": "Wall-clock duration of the LLM call in milliseconds.",
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "AgentInstanceHistoryRoleFilterProperty": {
+        "description": "AgentInstanceHistoryRoleEnum property with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AgentInstanceHistoryRoleExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedAgentInstanceHistoryRoleFilter"
+          }
+        ]
+      },
+      "AdvancedAgentInstanceHistoryRoleFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced AgentInstanceHistoryRoleEnum filter.",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryRoleEnum"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryRoleEnum"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceHistoryRoleEnum"
+            }
+          }
+        }
+      },
+      "AgentInstanceHistoryCommitStatusFilterProperty": {
+        "description": "AgentInstanceHistoryCommitStatusEnum property with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AgentInstanceHistoryCommitStatusExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedAgentInstanceHistoryCommitStatusFilter"
+          }
+        ]
+      },
+      "AdvancedAgentInstanceHistoryCommitStatusFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced AgentInstanceHistoryCommitStatusEnum filter.",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryCommitStatusEnum"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryCommitStatusEnum"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceHistoryCommitStatusEnum"
+            }
+          }
+        }
+      },
       "AuditLogResult": {
         "description": "Audit log item.",
         "type": "object",
         "required": [
-          "auditLogKey",
-          "entityKey",
-          "entityType",
-          "operationType",
-          "batchOperationKey",
-          "batchOperationType",
-          "timestamp",
           "actorId",
           "actorType",
           "agentElementId",
-          "tenantId",
-          "result",
+          "auditLogKey",
+          "batchOperationKey",
+          "batchOperationType",
           "category",
-          "processDefinitionId",
-          "processDefinitionKey",
-          "processInstanceKey",
-          "rootProcessInstanceKey",
-          "elementInstanceKey",
-          "jobKey",
-          "userTaskKey",
-          "decisionRequirementsId",
-          "decisionRequirementsKey",
           "decisionDefinitionId",
           "decisionDefinitionKey",
           "decisionEvaluationKey",
+          "decisionRequirementsId",
+          "decisionRequirementsKey",
           "deploymentKey",
+          "elementInstanceKey",
+          "entityDescription",
+          "entityKey",
+          "entityType",
           "formKey",
-          "resourceKey",
+          "jobKey",
+          "operationType",
+          "processDefinitionId",
+          "processDefinitionKey",
+          "processInstanceKey",
           "relatedEntityKey",
           "relatedEntityType",
-          "entityDescription"
+          "resourceKey",
+          "result",
+          "rootProcessInstanceKey",
+          "tenantId",
+          "timestamp",
+          "userTaskKey"
         ],
         "properties": {
           "auditLogKey": {
@@ -20339,14 +21197,14 @@
         "type": "object",
         "required": [
           "authorizedComponents",
-          "tenants",
-          "groups",
-          "roles",
-          "salesPlanType",
           "c8Links",
           "canLogout",
           "displayName",
           "email",
+          "groups",
+          "roles",
+          "salesPlanType",
+          "tenants",
           "username"
         ],
         "properties": {
@@ -20465,9 +21323,9 @@
         "required": [
           "ownerId",
           "ownerType",
+          "permissionTypes",
           "resourceId",
-          "resourceType",
-          "permissionTypes"
+          "resourceType"
         ]
       },
       "AuthorizationPropertyBasedRequest": {
@@ -20508,9 +21366,9 @@
         "required": [
           "ownerId",
           "ownerType",
+          "permissionTypes",
           "resourcePropertyName",
-          "resourceType",
-          "permissionTypes"
+          "resourceType"
         ],
         "x-properties-added-in-version": [
           {
@@ -20623,13 +21481,13 @@
       },
       "AuthorizationResult": {
         "required": [
+          "authorizationKey",
           "ownerId",
           "ownerType",
-          "resourceType",
+          "permissionTypes",
           "resourceId",
           "resourcePropertyName",
-          "permissionTypes",
-          "authorizationKey"
+          "resourceType"
         ],
         "type": "object",
         "properties": {
@@ -20981,17 +21839,17 @@
       },
       "BatchOperationResponse": {
         "required": [
+          "actorId",
+          "actorType",
           "batchOperationKey",
           "batchOperationType",
-          "state",
+          "endDate",
+          "errors",
           "operationsCompletedCount",
           "operationsFailedCount",
           "operationsTotalCount",
-          "actorType",
-          "actorId",
-          "errors",
-          "endDate",
-          "startDate"
+          "startDate",
+          "state"
         ],
         "type": "object",
         "properties": {
@@ -21221,13 +22079,13 @@
       "BatchOperationItemResponse": {
         "type": "object",
         "required": [
-          "rootProcessInstanceKey",
           "batchOperationKey",
           "errorMessage",
           "itemKey",
           "operationType",
-          "processedDate",
           "processInstanceKey",
+          "processedDate",
+          "rootProcessInstanceKey",
           "state"
         ],
         "properties": {
@@ -21446,8 +22304,8 @@
           }
         },
         "required": [
-          "targetProcessDefinitionKey",
-          "mappingInstructions"
+          "mappingInstructions",
+          "targetProcessDefinitionKey"
         ]
       },
       "ProcessInstanceModificationBatchOperationRequest": {
@@ -21792,8 +22650,8 @@
         "description": "Cluster variable search response item.",
         "type": "object",
         "required": [
-          "value",
-          "isTruncated"
+          "isTruncated",
+          "value"
         ],
         "allOf": [
           {
@@ -22003,12 +22861,12 @@
         "type": "object",
         "required": [
           "brokers",
+          "clusterId",
           "clusterSize",
-          "partitionsCount",
-          "replicationFactor",
           "gatewayVersion",
           "lastCompletedChangeId",
-          "clusterId"
+          "partitionsCount",
+          "replicationFactor"
         ],
         "properties": {
           "brokers": {
@@ -22087,10 +22945,10 @@
         "description": "Provides information on a broker node.",
         "type": "object",
         "required": [
-          "nodeId",
           "host",
-          "port",
+          "nodeId",
           "partitions",
+          "port",
           "version"
         ],
         "properties": {
@@ -22129,9 +22987,9 @@
         "description": "Provides information on a partition within a broker node.",
         "type": "object",
         "required": [
+          "health",
           "partitionId",
-          "role",
-          "health"
+          "role"
         ],
         "properties": {
           "partitionId": {
@@ -22197,8 +23055,8 @@
       "EvaluateConditionalResult": {
         "type": "object",
         "required": [
-          "processInstances",
           "conditionalEvaluationKey",
+          "processInstances",
           "tenantId"
         ],
         "x-semantic-provider": [
@@ -22729,14 +23587,14 @@
       },
       "EvaluatedDecisionResult": {
         "required": [
-          "decisionDefinitionType",
-          "evaluatedInputs",
-          "matchedRules",
           "decisionDefinitionId",
           "decisionDefinitionKey",
           "decisionDefinitionName",
+          "decisionDefinitionType",
           "decisionDefinitionVersion",
           "decisionEvaluationInstanceKey",
+          "evaluatedInputs",
+          "matchedRules",
           "output",
           "tenantId"
         ],
@@ -23360,11 +24218,11 @@
       },
       "EvaluatedDecisionOutputItem": {
         "required": [
-          "ruleId",
-          "ruleIndex",
           "outputId",
           "outputName",
-          "outputValue"
+          "outputValue",
+          "ruleId",
+          "ruleIndex"
         ],
         "type": "object",
         "description": "The evaluated decision outputs.",
@@ -23747,8 +24605,8 @@
         "type": "object",
         "required": [
           "deploymentKey",
-          "tenantId",
-          "deployments"
+          "deployments",
+          "tenantId"
         ],
         "x-semantic-provider": [
           "deploymentKey"
@@ -23782,10 +24640,10 @@
       "DeploymentMetadataResult": {
         "type": "object",
         "required": [
-          "processDefinition",
           "decisionDefinition",
           "decisionRequirements",
           "form",
+          "processDefinition",
           "resource"
         ],
         "properties": {
@@ -23851,9 +24709,9 @@
         "type": "object",
         "required": [
           "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionVersion",
           "resourceName",
-          "processDefinitionKey",
           "tenantId"
         ],
         "properties": {
@@ -24118,8 +24976,8 @@
       "DeleteResourceResponse": {
         "type": "object",
         "required": [
-          "resourceKey",
-          "batchOperation"
+          "batchOperation",
+          "resourceKey"
         ],
         "properties": {
           "resourceKey": {
@@ -24154,12 +25012,12 @@
       "ResourceResult": {
         "type": "object",
         "required": [
-          "resourceName",
-          "version",
-          "versionTag",
           "resourceId",
+          "resourceKey",
+          "resourceName",
           "tenantId",
-          "resourceKey"
+          "version",
+          "versionTag"
         ],
         "properties": {
           "resourceName": {
@@ -24541,10 +25399,10 @@
         "type": "object",
         "required": [
           "camunda.document.type",
-          "storeId",
-          "documentId",
           "contentHash",
-          "metadata"
+          "documentId",
+          "metadata",
+          "storeId"
         ],
         "properties": {
           "camunda.document.type": {
@@ -24641,8 +25499,8 @@
           {
             "type": "object",
             "required": [
-              "failedDocuments",
-              "createdDocuments"
+              "createdDocuments",
+              "failedDocuments"
             ],
             "properties": {
               "failedDocuments": {
@@ -24742,13 +25600,13 @@
         "description": "Information about the document that is returned in responses.",
         "type": "object",
         "required": [
-          "fileName",
-          "expiresAt",
-          "size",
           "contentType",
           "customProperties",
+          "expiresAt",
+          "fileName",
           "processDefinitionId",
-          "processInstanceKey"
+          "processInstanceKey",
+          "size"
         ],
         "properties": {
           "contentType": {
@@ -24823,8 +25681,8 @@
       "DocumentLink": {
         "type": "object",
         "required": [
-          "url",
-          "expiresAt"
+          "expiresAt",
+          "url"
         ],
         "properties": {
           "url": {
@@ -24863,6 +25721,27 @@
               "state",
               "incidentKey",
               "tenantId"
+            ]
+          },
+          "order": {
+            "$ref": "#/components/schemas/SortOrderEnum"
+          }
+        },
+        "required": [
+          "field"
+        ]
+      },
+      "ElementInstanceWaitStateQuerySortRequest": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "description": "The field to sort by.",
+            "type": "string",
+            "enum": [
+              "elementInstanceKey",
+              "processInstanceKey",
+              "rootProcessInstanceKey",
+              "elementId"
             ]
           },
           "order": {
@@ -25135,20 +26014,20 @@
       "ElementInstanceResult": {
         "type": "object",
         "required": [
-          "processDefinitionId",
-          "startDate",
           "elementId",
-          "elementName",
-          "type",
-          "state",
-          "hasIncident",
-          "tenantId",
           "elementInstanceKey",
-          "processInstanceKey",
-          "processDefinitionKey",
-          "rootProcessInstanceKey",
+          "elementName",
           "endDate",
-          "incidentKey"
+          "hasIncident",
+          "incidentKey",
+          "processDefinitionId",
+          "processDefinitionKey",
+          "processInstanceKey",
+          "rootProcessInstanceKey",
+          "startDate",
+          "state",
+          "tenantId",
+          "type"
         ],
         "properties": {
           "processDefinitionId": {
@@ -25324,6 +26203,13 @@
           }
         ],
         "properties": {
+          "sort": {
+            "description": "Sort field criteria.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ElementInstanceWaitStateQuerySortRequest"
+            }
+          },
           "filter": {
             "description": "Filter criteria for the inspection.",
             "allOf": [
@@ -25541,15 +26427,15 @@
         "description": "An element instance waiting state.",
         "type": "object",
         "required": [
-          "waitStateType",
-          "processInstanceKey",
-          "elementInstanceKey",
           "elementId",
+          "elementInstanceKey",
           "elementType",
-          "tenantId",
-          "rootProcessInstanceKey",
           "jobDetails",
-          "messageDetails"
+          "messageDetails",
+          "processInstanceKey",
+          "rootProcessInstanceKey",
+          "tenantId",
+          "waitStateType"
         ],
         "properties": {
           "waitStateType": {
@@ -25641,8 +26527,8 @@
         "type": "object",
         "required": [
           "jobKey",
-          "jobType",
           "jobKind",
+          "jobType",
           "listenerEventType",
           "retries"
         ],
@@ -25687,8 +26573,8 @@
       "MessageWaitStateDetails": {
         "type": "object",
         "required": [
-          "messageName",
-          "correlationKey"
+          "correlationKey",
+          "messageName"
         ],
         "properties": {
           "messageName": {
@@ -26115,11 +27001,11 @@
           "formKey"
         ],
         "required": [
-          "tenantId",
           "formId",
+          "formKey",
           "schema",
-          "version",
-          "formKey"
+          "tenantId",
+          "version"
         ],
         "properties": {
           "tenantId": {
@@ -26244,9 +27130,9 @@
       "CreateGlobalTaskListenerRequest": {
         "type": "object",
         "required": [
+          "eventTypes",
           "id",
-          "type",
-          "eventTypes"
+          "type"
         ],
         "allOf": [
           {
@@ -26262,8 +27148,8 @@
       "UpdateGlobalTaskListenerRequest": {
         "type": "object",
         "required": [
-          "type",
-          "eventTypes"
+          "eventTypes",
+          "type"
         ],
         "allOf": [
           {
@@ -26274,13 +27160,13 @@
       "GlobalTaskListenerResult": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "retries",
-          "eventTypes",
           "afterNonGlobal",
+          "eventTypes",
+          "id",
           "priority",
-          "source"
+          "retries",
+          "source",
+          "type"
         ],
         "allOf": [
           {
@@ -26571,9 +27457,9 @@
           }
         },
         "required": [
+          "description",
           "groupId",
-          "name",
-          "description"
+          "name"
         ]
       },
       "GroupUpdateRequest": {
@@ -26614,9 +27500,9 @@
           }
         },
         "required": [
+          "description",
           "groupId",
-          "name",
-          "description"
+          "name"
         ]
       },
       "GroupResult": {
@@ -26642,9 +27528,9 @@
           }
         },
         "required": [
-          "name",
+          "description",
           "groupId",
-          "description"
+          "name"
         ]
       },
       "GroupSearchQuerySortRequest": {
@@ -27060,6 +27946,15 @@
         "minLength": 1,
         "maxLength": 256,
         "example": "order-12345"
+      },
+      "IterationId": {
+        "description": "A client-provided sequential integer identifying a logical iteration: one LLM\ncall, its tool dispatches, and their results. Must be a positive integer,\nincreasing with each iteration. Established by the\nconnector when appending the first history item of an iteration.\n",
+        "type": "integer",
+        "format": "int32",
+        "minimum": 1,
+        "x-semantic-type": "IterationId",
+        "x-semantic-client-minted": true,
+        "example": 1
       },
       "ElementIdFilterProperty": {
         "description": "ElementId property with full advanced search capabilities.",
@@ -27627,18 +28522,18 @@
       "IncidentResult": {
         "type": "object",
         "required": [
+          "creationTime",
+          "elementId",
+          "elementInstanceKey",
+          "errorMessage",
+          "errorType",
           "incidentKey",
+          "jobKey",
+          "processDefinitionId",
           "processDefinitionKey",
           "processInstanceKey",
-          "elementInstanceKey",
-          "creationTime",
-          "state",
-          "errorType",
-          "errorMessage",
-          "elementId",
-          "processDefinitionId",
           "rootProcessInstanceKey",
-          "jobKey",
+          "state",
           "tenantId"
         ],
         "properties": {
@@ -28020,8 +28915,8 @@
         "description": "Global job statistics query result.",
         "type": "object",
         "required": [
-          "created",
           "completed",
+          "created",
           "failed",
           "isIncomplete"
         ],
@@ -28116,8 +29011,8 @@
         "description": "Job type statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -28138,10 +29033,10 @@
         "description": "Statistics for a single job type.",
         "type": "object",
         "required": [
-          "jobType",
-          "created",
           "completed",
+          "created",
           "failed",
+          "jobType",
           "workers"
         ],
         "properties": {
@@ -28192,8 +29087,8 @@
         "type": "object",
         "required": [
           "from",
-          "to",
-          "jobType"
+          "jobType",
+          "to"
         ],
         "properties": {
           "from": {
@@ -28219,8 +29114,8 @@
         "description": "Job worker statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -28241,10 +29136,10 @@
         "description": "Statistics for a single worker within a job type.",
         "type": "object",
         "required": [
-          "worker",
-          "created",
           "completed",
-          "failed"
+          "created",
+          "failed",
+          "worker"
         ],
         "properties": {
           "worker": {
@@ -28288,8 +29183,8 @@
         "type": "object",
         "required": [
           "from",
-          "to",
-          "jobType"
+          "jobType",
+          "to"
         ],
         "properties": {
           "from": {
@@ -28320,8 +29215,8 @@
         "description": "Job time-series statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -28342,10 +29237,10 @@
         "description": "Aggregated job metrics for a single time bucket.",
         "type": "object",
         "required": [
-          "time",
-          "created",
           "completed",
-          "failed"
+          "created",
+          "failed",
+          "time"
         ],
         "properties": {
           "time": {
@@ -28390,8 +29285,8 @@
         "type": "object",
         "required": [
           "from",
-          "to",
-          "jobType"
+          "jobType",
+          "to"
         ],
         "properties": {
           "from": {
@@ -28433,8 +29328,8 @@
         "description": "Job error statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -28540,9 +29435,9 @@
           }
         },
         "required": [
-          "type",
           "maxJobsToActivate",
-          "timeout"
+          "timeout",
+          "type"
         ],
         "x-properties-added-in-version": [
           {
@@ -28575,26 +29470,26 @@
         ],
         "type": "object",
         "required": [
-          "type",
-          "processDefinitionId",
-          "processDefinitionVersion",
-          "elementId",
           "customHeaders",
-          "worker",
-          "retries",
           "deadline",
-          "variables",
-          "tenantId",
-          "jobKey",
-          "processInstanceKey",
-          "processDefinitionKey",
+          "elementId",
           "elementInstanceKey",
+          "jobKey",
           "kind",
           "listenerEventType",
+          "priority",
+          "processDefinitionId",
+          "processDefinitionKey",
+          "processDefinitionVersion",
+          "processInstanceKey",
+          "retries",
           "rootProcessInstanceKey",
           "tags",
+          "tenantId",
+          "type",
           "userTask",
-          "priority"
+          "variables",
+          "worker"
         ],
         "properties": {
           "type": {
@@ -28754,11 +29649,11 @@
       },
       "UserTaskProperties": {
         "required": [
+          "action",
+          "assignee",
           "candidateGroups",
           "candidateUsers",
           "changedAttributes",
-          "action",
-          "assignee",
           "dueDate",
           "followUpDate",
           "formKey",
@@ -29123,31 +30018,31 @@
       "JobSearchResult": {
         "type": "object",
         "required": [
+          "creationTime",
           "customHeaders",
+          "deadline",
+          "deniedReason",
           "elementId",
           "elementInstanceKey",
+          "endTime",
+          "errorCode",
+          "errorMessage",
           "hasFailedWithRetriesLeft",
+          "isDenied",
           "jobKey",
           "kind",
+          "lastUpdateTime",
           "listenerEventType",
           "priority",
           "processDefinitionId",
           "processDefinitionKey",
           "processInstanceKey",
           "retries",
+          "rootProcessInstanceKey",
           "state",
           "tenantId",
           "type",
-          "worker",
-          "rootProcessInstanceKey",
-          "creationTime",
-          "deadline",
-          "deniedReason",
-          "endTime",
-          "errorCode",
-          "errorMessage",
-          "isDenied",
-          "lastUpdateTime"
+          "worker"
         ],
         "properties": {
           "customHeaders": {
@@ -29959,6 +30854,18 @@
           }
         ]
       },
+      "AgentHistoryItemKey": {
+        "description": "System-generated key for an agent history item.",
+        "format": "AgentHistoryItemKey",
+        "x-semantic-type": "AgentHistoryItemKey",
+        "example": "6755399441055744",
+        "type": "string",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LongKey"
+          }
+        ]
+      },
       "AuditLogKey": {
         "allOf": [
           {
@@ -30571,6 +31478,58 @@
           }
         }
       },
+      "AgentHistoryItemKeyFilterProperty": {
+        "description": "AgentHistoryItemKey property with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AgentHistoryItemKeyExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedAgentHistoryItemKeyFilter"
+          }
+        ]
+      },
+      "AdvancedAgentHistoryItemKeyFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced AgentHistoryItemKey filter.",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentHistoryItemKey"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentHistoryItemKey"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentHistoryItemKey"
+            }
+          },
+          "$notIn": {
+            "description": "Checks if the property matches none of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentHistoryItemKey"
+            }
+          }
+        }
+      },
       "AuditLogKeyFilterProperty": {
         "description": "AuditLogKey property with full advanced search capabilities.",
         "oneOf": [
@@ -30783,10 +31742,10 @@
         "description": "The response of a license request.",
         "type": "object",
         "required": [
-          "validLicense",
-          "licenseType",
+          "expiresAt",
           "isCommercial",
-          "expiresAt"
+          "licenseType",
+          "validLicense"
         ],
         "properties": {
           "validLicense": {
@@ -30900,8 +31859,8 @@
         "required": [
           "claimName",
           "claimValue",
-          "name",
-          "mappingRuleId"
+          "mappingRuleId",
+          "name"
         ]
       },
       "MappingRuleCreateResult": {
@@ -30967,8 +31926,8 @@
         "required": [
           "claimName",
           "claimValue",
-          "name",
-          "mappingRuleId"
+          "mappingRuleId",
+          "name"
         ]
       },
       "MappingRuleSearchQuerySortRequest": {
@@ -31083,9 +32042,9 @@
         ],
         "type": "object",
         "required": [
-          "tenantId",
           "messageKey",
-          "processInstanceKey"
+          "processInstanceKey",
+          "tenantId"
         ],
         "properties": {
           "tenantId": {
@@ -31163,8 +32122,8 @@
         ],
         "type": "object",
         "required": [
-          "tenantId",
-          "messageKey"
+          "messageKey",
+          "tenantId"
         ],
         "properties": {
           "tenantId": {
@@ -31208,11 +32167,9 @@
       "MessageSubscriptionResult": {
         "type": "object",
         "required": [
-          "rootProcessInstanceKey",
           "correlationKey",
           "elementId",
           "elementInstanceKey",
-          "toolProperties",
           "inboundConnectorType",
           "lastUpdatedDate",
           "messageName",
@@ -31224,8 +32181,10 @@
           "processDefinitionName",
           "processDefinitionVersion",
           "processInstanceKey",
+          "rootProcessInstanceKey",
           "tenantId",
-          "toolName"
+          "toolName",
+          "toolProperties"
         ],
         "properties": {
           "messageSubscriptionKey": {
@@ -31655,16 +32614,16 @@
           "correlationKey",
           "correlationTime",
           "elementId",
+          "elementInstanceKey",
           "messageKey",
           "messageName",
           "partitionId",
           "processDefinitionId",
+          "processDefinitionKey",
           "processInstanceKey",
-          "subscriptionKey",
-          "tenantId",
           "rootProcessInstanceKey",
-          "elementInstanceKey",
-          "processDefinitionKey"
+          "subscriptionKey",
+          "tenantId"
         ],
         "properties": {
           "correlationKey": {
@@ -32115,11 +33074,11 @@
         "description": "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
         "type": "object",
         "required": [
-          "type",
-          "title",
-          "status",
           "detail",
-          "instance"
+          "instance",
+          "status",
+          "title",
+          "type"
         ],
         "properties": {
           "type": {
@@ -32287,14 +33246,14 @@
       "ProcessDefinitionResult": {
         "type": "object",
         "required": [
-          "processDefinitionKey",
+          "hasStartForm",
           "name",
-          "resourceName",
-          "version",
-          "versionTag",
           "processDefinitionId",
+          "processDefinitionKey",
+          "resourceName",
           "tenantId",
-          "hasStartForm"
+          "version",
+          "versionTag"
         ],
         "properties": {
           "name": {
@@ -32730,13 +33689,13 @@
           }
         },
         "required": [
+          "activeInstancesWithIncidentCount",
+          "activeInstancesWithoutIncidentCount",
           "processDefinitionId",
           "processDefinitionKey",
-          "tenantId",
           "processDefinitionName",
           "processDefinitionVersion",
-          "activeInstancesWithIncidentCount",
-          "activeInstancesWithoutIncidentCount"
+          "tenantId"
         ]
       },
       "ProcessDefinitionInstanceVersionStatisticsQuerySortRequest": {
@@ -33024,14 +33983,14 @@
           "processInstanceKey"
         ],
         "required": [
+          "businessId",
           "processDefinitionId",
           "processDefinitionKey",
           "processDefinitionVersion",
-          "tenantId",
-          "variables",
           "processInstanceKey",
           "tags",
-          "businessId"
+          "tenantId",
+          "variables"
         ],
         "type": "object",
         "properties": {
@@ -33525,22 +34484,22 @@
         "description": "Process instance search response item.",
         "type": "object",
         "required": [
+          "businessId",
+          "endDate",
+          "hasIncident",
+          "parentElementInstanceKey",
+          "parentProcessInstanceKey",
           "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionName",
           "processDefinitionVersion",
           "processDefinitionVersionTag",
-          "startDate",
-          "endDate",
-          "state",
-          "hasIncident",
-          "tenantId",
           "processInstanceKey",
-          "processDefinitionKey",
-          "parentProcessInstanceKey",
-          "parentElementInstanceKey",
           "rootProcessInstanceKey",
+          "startDate",
+          "state",
           "tags",
-          "businessId"
+          "tenantId"
         ],
         "properties": {
           "processDefinitionId": {
@@ -33728,9 +34687,9 @@
       "ProcessInstanceCallHierarchyEntry": {
         "type": "object",
         "required": [
-          "processInstanceKey",
           "processDefinitionKey",
-          "processDefinitionName"
+          "processDefinitionName",
+          "processInstanceKey"
         ],
         "properties": {
           "processInstanceKey": {
@@ -33775,11 +34734,11 @@
         "description": "Process instance sequence flow result.",
         "type": "object",
         "required": [
-          "rootProcessInstanceKey",
           "elementId",
           "processDefinitionId",
           "processDefinitionKey",
           "processInstanceKey",
+          "rootProcessInstanceKey",
           "sequenceFlowId",
           "tenantId"
         ],
@@ -33881,8 +34840,8 @@
           }
         },
         "required": [
-          "targetProcessDefinitionKey",
-          "mappingInstructions"
+          "mappingInstructions",
+          "targetProcessDefinitionKey"
         ]
       },
       "MigrateProcessInstanceMappingInstruction": {
@@ -34309,8 +35268,8 @@
           }
         },
         "required": [
-          "roleId",
-          "name"
+          "name",
+          "roleId"
         ]
       },
       "RoleCreateResult": {
@@ -34335,9 +35294,9 @@
           }
         },
         "required": [
-          "roleId",
+          "description",
           "name",
-          "description"
+          "roleId"
         ]
       },
       "RoleUpdateRequest": {
@@ -34378,9 +35337,9 @@
           }
         },
         "required": [
-          "roleId",
+          "description",
           "name",
-          "description"
+          "roleId"
         ]
       },
       "RoleResult": {
@@ -34406,9 +35365,9 @@
           }
         },
         "required": [
-          "roleId",
+          "description",
           "name",
-          "description"
+          "roleId"
         ]
       },
       "RoleSearchQuerySortRequest": {
@@ -34894,10 +35853,10 @@
         "description": "Pagination information about the search results.",
         "type": "object",
         "required": [
-          "totalItems",
+          "endCursor",
           "hasMoreTotalItems",
           "startCursor",
-          "endCursor"
+          "totalItems"
         ],
         "x-semantic-provider": [
           "startCursor",
@@ -34976,8 +35935,8 @@
       "SignalBroadcastResult": {
         "type": "object",
         "required": [
-          "tenantId",
-          "signalKey"
+          "signalKey",
+          "tenantId"
         ],
         "x-semantic-provider": [
           "signalKey"
@@ -35015,8 +35974,8 @@
       },
       "UsageMetricsResponse": {
         "required": [
-          "tenants",
-          "activeTenants"
+          "activeTenants",
+          "tenants"
         ],
         "type": "object",
         "allOf": [
@@ -35048,9 +36007,9 @@
       },
       "UsageMetricsResponseItem": {
         "required": [
-          "processInstances",
+          "assignees",
           "decisionInstances",
-          "assignees"
+          "processInstances"
         ],
         "type": "object",
         "properties": {
@@ -35075,11 +36034,11 @@
         "description": "Envelope for all system configuration sections. Each property\nrepresents a feature area.\n",
         "type": "object",
         "required": [
-          "jobMetrics",
+          "authentication",
+          "cloud",
           "components",
           "deployment",
-          "authentication",
-          "cloud"
+          "jobMetrics"
         ],
         "properties": {
           "jobMetrics": {
@@ -35123,10 +36082,10 @@
         "required": [
           "enabled",
           "exportInterval",
-          "maxWorkerNameLength",
           "maxJobTypeLength",
           "maxTenantIdLength",
-          "maxUniqueKeys"
+          "maxUniqueKeys",
+          "maxWorkerNameLength"
         ],
         "properties": {
           "enabled": {
@@ -35286,8 +36245,8 @@
           }
         },
         "required": [
-          "tenantId",
-          "name"
+          "name",
+          "tenantId"
         ]
       },
       "TenantCreateResult": {
@@ -35317,9 +36276,9 @@
           }
         },
         "required": [
-          "tenantId",
+          "description",
           "name",
-          "description"
+          "tenantId"
         ]
       },
       "TenantUpdateRequest": {
@@ -35361,9 +36320,9 @@
           }
         },
         "required": [
-          "tenantId",
+          "description",
           "name",
-          "description"
+          "tenantId"
         ]
       },
       "TenantResult": {
@@ -35391,9 +36350,9 @@
           }
         },
         "required": [
-          "tenantId",
+          "description",
           "name",
-          "description"
+          "tenantId"
         ]
       },
       "TenantSearchQuerySortRequest": {
@@ -36017,30 +36976,30 @@
       "UserTaskResult": {
         "type": "object",
         "required": [
-          "tenantId",
-          "userTaskKey",
-          "name",
-          "processInstanceKey",
-          "rootProcessInstanceKey",
-          "processDefinitionKey",
-          "elementInstanceKey",
-          "processDefinitionId",
-          "processName",
-          "state",
+          "assignee",
           "candidateGroups",
           "candidateUsers",
-          "elementId",
+          "completionDate",
           "creationDate",
           "customHeaders",
-          "priority",
-          "tags",
-          "assignee",
-          "completionDate",
           "dueDate",
+          "elementId",
+          "elementInstanceKey",
           "externalFormReference",
           "followUpDate",
+          "formKey",
+          "name",
+          "priority",
+          "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionVersion",
-          "formKey"
+          "processInstanceKey",
+          "processName",
+          "rootProcessInstanceKey",
+          "state",
+          "tags",
+          "tenantId",
+          "userTaskKey"
         ],
         "properties": {
           "name": {
@@ -36670,8 +37629,8 @@
           }
         },
         "required": [
-          "username",
-          "password"
+          "password",
+          "username"
         ]
       },
       "UserCreateResult": {
@@ -36700,9 +37659,9 @@
           }
         },
         "required": [
-          "username",
+          "email",
           "name",
-          "email"
+          "username"
         ]
       },
       "UserUpdateRequest": {
@@ -36745,9 +37704,9 @@
           }
         },
         "required": [
-          "username",
+          "email",
           "name",
-          "email"
+          "username"
         ]
       },
       "UserResult": {
@@ -36773,9 +37732,9 @@
           }
         },
         "required": [
-          "username",
+          "email",
           "name",
-          "email"
+          "username"
         ]
       },
       "UserSearchQuerySortRequest": {
@@ -37050,10 +38009,10 @@
         "required": [
           "name",
           "processInstanceKey",
-          "tenantId",
-          "variableKey",
+          "rootProcessInstanceKey",
           "scopeKey",
-          "rootProcessInstanceKey"
+          "tenantId",
+          "variableKey"
         ],
         "properties": {
           "name": {
@@ -37159,6 +38118,26 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/AgentInstanceStatusEnum"
+          }
+        ]
+      },
+      "AgentInstanceHistoryRoleExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentInstanceHistoryRoleEnum"
+          }
+        ]
+      },
+      "AgentInstanceHistoryCommitStatusExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentInstanceHistoryCommitStatusEnum"
           }
         ]
       },
@@ -37500,6 +38479,16 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/AgentInstanceKey"
+          }
+        ]
+      },
+      "AgentHistoryItemKeyExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentHistoryItemKey"
           }
         ]
       },

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,7 +1,37 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:b2ba0d0bc85430aa0146f7430dad7a5e9de916e833676bb97cafd4357f93e8b9",
+  "specHash": "sha256:9a1790204bd0ebcd617b436f47e470015da360693431dcad2b57725ffef1ffe5",
   "semanticKeys": [
+    {
+      "name": "AgentHistoryItemKey",
+      "semanticType": "AgentHistoryItemKey",
+      "category": "system-key",
+      "description": "System-generated key for an agent history item.",
+      "composition": {
+        "schemaKind": "allOf",
+        "refs": [
+          "LongKey"
+        ],
+        "inlineFragments": 0
+      },
+      "constraints": {
+        "pattern": "^-?[0-9]+$",
+        "minLength": 1,
+        "maxLength": 25
+      },
+      "examples": [
+        "6755399441055744"
+      ],
+      "extensions": {
+        "x-semantic-type": "AgentHistoryItemKey"
+      },
+      "flags": {
+        "semanticKey": true,
+        "includesLongKeyRef": true,
+        "deprecated": false
+      },
+      "stableId": "agent-history-item-key"
+    },
     {
       "name": "AgentInstanceKey",
       "semanticType": "AgentInstanceKey",
@@ -1153,6 +1183,54 @@
   ],
   "unions": [
     {
+      "name": "AgentHistoryItemKeyFilterProperty",
+      "kind": "union-wrapper",
+      "description": "AgentHistoryItemKey property with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "AgentHistoryItemKeyExactMatch"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AdvancedAgentHistoryItemKeyFilter"
+        }
+      ],
+      "stableId": "agent-history-item-key-filter-property"
+    },
+    {
+      "name": "AgentInstanceHistoryCommitStatusFilterProperty",
+      "kind": "union-wrapper",
+      "description": "AgentInstanceHistoryCommitStatusEnum property with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "AgentInstanceHistoryCommitStatusExactMatch"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AdvancedAgentInstanceHistoryCommitStatusFilter"
+        }
+      ],
+      "stableId": "agent-instance-history-commit-status-filter-property"
+    },
+    {
+      "name": "AgentInstanceHistoryRoleFilterProperty",
+      "kind": "union-wrapper",
+      "description": "AgentInstanceHistoryRoleEnum property with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "AgentInstanceHistoryRoleExactMatch"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AdvancedAgentInstanceHistoryRoleFilter"
+        }
+      ],
+      "stableId": "agent-instance-history-role-filter-property"
+    },
+    {
       "name": "AgentInstanceKeyFilterProperty",
       "kind": "union-wrapper",
       "description": "AgentInstanceKey property with full advanced search capabilities.",
@@ -1167,6 +1245,26 @@
         }
       ],
       "stableId": "agent-instance-key-filter-property"
+    },
+    {
+      "name": "AgentInstanceMessageContent",
+      "kind": "union-wrapper",
+      "description": "A single content block within a history item. Discriminated by `contentType`.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "AgentInstanceTextContent"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AgentInstanceDocumentContent"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AgentInstanceObjectContent"
+        }
+      ],
+      "stableId": "agent-instance-message-content"
     },
     {
       "name": "AgentInstanceStatusFilterProperty",
@@ -2138,6 +2236,14 @@
       ]
     },
     {
+      "operationId": "searchAgentInstanceHistory",
+      "path": "/agent-instances/{agentInstanceKey}/history/search",
+      "method": "post",
+      "tags": [
+        "Agent instance"
+      ]
+    },
+    {
       "operationId": "searchAuditLogs",
       "path": "/audit-logs/search",
       "method": "post",
@@ -2945,6 +3051,78 @@
       ],
       "requestBodySchemaRef": "AgentInstanceSearchQuery",
       "successResponseSchemaRef": "AgentInstanceSearchQueryResult",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": true,
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
+      "operationId": "createAgentInstanceHistoryItem",
+      "path": "/agent-instances/{agentInstanceKey}/history",
+      "method": "post",
+      "tags": [
+        "Agent instance"
+      ],
+      "summary": "Create agent instance history item",
+      "description": "Appends a single history item to an agent instance's conversation history.\nThe created item has commitStatus PENDING until the job identified by jobLease\ncompletes successfully, at which point it transitions to COMMITTED. If the job\nfails or is superseded by a retry, the item is marked DISCARDED.\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [
+        "agentInstanceKey"
+      ],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "agent-instances.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "AgentInstanceHistoryItemRequest",
+      "successResponseSchemaRef": "AgentInstanceHistoryItemCreationResult",
+      "successStatus": 201,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-semantic-establishes": {
+          "kind": "AgentInstanceIteration",
+          "identifiedBy": [
+            {
+              "in": "body",
+              "name": "iteration",
+              "semanticType": "IterationId"
+            }
+          ]
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
+      "operationId": "searchAgentInstanceHistory",
+      "path": "/agent-instances/{agentInstanceKey}/history/search",
+      "method": "post",
+      "tags": [
+        "Agent instance"
+      ],
+      "summary": "Search agent instance history",
+      "description": "Searches the conversation history of an agent instance. Committed items\nare returned by default.\n",
+      "eventuallyConsistent": true,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [
+        "agentInstanceKey"
+      ],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "agent-instances.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "AgentInstanceHistorySearchQuery",
+      "successResponseSchemaRef": "AgentInstanceHistorySearchQueryResult",
       "successStatus": 200,
       "vendorExtensions": {
         "x-eventually-consistent": true,
@@ -9280,6 +9458,13 @@
       "stableId": "agent-instance-creation-result"
     },
     {
+      "schemaName": "AgentInstanceHistoryItemCreationResult",
+      "providers": [
+        "historyItemKey"
+      ],
+      "stableId": "agent-instance-history-item-creation-result"
+    },
+    {
       "schemaName": "AuthorizationCreateResult",
       "providers": [
         "authorizationKey"
@@ -9429,11 +9614,11 @@
     }
   ],
   "integrity": {
-    "totalSemanticKeys": 40,
-    "totalUnions": 59,
-    "totalOperations": 191,
-    "totalEventuallyConsistent": 89,
+    "totalSemanticKeys": 41,
+    "totalUnions": 63,
+    "totalOperations": 193,
+    "totalEventuallyConsistent": 90,
     "totalDeprecatedEnumSchemas": 2,
-    "totalSemanticProviders": 22
+    "totalSemanticProviders": 23
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@camunda8/sdk-infra": "^1.3.0",
-        "@commitlint/cli": "^21.0.1",
-        "@commitlint/config-conventional": "^21.0.1",
-        "@semantic-release/changelog": "^6.0.3",
-        "@semantic-release/exec": "^7.0.3",
-        "@semantic-release/git": "^10.0.1",
-        "camunda-schema-bundler": "^2.4.1",
-        "semantic-release": "^25.0.2"
+        "@camunda8/sdk-infra": "1.3.0",
+        "@commitlint/cli": "21.0.1",
+        "@commitlint/config-conventional": "21.0.1",
+        "@semantic-release/changelog": "6.0.3",
+        "@semantic-release/exec": "7.1.0",
+        "@semantic-release/git": "10.0.1",
+        "camunda-schema-bundler": "2.4.3",
+        "semantic-release": "25.0.3"
       }
     },
     "node_modules/@actions/core": {
@@ -1378,9 +1378,9 @@
       }
     },
     "node_modules/camunda-schema-bundler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/camunda-schema-bundler/-/camunda-schema-bundler-2.4.1.tgz",
-      "integrity": "sha512-fG/7I30Nhtb1XPfo1pboAVp9mhO62JIso8XNc9N4AiZk0n2g96ht1bhz0jt27zmD+/b/wXPOGBuYyhzY4bna9w==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/camunda-schema-bundler/-/camunda-schema-bundler-2.4.3.tgz",
+      "integrity": "sha512-UFLczhFGZ2UYXEtoxT5/FEPca+5VDXibbMAF7FLFviqinhAV8HfLs8gPZI6V670DIYVZzq3tdbniWTIeANHjIQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/exec": "7.1.0",
     "@semantic-release/git": "10.0.1",
-    "camunda-schema-bundler": "2.4.1",
+    "camunda-schema-bundler": "2.4.3",
     "semantic-release": "25.0.3"
   }
 }

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -926,6 +926,10 @@ internal static class CSharpClientGenerator
         var underlyingType = GetUnderlyingPrimitiveType(schema, doc);
         var isString = underlyingType == "string";
         var interfaceName = isString ? "global::Camunda.Orchestration.Sdk.ICamundaKey" : "global::Camunda.Orchestration.Sdk.ICamundaLongKey";
+        // ICamundaLongKey mandates a `long` Value and a static AssumeExists(long) factory (the
+        // CamundaLongKeyJsonConverter reflects AssumeExists(long)). Narrower integer primitives
+        // (e.g. int32 IterationId) must be widened to long so the struct satisfies the interface.
+        var valueType = isString ? underlyingType : "long";
         var (pattern, minLength, maxLength) = isString ? GetConstraints(schema, doc) : (null, null, null);
 
         sb.AppendLine($"/// <summary>");
@@ -935,20 +939,20 @@ internal static class CSharpClientGenerator
         sb.AppendLine("{");
 
         // Value property
-        sb.AppendLine($"    /// <summary>The underlying {underlyingType} value.</summary>");
-        sb.AppendLine($"    public {underlyingType} Value {{ get; }}");
+        sb.AppendLine($"    /// <summary>The underlying {valueType} value.</summary>");
+        sb.AppendLine($"    public {valueType} Value {{ get; }}");
         sb.AppendLine();
 
         // Private constructor
-        sb.AppendLine($"    private {typeName}({underlyingType} value) => Value = value;");
+        sb.AppendLine($"    private {typeName}({valueType} value) => Value = value;");
         sb.AppendLine();
 
         // AssumeExists factory
         sb.AppendLine($"    /// <summary>");
-        sb.AppendLine($"    /// Creates a <see cref=\"{typeName}\"/> from a raw {underlyingType} value.");
+        sb.AppendLine($"    /// Creates a <see cref=\"{typeName}\"/> from a raw {valueType} value.");
         sb.AppendLine($"    /// Use this when side-loading values not received from an API call.");
         sb.AppendLine($"    /// </summary>");
-        sb.AppendLine($"    public static {typeName} AssumeExists({underlyingType} value)");
+        sb.AppendLine($"    public static {typeName} AssumeExists({valueType} value)");
         sb.AppendLine("    {");
 
         if (isString)

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -968,6 +968,81 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Create agent instance history item
+    /// Appends a single history item to an agent instance&apos;s conversation history.
+    /// The created item has commitStatus PENDING until the job identified by jobLease
+    /// completes successfully, at which point it transitions to COMMITTED. If the job
+    /// fails or is superseded by a retry, the item is marked DISCARDED.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: createAgentInstanceHistoryItem
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task CreateAgentInstanceHistoryItemExample(
+    ///     AgentInstanceKey agentInstanceKey,
+    ///     ElementInstanceKey elementInstanceKey,
+    ///     JobKey jobKey,
+    ///     string jobLease)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.CreateAgentInstanceHistoryItemAsync(
+    ///         agentInstanceKey,
+    ///         new AgentInstanceHistoryItemRequest
+    ///         {
+    ///             ElementInstanceKey = elementInstanceKey,
+    ///             JobKey = jobKey,
+    ///             JobLease = jobLease,
+    ///             Role = AgentInstanceHistoryRoleEnum.ASSISTANT,
+    ///             Content = new List&lt;AgentInstanceMessageContent&gt;
+    ///             {
+    ///                 new AgentInstanceTextContent { Text = &quot;How can I help you today?&quot; },
+    ///             },
+    ///             ProducedAt = DateTimeOffset.UtcNow,
+    ///         });
+    /// 
+    ///     Console.WriteLine($&quot;Created history item: {result.HistoryItemKey}&quot;);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task CreateAgentInstanceHistoryItemExample(
+    ///     AgentInstanceKey agentInstanceKey,
+    ///     ElementInstanceKey elementInstanceKey,
+    ///     JobKey jobKey,
+    ///     string jobLease)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.CreateAgentInstanceHistoryItemAsync(
+    ///         agentInstanceKey,
+    ///         new AgentInstanceHistoryItemRequest
+    ///         {
+    ///             ElementInstanceKey = elementInstanceKey,
+    ///             JobKey = jobKey,
+    ///             JobLease = jobLease,
+    ///             Role = AgentInstanceHistoryRoleEnum.ASSISTANT,
+    ///             Content = new List&lt;AgentInstanceMessageContent&gt;
+    ///             {
+    ///                 new AgentInstanceTextContent { Text = &quot;How can I help you today?&quot; },
+    ///             },
+    ///             ProducedAt = DateTimeOffset.UtcNow,
+    ///         });
+    /// 
+    ///     Console.WriteLine($&quot;Created history item: {result.HistoryItemKey}&quot;);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<AgentInstanceHistoryItemCreationResult> CreateAgentInstanceHistoryItemAsync(AgentInstanceKey agentInstanceKey, AgentInstanceHistoryItemRequest body, CancellationToken ct = default)
+    {
+        var path = $"/agent-instances/{Uri.EscapeDataString(agentInstanceKey.ToString()!)}/history";
+        return await InvokeWithRetryAsync(() => SendAsync<AgentInstanceHistoryItemCreationResult>(HttpMethod.Post, path, body, ct), "createAgentInstanceHistoryItem", false, ct);
+    }
+
+    /// <summary>
     /// Create authorization
     /// Create the authorization.
     /// </summary>
@@ -5365,6 +5440,84 @@ public partial class CamundaClient
     {
         var path = $"/batch-operations/{Uri.EscapeDataString(batchOperationKey.ToString()!)}/resumption";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Post, path, null, ct); return 0; }, "resumeBatchOperation", false, ct);
+    }
+
+    /// <summary>
+    /// Search agent instance history
+    /// Searches the conversation history of an agent instance. Committed items
+    /// are returned by default.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: searchAgentInstanceHistory
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SearchAgentInstanceHistoryExample(AgentInstanceKey agentInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SearchAgentInstanceHistoryAsync(
+    ///         agentInstanceKey,
+    ///         new AgentInstanceHistorySearchQuery
+    ///         {
+    ///             Sort = new List&lt;AgentInstanceHistorySearchQuerySortRequest&gt;
+    ///             {
+    ///                 new AgentInstanceHistorySearchQuerySortRequest
+    ///                 {
+    ///                     Field = AgentInstanceHistorySearchQuerySortRequestField.ProducedAt,
+    ///                     Order = SortOrderEnum.ASC,
+    ///                 },
+    ///             },
+    ///             Page = new LimitPagination { Limit = 20 },
+    ///         });
+    /// 
+    ///     foreach (var item in result.Items)
+    ///     {
+    ///         Console.WriteLine($&quot;{item.HistoryItemKey} ({item.Role})&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SearchAgentInstanceHistoryExample(AgentInstanceKey agentInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SearchAgentInstanceHistoryAsync(
+    ///         agentInstanceKey,
+    ///         new AgentInstanceHistorySearchQuery
+    ///         {
+    ///             Sort = new List&lt;AgentInstanceHistorySearchQuerySortRequest&gt;
+    ///             {
+    ///                 new AgentInstanceHistorySearchQuerySortRequest
+    ///                 {
+    ///                     Field = AgentInstanceHistorySearchQuerySortRequestField.ProducedAt,
+    ///                     Order = SortOrderEnum.ASC,
+    ///                 },
+    ///             },
+    ///             Page = new LimitPagination { Limit = 20 },
+    ///         });
+    /// 
+    ///     foreach (var item in result.Items)
+    ///     {
+    ///         Console.WriteLine($&quot;{item.HistoryItemKey} ({item.Role})&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<AgentInstanceHistorySearchQueryResult> SearchAgentInstanceHistoryAsync(AgentInstanceKey agentInstanceKey, AgentInstanceHistorySearchQuery body, ConsistencyOptions<AgentInstanceHistorySearchQueryResult>? consistency = null, CancellationToken ct = default)
+    {
+        var path = $"/agent-instances/{Uri.EscapeDataString(agentInstanceKey.ToString()!)}/history/search";
+        if (consistency != null && consistency.WaitUpToMs > 0)
+        {
+            return await EventualPoller.PollAsync("searchAgentInstanceHistory", false,
+                () => InvokeWithRetryAsync(() => SendAsync<AgentInstanceHistorySearchQueryResult>(HttpMethod.Post, path, body, ct), "searchAgentInstanceHistory", false, ct),
+                consistency!, _logger, ct);
+        }
+
+        return await InvokeWithRetryAsync(() => SendAsync<AgentInstanceHistorySearchQueryResult>(HttpMethod.Post, path, body, ct), "searchAgentInstanceHistory", false, ct);
     }
 
     /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -11,16 +11,42 @@ namespace Camunda.Orchestration.Sdk;
 /// The field to sort by.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AgentInstanceHistorySearchQuerySortRequestField
+{
+    [JsonPropertyName("producedAt")]
+    ProducedAt,
+    [JsonPropertyName("historyItemKey")]
+    HistoryItemKey,
+    [JsonPropertyName("iteration")]
+    Iteration,
+}
+
+/// <summary>
+/// The field to sort by.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AgentInstanceSearchQuerySortRequestField
 {
+    [JsonPropertyName("agentInstanceKey")]
+    AgentInstanceKey,
+    [JsonPropertyName("status")]
+    Status,
+    [JsonPropertyName("elementId")]
+    ElementId,
+    [JsonPropertyName("processInstanceKey")]
+    ProcessInstanceKey,
+    [JsonPropertyName("rootProcessInstanceKey")]
+    RootProcessInstanceKey,
+    [JsonPropertyName("processDefinitionKey")]
+    ProcessDefinitionKey,
+    [JsonPropertyName("tenantId")]
+    TenantId,
     [JsonPropertyName("creationDate")]
     CreationDate,
     [JsonPropertyName("lastUpdatedDate")]
     LastUpdatedDate,
     [JsonPropertyName("completionDate")]
     CompletionDate,
-    [JsonPropertyName("status")]
-    Status,
 }
 
 /// <summary>
@@ -521,6 +547,22 @@ public enum ElementInstanceSearchQuerySortRequestField
     IncidentKey,
     [JsonPropertyName("tenantId")]
     TenantId,
+}
+
+/// <summary>
+/// The field to sort by.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ElementInstanceWaitStateQuerySortRequestField
+{
+    [JsonPropertyName("elementInstanceKey")]
+    ElementInstanceKey,
+    [JsonPropertyName("processInstanceKey")]
+    ProcessInstanceKey,
+    [JsonPropertyName("rootProcessInstanceKey")]
+    RootProcessInstanceKey,
+    [JsonPropertyName("elementId")]
+    ElementId,
 }
 
 /// <summary>
@@ -1248,6 +1290,105 @@ public sealed class AdvancedActorTypeFilter
     /// </summary>
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
+/// Advanced AgentHistoryItemKey filter.
+/// </summary>
+public sealed class AdvancedAgentHistoryItemKeyFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public AgentHistoryItemKey? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public AgentHistoryItemKey? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<AgentHistoryItemKey>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches none of the provided values.
+    /// </summary>
+    [JsonPropertyName("$notIn")]
+    public List<AgentHistoryItemKey>? NotIn { get; set; }
+
+}
+
+/// <summary>
+/// Advanced AgentInstanceHistoryCommitStatusEnum filter.
+/// </summary>
+public sealed class AdvancedAgentInstanceHistoryCommitStatusFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public AgentInstanceHistoryCommitStatusEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public AgentInstanceHistoryCommitStatusEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<AgentInstanceHistoryCommitStatusEnum>? In { get; set; }
+
+}
+
+/// <summary>
+/// Advanced AgentInstanceHistoryRoleEnum filter.
+/// </summary>
+public sealed class AdvancedAgentInstanceHistoryRoleFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public AgentInstanceHistoryRoleEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public AgentInstanceHistoryRoleEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<AgentInstanceHistoryRoleEnum>? In { get; set; }
 
 }
 
@@ -3242,6 +3383,99 @@ public sealed class AdvancedWaitStateTypeFilter
 }
 
 /// <summary>
+/// System-generated key for an agent history item.
+/// </summary>
+public readonly record struct AgentHistoryItemKey : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private AgentHistoryItemKey(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="AgentHistoryItemKey"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static AgentHistoryItemKey AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "AgentHistoryItemKey", pattern: "^-?[0-9]+$", minLength: 1, maxLength: 25);
+        return new AgentHistoryItemKey(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: "^-?[0-9]+$", minLength: 1, maxLength: 25);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct AgentHistoryItemKeyExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private AgentHistoryItemKeyExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="AgentHistoryItemKeyExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static AgentHistoryItemKeyExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "AgentHistoryItemKeyExactMatch");
+        return new AgentHistoryItemKeyExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// AgentHistoryItemKey property with full advanced search capabilities.
+/// </summary>
+public sealed class AgentHistoryItemKeyFilterProperty
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public AgentHistoryItemKey? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public AgentHistoryItemKey? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<AgentHistoryItemKey>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches none of the provided values.
+    /// </summary>
+    [JsonPropertyName("$notIn")]
+    public List<AgentHistoryItemKey>? NotIn { get; set; }
+
+}
+
+/// <summary>
 /// Request to create a new agent instance.
 /// </summary>
 public sealed class AgentInstanceCreationRequest
@@ -3310,6 +3544,19 @@ public sealed class AgentInstanceDefinition
 }
 
 /// <summary>
+/// A Camunda Document Store reference content block.
+/// </summary>
+public sealed class AgentInstanceDocumentContent : AgentInstanceMessageContent
+{
+    /// <summary>
+    /// A reference to a document stored in the Camunda Document Store.
+    /// </summary>
+    [JsonPropertyName("documentReference")]
+    public DocumentReference DocumentReference { get; set; } = null!;
+
+}
+
+/// <summary>
 /// Agent instance search filter.
 /// </summary>
 public sealed class AgentInstanceFilter
@@ -3337,6 +3584,15 @@ public sealed class AgentInstanceFilter
     /// </summary>
     [JsonPropertyName("processInstanceKey")]
     public ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The key of the root process instance. Filters agent instances belonging to a specific
+    /// call hierarchy. The root process instance is the top-level ancestor in the process
+    /// instance hierarchy.
+    /// 
+    /// </summary>
+    [JsonPropertyName("rootProcessInstanceKey")]
+    public ProcessInstanceKeyFilterProperty? RootProcessInstanceKey { get; set; }
 
     /// <summary>
     /// The key of the process definition associated with this agent instance.
@@ -3392,6 +3648,456 @@ public sealed class AgentInstanceFilter
     /// </summary>
     [JsonPropertyName("processDefinitionVersionTag")]
     public StringFilterProperty? ProcessDefinitionVersionTag { get; set; }
+
+}
+
+/// <summary>
+/// The commit status of a history item.
+/// COMMITTED: the producing job completed successfully.
+/// PENDING: the producing job is still active (in-flight).
+/// DISCARDED: the producing job failed; this item was superseded by a later activation.
+/// 
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AgentInstanceHistoryCommitStatusEnum
+{
+    [JsonPropertyName("COMMITTED")]
+    COMMITTED,
+    [JsonPropertyName("PENDING")]
+    PENDING,
+    [JsonPropertyName("DISCARDED")]
+    DISCARDED,
+}
+
+/// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct AgentInstanceHistoryCommitStatusExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private AgentInstanceHistoryCommitStatusExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="AgentInstanceHistoryCommitStatusExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static AgentInstanceHistoryCommitStatusExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "AgentInstanceHistoryCommitStatusExactMatch");
+        return new AgentInstanceHistoryCommitStatusExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// AgentInstanceHistoryCommitStatusEnum property with full advanced search capabilities.
+/// </summary>
+public sealed class AgentInstanceHistoryCommitStatusFilterProperty
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public AgentInstanceHistoryCommitStatusEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public AgentInstanceHistoryCommitStatusEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<AgentInstanceHistoryCommitStatusEnum>? In { get; set; }
+
+}
+
+/// <summary>
+/// Agent instance history item search filter.
+/// </summary>
+public sealed class AgentInstanceHistoryFilter
+{
+    /// <summary>
+    /// The unique key of the history item.
+    /// </summary>
+    [JsonPropertyName("historyItemKey")]
+    public AgentHistoryItemKeyFilterProperty? HistoryItemKey { get; set; }
+
+    /// <summary>
+    /// The role of the history item.
+    /// </summary>
+    [JsonPropertyName("role")]
+    public AgentInstanceHistoryRoleFilterProperty? Role { get; set; }
+
+    /// <summary>
+    /// The key of the element instance under which the history item was produced.
+    /// </summary>
+    [JsonPropertyName("elementInstanceKey")]
+    public ElementInstanceKeyFilterProperty? ElementInstanceKey { get; set; }
+
+    /// <summary>
+    /// The key of the job activation that produced the history item.
+    /// </summary>
+    [JsonPropertyName("jobKey")]
+    public JobKeyFilterProperty? JobKey { get; set; }
+
+    /// <summary>
+    /// The iteration number.
+    /// </summary>
+    [JsonPropertyName("iteration")]
+    public IntegerFilterProperty? Iteration { get; set; }
+
+    /// <summary>
+    /// The commit status of the history item. Defaults to COMMITTED only.
+    /// Include PENDING or DISCARDED explicitly to debug in-flight or failed activations.
+    /// 
+    /// </summary>
+    [JsonPropertyName("commitStatus")]
+    public AgentInstanceHistoryCommitStatusFilterProperty? CommitStatus { get; set; }
+
+    /// <summary>
+    /// The timestamp when the history item was produced.
+    /// </summary>
+    [JsonPropertyName("producedAt")]
+    public DateTimeFilterProperty? ProducedAt { get; set; }
+
+}
+
+/// <summary>
+/// Response returned after successfully appending a history item.
+/// </summary>
+public sealed class AgentInstanceHistoryItemCreationResult
+{
+    /// <summary>
+    /// The system-generated key for the created history item.
+    /// </summary>
+    [JsonPropertyName("historyItemKey")]
+    public AgentHistoryItemKey HistoryItemKey { get; set; }
+
+}
+
+/// <summary>
+/// Per-call token and latency metrics for an ASSISTANT history item.
+/// </summary>
+public sealed class AgentInstanceHistoryItemMetrics
+{
+    /// <summary>
+    /// Input tokens consumed by this LLM call.
+    /// </summary>
+    [JsonPropertyName("inputTokens")]
+    public long InputTokens { get; set; }
+
+    /// <summary>
+    /// Output tokens produced by this LLM call.
+    /// </summary>
+    [JsonPropertyName("outputTokens")]
+    public long OutputTokens { get; set; }
+
+    /// <summary>
+    /// Wall-clock duration of the LLM call in milliseconds.
+    /// </summary>
+    [JsonPropertyName("durationMs")]
+    public long DurationMs { get; set; }
+
+}
+
+/// <summary>
+/// Request to append a single history item to an agent instance&apos;s conversation history.
+/// </summary>
+public sealed class AgentInstanceHistoryItemRequest
+{
+    /// <summary>
+    /// The key of the currently-active element instance.
+    /// 
+    /// </summary>
+    [JsonPropertyName("elementInstanceKey")]
+    public ElementInstanceKey ElementInstanceKey { get; set; }
+
+    /// <summary>
+    /// The key of the current job activation during which this history item was produced.
+    /// </summary>
+    [JsonPropertyName("jobKey")]
+    public JobKey JobKey { get; set; }
+
+    /// <summary>
+    /// Opaque lease token received from the job activation response.
+    /// </summary>
+    [JsonPropertyName("jobLease")]
+    public string JobLease { get; set; } = null!;
+
+    /// <summary>
+    /// Sequential iteration number this item belongs to. Omit if not grouping items into iterations.
+    /// </summary>
+    [JsonPropertyName("iteration")]
+    public IterationId? Iteration { get; set; }
+
+    /// <summary>
+    /// The role of this history item in the conversation.
+    /// </summary>
+    [JsonPropertyName("role")]
+    public AgentInstanceHistoryRoleEnum Role { get; set; }
+
+    /// <summary>
+    /// The content blocks of this history item.
+    /// </summary>
+    [JsonPropertyName("content")]
+    public List<AgentInstanceMessageContent> Content { get; set; } = null!;
+
+    /// <summary>
+    /// Tool calls associated with this history item.
+    /// For ASSISTANT items: tool calls dispatched by this LLM response, with arguments populated.
+    /// For TOOL_RESULT items: single-entry array referencing the originating tool call, with arguments null.
+    /// Omit for USER items.
+    /// 
+    /// </summary>
+    [JsonPropertyName("toolCalls")]
+    public List<AgentInstanceToolCall>? ToolCalls { get; set; }
+
+    /// <summary>
+    /// Per-call token and latency metrics. Present on ASSISTANT items only.
+    /// </summary>
+    [JsonPropertyName("metrics")]
+    public AgentInstanceHistoryItemMetrics? Metrics { get; set; }
+
+    /// <summary>
+    /// The connector-side timestamp of when this message was produced.
+    /// </summary>
+    [JsonPropertyName("producedAt")]
+    public DateTimeOffset ProducedAt { get; set; }
+
+}
+
+/// <summary>
+/// A single conversation history item belonging to an agent instance.
+/// </summary>
+public sealed class AgentInstanceHistoryItemResult
+{
+    /// <summary>
+    /// The unique key for this history item. Stable and sortable by creation order.
+    /// </summary>
+    [JsonPropertyName("historyItemKey")]
+    public AgentHistoryItemKey HistoryItemKey { get; set; }
+
+    /// <summary>
+    /// The key of the agent instance this item belongs to.
+    /// </summary>
+    [JsonPropertyName("agentInstanceKey")]
+    public AgentInstanceKey AgentInstanceKey { get; set; }
+
+    /// <summary>
+    /// The key of the AI Agent Task or ad-hoc sub-process element instance under which this item was produced.
+    /// </summary>
+    [JsonPropertyName("elementInstanceKey")]
+    public ElementInstanceKey ElementInstanceKey { get; set; }
+
+    /// <summary>
+    /// The key of the job activation during which this item was produced.
+    /// </summary>
+    [JsonPropertyName("jobKey")]
+    public JobKey JobKey { get; set; }
+
+    /// <summary>
+    /// The lease token of the activation that produced this item.
+    /// </summary>
+    [JsonPropertyName("jobLease")]
+    public string JobLease { get; set; } = null!;
+
+    /// <summary>
+    /// The sequential iteration number this item belongs to. Null if not provided by the connector.
+    /// </summary>
+    [JsonPropertyName("iteration")]
+    public IterationId? Iteration { get; set; }
+
+    /// <summary>
+    /// The role of this history item in the conversation.
+    /// </summary>
+    [JsonPropertyName("role")]
+    public AgentInstanceHistoryRoleEnum Role { get; set; }
+
+    /// <summary>
+    /// The content blocks of this history item.
+    /// </summary>
+    [JsonPropertyName("content")]
+    public List<AgentInstanceMessageContent> Content { get; set; } = null!;
+
+    /// <summary>
+    /// Tool calls for this item. Empty for USER items and ASSISTANT items with no tool dispatches.
+    /// ASSISTANT items: dispatched tool calls with arguments populated.
+    /// TOOL_RESULT items: single-entry array referencing the originating tool call (arguments null).
+    /// 
+    /// </summary>
+    [JsonPropertyName("toolCalls")]
+    public List<AgentInstanceToolCall> ToolCalls { get; set; } = null!;
+
+    /// <summary>
+    /// Per-call token and latency metrics. Present on ASSISTANT items only.
+    /// </summary>
+    [JsonPropertyName("metrics")]
+    public AgentInstanceHistoryItemMetrics? Metrics { get; set; }
+
+    /// <summary>
+    /// The commit status of this history item.
+    /// </summary>
+    [JsonPropertyName("commitStatus")]
+    public AgentInstanceHistoryCommitStatusEnum CommitStatus { get; set; }
+
+    /// <summary>
+    /// The connector-side timestamp of when this message was produced.
+    /// </summary>
+    [JsonPropertyName("producedAt")]
+    public DateTimeOffset ProducedAt { get; set; }
+
+}
+
+/// <summary>
+/// The role of a history item in the agent conversation.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AgentInstanceHistoryRoleEnum
+{
+    [JsonPropertyName("USER")]
+    USER,
+    [JsonPropertyName("ASSISTANT")]
+    ASSISTANT,
+    [JsonPropertyName("TOOL_RESULT")]
+    TOOLRESULT,
+}
+
+/// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct AgentInstanceHistoryRoleExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private AgentInstanceHistoryRoleExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="AgentInstanceHistoryRoleExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static AgentInstanceHistoryRoleExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "AgentInstanceHistoryRoleExactMatch");
+        return new AgentInstanceHistoryRoleExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// AgentInstanceHistoryRoleEnum property with full advanced search capabilities.
+/// </summary>
+public sealed class AgentInstanceHistoryRoleFilterProperty
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public AgentInstanceHistoryRoleEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public AgentInstanceHistoryRoleEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<AgentInstanceHistoryRoleEnum>? In { get; set; }
+
+}
+
+/// <summary>
+/// Agent instance history search request.
+/// </summary>
+public sealed class AgentInstanceHistorySearchQuery
+{
+    /// <summary>
+    /// Sort field criteria.
+    /// </summary>
+    [JsonPropertyName("sort")]
+    public List<AgentInstanceHistorySearchQuerySortRequest>? Sort { get; set; }
+
+    /// <summary>
+    /// The history item search filters.
+    /// </summary>
+    [JsonPropertyName("filter")]
+    public AgentInstanceHistoryFilter? Filter { get; set; }
+
+    /// <summary>
+    /// Pagination criteria.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public SearchQueryPageRequest? Page { get; set; }
+
+}
+
+/// <summary>
+/// Agent instance history search response.
+/// </summary>
+public sealed class AgentInstanceHistorySearchQueryResult
+{
+    /// <summary>
+    /// The matching history items.
+    /// </summary>
+    [JsonPropertyName("items")]
+    public List<AgentInstanceHistoryItemResult> Items { get; set; } = null!;
+
+    /// <summary>
+    /// Pagination information about the search results.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public SearchQueryPageResponse Page { get; set; } = null!;
+
+}
+
+/// <summary>
+/// AgentInstanceHistorySearchQuerySortRequest
+/// </summary>
+public sealed class AgentInstanceHistorySearchQuerySortRequest
+{
+    /// <summary>
+    /// The field to sort by.
+    /// </summary>
+    [JsonPropertyName("field")]
+    public AgentInstanceHistorySearchQuerySortRequestField Field { get; set; }
+
+    /// <summary>
+    /// The order in which to sort the related field.
+    /// </summary>
+    [JsonPropertyName("order")]
+    public SortOrderEnum? Order { get; set; }
 
 }
 
@@ -3514,6 +4220,40 @@ public sealed class AgentInstanceLimits
 }
 
 /// <summary>
+/// A single content block within a history item. Discriminated by `contentType`.
+/// </summary>
+/// <remarks>
+/// Use one of the following concrete types:
+/// <list type="bullet">
+/// <item><description><see cref="AgentInstanceTextContent"/></description></item>
+/// <item><description><see cref="AgentInstanceDocumentContent"/></description></item>
+/// <item><description><see cref="AgentInstanceObjectContent"/></description></item>
+/// </list>
+/// </remarks>
+/// <seealso cref="AgentInstanceTextContent"/>
+/// <seealso cref="AgentInstanceDocumentContent"/>
+/// <seealso cref="AgentInstanceObjectContent"/>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "contentType")]
+[JsonDerivedType(typeof(AgentInstanceTextContent), "TEXT")]
+[JsonDerivedType(typeof(AgentInstanceDocumentContent), "DOCUMENT")]
+[JsonDerivedType(typeof(AgentInstanceObjectContent), "OBJECT")]
+public abstract class AgentInstanceMessageContent { }
+
+/// <summary>
+/// The content type discriminator for a history item content block.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AgentInstanceMessageContentTypeEnum
+{
+    [JsonPropertyName("TEXT")]
+    TEXT,
+    [JsonPropertyName("DOCUMENT")]
+    DOCUMENT,
+    [JsonPropertyName("OBJECT")]
+    OBJECT,
+}
+
+/// <summary>
 /// Aggregated metrics for an agent instance across all model calls.
 /// </summary>
 public sealed class AgentInstanceMetrics
@@ -3575,6 +4315,19 @@ public sealed class AgentInstanceMetricsDelta
     /// </summary>
     [JsonPropertyName("toolCalls")]
     public int? ToolCalls { get; set; }
+
+}
+
+/// <summary>
+/// An arbitrary structured content block.
+/// </summary>
+public sealed class AgentInstanceObjectContent : AgentInstanceMessageContent
+{
+    /// <summary>
+    /// Arbitrary structured content.
+    /// </summary>
+    [JsonPropertyName("object")]
+    public object Object { get; set; } = null!;
 
 }
 
@@ -3850,6 +4603,52 @@ public sealed class AgentInstanceStatusFilterProperty
     /// </summary>
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
+/// A plain-text content block.
+/// </summary>
+public sealed class AgentInstanceTextContent : AgentInstanceMessageContent
+{
+    /// <summary>
+    /// The text content.
+    /// </summary>
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = null!;
+
+}
+
+/// <summary>
+/// A tool call associated with a history item. Used in both ASSISTANT and TOOL_RESULT items.
+/// ASSISTANT items carry arguments; TOOL_RESULT items carry arguments as null.
+/// 
+/// </summary>
+public sealed class AgentInstanceToolCall
+{
+    /// <summary>
+    /// The LLM-assigned tool call ID. Correlates ASSISTANT items to their matching TOOL_RESULT items.
+    /// </summary>
+    [JsonPropertyName("toolCallId")]
+    public string ToolCallId { get; set; } = null!;
+
+    /// <summary>
+    /// The LLM-visible tool name.
+    /// </summary>
+    [JsonPropertyName("toolName")]
+    public string ToolName { get; set; } = null!;
+
+    /// <summary>
+    /// The BPMN element ID handling this tool.
+    /// </summary>
+    [JsonPropertyName("elementId")]
+    public string? ElementId { get; set; }
+
+    /// <summary>
+    /// The tool call arguments as provided by the LLM. Null on TOOL_RESULT items.
+    /// </summary>
+    [JsonPropertyName("arguments")]
+    public object? Arguments { get; set; }
 
 }
 
@@ -10038,6 +10837,12 @@ public sealed class ElementInstanceWaitStateFilter
 public sealed class ElementInstanceWaitStateQuery
 {
     /// <summary>
+    /// Sort field criteria.
+    /// </summary>
+    [JsonPropertyName("sort")]
+    public List<ElementInstanceWaitStateQuerySortRequest>? Sort { get; set; }
+
+    /// <summary>
     /// Filter criteria for the inspection.
     /// </summary>
     [JsonPropertyName("filter")]
@@ -10067,6 +10872,25 @@ public sealed class ElementInstanceWaitStateQueryResult
     /// </summary>
     [JsonPropertyName("page")]
     public SearchQueryPageResponse Page { get; set; } = null!;
+
+}
+
+/// <summary>
+/// ElementInstanceWaitStateQuerySortRequest
+/// </summary>
+public sealed class ElementInstanceWaitStateQuerySortRequest
+{
+    /// <summary>
+    /// The field to sort by.
+    /// </summary>
+    [JsonPropertyName("field")]
+    public ElementInstanceWaitStateQuerySortRequestField Field { get; set; }
+
+    /// <summary>
+    /// The order in which to sort the related field.
+    /// </summary>
+    [JsonPropertyName("order")]
+    public SortOrderEnum? Order { get; set; }
 
 }
 
@@ -12340,6 +13164,33 @@ public sealed class IntegerFilterProperty
     [JsonPropertyName("$in")]
     public List<int>? In { get; set; }
 
+}
+
+/// <summary>
+/// A client-provided sequential integer identifying a logical iteration: one LLM
+/// call, its tool dispatches, and their results. Must be a positive integer,
+/// increasing with each iteration. Established by the
+/// connector when appending the first history item of an iteration.
+/// 
+/// </summary>
+public readonly record struct IterationId : global::Camunda.Orchestration.Sdk.ICamundaLongKey
+{
+    /// <summary>The underlying long value.</summary>
+    public long Value { get; }
+
+    private IterationId(long value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="IterationId"/> from a raw long value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static IterationId AssumeExists(long value)
+    {
+        return new IterationId(value);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
 }
 
 /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:b2ba0d0bc85430aa0146f7430dad7a5e9de916e833676bb97cafd4357f93e8b9";
+    public const string SpecHash = "sha256:9a1790204bd0ebcd617b436f47e470015da360693431dcad2b57725ffef1ffe5";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/CamundaLongKeyContractTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/CamundaLongKeyContractTests.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Guards the <see cref="ICamundaLongKey"/> contract for every generated branded
+/// struct backed by an integer primitive (e.g. IterationId).
+///
+/// Defect class: the generator brands every primitive component schema as a
+/// readonly record struct. Non-string primitives implement <see cref="ICamundaLongKey"/>,
+/// whose <c>Value</c> is <c>long</c> and whose JSON converter
+/// (<c>CamundaLongKeyJsonConverter&lt;T&gt;</c>) reflects a static <c>AssumeExists(long)</c>
+/// factory. A narrower integer primitive (int32) must therefore be widened to <c>long</c>;
+/// emitting <c>int Value</c> / <c>AssumeExists(int)</c> breaks the interface (CS0738) and
+/// the converter at runtime.
+///
+/// This test is class-scoped: it sweeps the whole SDK assembly so any future
+/// integer-typed primitive schema is covered, not just IterationId.
+/// </summary>
+public class CamundaLongKeyContractTests
+{
+    private static IEnumerable<Type> LongKeyStructs() =>
+        typeof(ICamundaLongKey).Assembly
+            .GetTypes()
+            .Where(t => t.IsValueType && typeof(ICamundaLongKey).IsAssignableFrom(t));
+
+    [Fact]
+    public void EveryLongKeyStruct_HasLongValueProperty()
+    {
+        foreach (var type in LongKeyStructs())
+        {
+            var valueProp = type.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(valueProp);
+            Assert.Equal(typeof(long), valueProp!.PropertyType);
+        }
+    }
+
+    [Fact]
+    public void EveryLongKeyStruct_HasStaticAssumeExistsLongFactory()
+    {
+        foreach (var type in LongKeyStructs())
+        {
+            var factory = type.GetMethod(
+                "AssumeExists",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: [typeof(long)],
+                modifiers: null);
+            Assert.NotNull(factory);
+            Assert.Equal(type, factory!.ReturnType);
+        }
+    }
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -65,6 +65,28 @@ TYPE Camunda.Orchestration.Sdk.AdvancedActorTypeFilter : sealed class
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogActorTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
 
+TYPE Camunda.Orchestration.Sdk.AdvancedAgentHistoryItemKeyFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentHistoryItemKey>? In { get; set; } [JsonPropertyName("$in")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentHistoryItemKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
+
+TYPE Camunda.Orchestration.Sdk.AdvancedAgentInstanceHistoryCommitStatusFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.AdvancedAgentInstanceHistoryRoleFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum>? In { get; set; } [JsonPropertyName("$in")]
+
 TYPE Camunda.Orchestration.Sdk.AdvancedAgentInstanceKeyFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceKey? Eq { get; set; } [JsonPropertyName("$eq")]
@@ -445,6 +467,32 @@ TYPE Camunda.Orchestration.Sdk.AdvancedWaitStateTypeFilter : sealed class
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.WaitStateTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
 
+TYPE Camunda.Orchestration.Sdk.AgentHistoryItemKey : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentHistoryItemKey>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.AgentHistoryItemKey other)
+  METHOD static Camunda.Orchestration.Sdk.AgentHistoryItemKey AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.AgentHistoryItemKeyExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentHistoryItemKeyExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.AgentHistoryItemKeyExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.AgentHistoryItemKeyExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.AgentHistoryItemKeyFilterProperty : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentHistoryItemKey>? In { get; set; } [JsonPropertyName("$in")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentHistoryItemKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
+
 TYPE Camunda.Orchestration.Sdk.AgentInstanceCreationRequest : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceDefinition Definition { get; set; } [JsonPropertyName("definition")]
@@ -461,6 +509,10 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceDefinition : sealed class
   PROP System.String Provider { get; set; } [JsonPropertyName("provider")]
   PROP System.String SystemPrompt { get; set; } [JsonPropertyName("systemPrompt")]
 
+TYPE Camunda.Orchestration.Sdk.AgentInstanceDocumentContent : sealed class base=Camunda.Orchestration.Sdk.AgentInstanceMessageContent
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.DocumentReference DocumentReference { get; set; } [JsonPropertyName("documentReference")]
+
 TYPE Camunda.Orchestration.Sdk.AgentInstanceFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceKeyFilterProperty? AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
@@ -472,10 +524,127 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceFilter : sealed class
   PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? ProcessDefinitionVersion { get; set; } [JsonPropertyName("processDefinitionVersion")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? RootProcessInstanceKey { get; set; } [JsonPropertyName("rootProcessInstanceKey")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionVersionTag { get; set; } [JsonPropertyName("processDefinitionVersionTag")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty>? ElementInstanceKeys { get; set; } [JsonPropertyName("elementInstanceKeys")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER COMMITTED = 0 json="COMMITTED"
+  MEMBER PENDING = 1 json="PENDING"
+  MEMBER DISCARDED = 2 json="DISCARDED"
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusFilterProperty : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentHistoryItemKeyFilterProperty? HistoryItemKey { get; set; } [JsonPropertyName("historyItemKey")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusFilterProperty? CommitStatus { get; set; } [JsonPropertyName("commitStatus")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleFilterProperty? Role { get; set; } [JsonPropertyName("role")]
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? ProducedAt { get; set; } [JsonPropertyName("producedAt")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? Iteration { get; set; } [JsonPropertyName("iteration")]
+  PROP Camunda.Orchestration.Sdk.JobKeyFilterProperty? JobKey { get; set; } [JsonPropertyName("jobKey")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemCreationResult : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey HistoryItemKey { get; set; } [JsonPropertyName("historyItemKey")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics : sealed class
+  CTOR ()
+  PROP System.Int64 DurationMs { get; set; } [JsonPropertyName("durationMs")]
+  PROP System.Int64 InputTokens { get; set; } [JsonPropertyName("inputTokens")]
+  PROP System.Int64 OutputTokens { get; set; } [JsonPropertyName("outputTokens")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics? Metrics { get; set; } [JsonPropertyName("metrics")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum Role { get; set; } [JsonPropertyName("role")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.IterationId? Iteration { get; set; } [JsonPropertyName("iteration")]
+  PROP Camunda.Orchestration.Sdk.JobKey JobKey { get; set; } [JsonPropertyName("jobKey")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceMessageContent> Content { get; set; } [JsonPropertyName("content")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceToolCall>? ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
+  PROP System.DateTimeOffset ProducedAt { get; set; } [JsonPropertyName("producedAt")]
+  PROP System.String JobLease { get; set; } [JsonPropertyName("jobLease")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemResult : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey HistoryItemKey { get; set; } [JsonPropertyName("historyItemKey")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum CommitStatus { get; set; } [JsonPropertyName("commitStatus")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics? Metrics { get; set; } [JsonPropertyName("metrics")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum Role { get; set; } [JsonPropertyName("role")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceKey AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.IterationId? Iteration { get; set; } [JsonPropertyName("iteration")]
+  PROP Camunda.Orchestration.Sdk.JobKey JobKey { get; set; } [JsonPropertyName("jobKey")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceMessageContent> Content { get; set; } [JsonPropertyName("content")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceToolCall> ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
+  PROP System.DateTimeOffset ProducedAt { get; set; } [JsonPropertyName("producedAt")]
+  PROP System.String JobLease { get; set; } [JsonPropertyName("jobLease")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER USER = 0 json="USER"
+  MEMBER ASSISTANT = 1 json="ASSISTANT"
+  MEMBER TOOLRESULT = 2 json="TOOL_RESULT"
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleFilterProperty : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQuery : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryFilter? Filter { get; set; } [JsonPropertyName("filter")]
+  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQueryResult : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceHistoryItemResult> Items { get; set; } [JsonPropertyName("items")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQuerySortRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQuerySortRequestField Field { get; set; } [JsonPropertyName("field")]
+  PROP Camunda.Orchestration.Sdk.SortOrderEnum? Order { get; set; } [JsonPropertyName("order")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQuerySortRequestField : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER ProducedAt = 0 json="producedAt"
+  MEMBER HistoryItemKey = 1 json="historyItemKey"
+  MEMBER Iteration = 2 json="iteration"
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceKey : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentInstanceKey>]
   PROP System.String Value { get; }
@@ -509,6 +678,19 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceLimits : sealed class
   PROP System.Int32 MaxToolCalls { get; set; } [JsonPropertyName("maxToolCalls")]
   PROP System.Int64 MaxTokens { get; set; } [JsonPropertyName("maxTokens")]
 
+TYPE Camunda.Orchestration.Sdk.AgentInstanceMessageContent : abstract class
+  ATTR JsonPolymorphic discriminator=contentType
+  ATTR JsonDerivedType Camunda.Orchestration.Sdk.AgentInstanceDocumentContent tag=DOCUMENT
+  ATTR JsonDerivedType Camunda.Orchestration.Sdk.AgentInstanceObjectContent tag=OBJECT
+  ATTR JsonDerivedType Camunda.Orchestration.Sdk.AgentInstanceTextContent tag=TEXT
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceMessageContentTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER TEXT = 0 json="TEXT"
+  MEMBER DOCUMENT = 1 json="DOCUMENT"
+  MEMBER OBJECT = 2 json="OBJECT"
+
 TYPE Camunda.Orchestration.Sdk.AgentInstanceMetrics : sealed class
   CTOR ()
   PROP System.Int32 ModelCalls { get; set; } [JsonPropertyName("modelCalls")]
@@ -522,6 +704,10 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceMetricsDelta : sealed class
   PROP System.Int32? ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
   PROP System.Int64? InputTokens { get; set; } [JsonPropertyName("inputTokens")]
   PROP System.Int64? OutputTokens { get; set; } [JsonPropertyName("outputTokens")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceObjectContent : sealed class base=Camunda.Orchestration.Sdk.AgentInstanceMessageContent
+  CTOR ()
+  PROP System.Object Object { get; set; } [JsonPropertyName("object")]
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceResult : sealed class
   CTOR ()
@@ -563,10 +749,16 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceSearchQuerySortRequest : sealed clas
 TYPE Camunda.Orchestration.Sdk.AgentInstanceSearchQuerySortRequestField : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
   underlying=System.Int32
-  MEMBER CreationDate = 0 json="creationDate"
-  MEMBER LastUpdatedDate = 1 json="lastUpdatedDate"
-  MEMBER CompletionDate = 2 json="completionDate"
-  MEMBER Status = 3 json="status"
+  MEMBER AgentInstanceKey = 0 json="agentInstanceKey"
+  MEMBER Status = 1 json="status"
+  MEMBER ElementId = 2 json="elementId"
+  MEMBER ProcessInstanceKey = 3 json="processInstanceKey"
+  MEMBER RootProcessInstanceKey = 4 json="rootProcessInstanceKey"
+  MEMBER ProcessDefinitionKey = 5 json="processDefinitionKey"
+  MEMBER TenantId = 6 json="tenantId"
+  MEMBER CreationDate = 7 json="creationDate"
+  MEMBER LastUpdatedDate = 8 json="lastUpdatedDate"
+  MEMBER CompletionDate = 9 json="completionDate"
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
@@ -595,6 +787,17 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusFilterProperty : sealed class
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceStatusEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceTextContent : sealed class base=Camunda.Orchestration.Sdk.AgentInstanceMessageContent
+  CTOR ()
+  PROP System.String Text { get; set; } [JsonPropertyName("text")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceToolCall : sealed class
+  CTOR ()
+  PROP System.Object? Arguments { get; set; } [JsonPropertyName("arguments")]
+  PROP System.String ToolCallId { get; set; } [JsonPropertyName("toolCallId")]
+  PROP System.String ToolName { get; set; } [JsonPropertyName("toolName")]
+  PROP System.String? ElementId { get; set; } [JsonPropertyName("elementId")]
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceUpdateRequest : sealed class
   CTOR ()
@@ -1351,6 +1554,8 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task UpdateJobAsync(Camunda.Orchestration.Sdk.JobKey jobKey, Camunda.Orchestration.Sdk.JobUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UpdateUserTaskAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceCreationResult> CreateAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceCreationRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceHistoryItemCreationResult> CreateAgentInstanceHistoryItemAsync(Camunda.Orchestration.Sdk.AgentInstanceKey agentInstanceKey, Camunda.Orchestration.Sdk.AgentInstanceHistoryItemRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQueryResult> SearchAgentInstanceHistoryAsync(Camunda.Orchestration.Sdk.AgentInstanceKey agentInstanceKey, Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceResult> GetAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceKey agentInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AgentInstanceResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceSearchQueryResult> SearchAgentInstancesAsync(Camunda.Orchestration.Sdk.AgentInstanceSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AgentInstanceSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AuditLogResult> GetAuditLogAsync(Camunda.Orchestration.Sdk.AuditLogKey auditLogKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AuditLogResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -2655,11 +2860,25 @@ TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateQuery : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ElementInstanceWaitStateFilter? Filter { get; set; } [JsonPropertyName("filter")]
   PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementInstanceWaitStateQuerySortRequest>? Sort { get; set; } [JsonPropertyName("sort")]
 
 TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateQueryResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementInstanceWaitStateResult> Items { get; set; } [JsonPropertyName("items")]
+
+TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateQuerySortRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.ElementInstanceWaitStateQuerySortRequestField Field { get; set; } [JsonPropertyName("field")]
+  PROP Camunda.Orchestration.Sdk.SortOrderEnum? Order { get; set; } [JsonPropertyName("order")]
+
+TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateQuerySortRequestField : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER ElementInstanceKey = 0 json="elementInstanceKey"
+  MEMBER ProcessInstanceKey = 1 json="processInstanceKey"
+  MEMBER RootProcessInstanceKey = 2 json="rootProcessInstanceKey"
+  MEMBER ElementId = 3 json="elementId"
 
 TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateResult : sealed class
   CTOR ()
@@ -3320,6 +3539,14 @@ TYPE Camunda.Orchestration.Sdk.IntegerFilterProperty : sealed class
   PROP System.Int32? Lt { get; set; } [JsonPropertyName("$lt")]
   PROP System.Int32? Lte { get; set; } [JsonPropertyName("$lte")]
   PROP System.Int32? Neq { get; set; } [JsonPropertyName("$neq")]
+
+TYPE Camunda.Orchestration.Sdk.IterationId : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaLongKey,System.IEquatable<Camunda.Orchestration.Sdk.IterationId>]
+  PROP System.Int64 Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.IterationId other)
+  METHOD static Camunda.Orchestration.Sdk.IterationId AssumeExists(System.Int64 value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.JobActivationRequest : sealed class interfaces=[Camunda.Orchestration.Sdk.ITenantIdsSettable]
   CTOR ()


### PR DESCRIPTION
## What

Bumps `camunda-schema-bundler` `2.4.1` -> `2.4.3` and regenerates the SDK against the current upstream spec, adding examples for two new agent-instance-history operations.

### Changes

- **`fix(deps)`** — bump `camunda-schema-bundler` to `2.4.3`. The 2.4.3 fix excludes non-string-typed semantic keys from the union metadata (`semanticKeys=41`).
- **`fix`** — generator: widen integer-backed branded structs to `long` so they satisfy the `ICamundaLongKey` contract. Upstream added `IterationId` (an `int32`-typed branded key); the generator previously emitted `int Value`, but `ICamundaLongKey` mandates `long Value` (CS0738). Added a class-scoped reflection guard test (`CamundaLongKeyContractTests`) asserting **every** `ICamundaLongKey` struct exposes `long Value` and a static `AssumeExists(long)` factory.
- **`docs`** — add examples for `createAgentInstanceHistoryItem` and `searchAgentInstanceHistory` (operation-map at 100% coverage).
- **`chore(gen)`** — regenerated `Generated/*`, bundled spec, and the public API baseline.

## Why

Mirrors the JS rollout (camunda/orchestration-cluster-api-js#259). The bundler bump alone would have broken C# release CI: regenerating against the current upstream spec surfaces `IterationId`, which does not compile without the generator fix.

## How tested

- `dotnet build` green
- 1035/1035 unit tests pass (net8.0 + net10.0)
- `dotnet format --verify-no-changes` exit 0
- `check-example-coverage` 100%