### PR TITLE
fix: adopt upstream wait-state details union to unblock main build

### DIFF
--- a/examples/VariableElement.cs
+++ b/examples/VariableElement.cs
@@ -134,7 +134,13 @@ public static class VariableElementExamples
 
         foreach (var waitState in result.Items)
         {
-            Console.WriteLine($"{waitState.ElementId}: {waitState.WaitStateType}");
+            var details = waitState.Details switch
+            {
+                JobWaitStateDetails job => $"waiting on job '{job.JobType}'",
+                MessageWaitStateDetails message => $"waiting for message '{message.MessageName}'",
+                _ => "waiting",
+            };
+            Console.WriteLine($"{waitState.ElementId}: {details}");
         }
     }
     // </SearchElementInstanceWaitStates>

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -20254,6 +20254,8 @@
           "entityKey",
           "entityType",
           "formKey",
+          "inboundChannelToolName",
+          "inboundChannelType",
           "jobKey",
           "operationType",
           "processDefinitionId",
@@ -20496,8 +20498,28 @@
             "type": "string",
             "description": "Additional description of the entity affected by the operation.\nFor example, for variable operations, this will contain the variable name.\n",
             "nullable": true
+          },
+          "inboundChannelType": {
+            "type": "string",
+            "description": "The type of the inbound channel that triggered the operation (e.g. MCP).",
+            "nullable": true
+          },
+          "inboundChannelToolName": {
+            "type": "string",
+            "description": "The tool name of the inbound channel (e.g. the MCP tool that triggered the operation).",
+            "nullable": true
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "inboundChannelType",
+            "addedInVersion": "8.10"
+          },
+          {
+            "propertyName": "inboundChannelToolName",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "AuditLogSearchQuerySortRequest": {
         "type": "object",
@@ -20526,6 +20548,8 @@
               "processDefinitionId",
               "processDefinitionKey",
               "processInstanceKey",
+              "inboundChannelType",
+              "inboundChannelToolName",
               "result",
               "tenantId",
               "timestamp",
@@ -20802,8 +20826,34 @@
                 "$ref": "#/components/schemas/StringFilterProperty"
               }
             ]
+          },
+          "inboundChannelType": {
+            "description": "The inbound channel type search filter (e.g. MCP).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ]
+          },
+          "inboundChannelToolName": {
+            "description": "The inbound channel tool name search filter.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ]
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "inboundChannelType",
+            "addedInVersion": "8.10"
+          },
+          {
+            "propertyName": "inboundChannelToolName",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "AuditLogSearchQueryResult": {
         "description": "Audit log search response.",
@@ -26427,25 +26477,15 @@
         "description": "An element instance waiting state.",
         "type": "object",
         "required": [
+          "details",
           "elementId",
           "elementInstanceKey",
           "elementType",
-          "jobDetails",
-          "messageDetails",
           "processInstanceKey",
           "rootProcessInstanceKey",
-          "tenantId",
-          "waitStateType"
+          "tenantId"
         ],
         "properties": {
-          "waitStateType": {
-            "description": "The type of waiting state an element instance is in.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/WaitStateTypeEnum"
-              }
-            ]
-          },
           "rootProcessInstanceKey": {
             "description": "Key of the root process instance.",
             "nullable": true,
@@ -26495,25 +26535,34 @@
               }
             ]
           },
-          "jobDetails": {
-            "description": "Job details, present when waitStateType is JOB.",
-            "nullable": true,
+          "details": {
+            "description": "Wait-state-specific details, resolved by waitStateType.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/JobWaitStateDetails"
-              }
-            ]
-          },
-          "messageDetails": {
-            "description": "Message details, present when waitStateType is MESSAGE.",
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MessageWaitStateDetails"
+                "$ref": "#/components/schemas/WaitStateDetails"
               }
             ]
           }
         }
+      },
+      "WaitStateDetails": {
+        "x-polymorphic-schema": true,
+        "description": "Wait-state-specific details of an element instance.",
+        "discriminator": {
+          "propertyName": "waitStateType",
+          "mapping": {
+            "JOB": "#/components/schemas/JobWaitStateDetails",
+            "MESSAGE": "#/components/schemas/MessageWaitStateDetails"
+          }
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/JobWaitStateDetails"
+          },
+          {
+            "$ref": "#/components/schemas/MessageWaitStateDetails"
+          }
+        ]
       },
       "WaitStateTypeEnum": {
         "description": "The type of waiting state an element instance is in.",
@@ -26523,6 +26572,19 @@
           "MESSAGE"
         ]
       },
+      "BaseWaitStateDetails": {
+        "description": "Common fields shared by all wait-state details variants.",
+        "type": "object",
+        "required": [
+          "waitStateType"
+        ],
+        "properties": {
+          "waitStateType": {
+            "description": "The wait state type discriminator.",
+            "type": "string"
+          }
+        }
+      },
       "JobWaitStateDetails": {
         "type": "object",
         "required": [
@@ -26530,7 +26592,13 @@
           "jobKind",
           "jobType",
           "listenerEventType",
-          "retries"
+          "retries",
+          "waitStateType"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseWaitStateDetails"
+          }
         ],
         "properties": {
           "jobKey": {
@@ -26574,7 +26642,13 @@
         "type": "object",
         "required": [
           "correlationKey",
-          "messageName"
+          "messageName",
+          "waitStateType"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseWaitStateDetails"
+          }
         ],
         "properties": {
           "messageName": {

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:61f14b16b2e19192bcdb9b0748d03729298cdfad7fdf9c72fd177ffa82d57a56",
+  "specHash": "sha256:f89b800d7e8f2358254a1f389803e1bd146426b4fb71ec83cec33c9ecde234e8",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -2171,6 +2171,22 @@
         }
       ],
       "stableId": "variable-key-filter-property"
+    },
+    {
+      "name": "WaitStateDetails",
+      "kind": "union-wrapper",
+      "description": "Wait-state-specific details of an element instance.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "JobWaitStateDetails"
+        },
+        {
+          "branchType": "ref",
+          "ref": "MessageWaitStateDetails"
+        }
+      ],
+      "stableId": "wait-state-details"
     },
     {
       "name": "WaitStateElementTypeFilterProperty",
@@ -9615,7 +9631,7 @@
   ],
   "integrity": {
     "totalSemanticKeys": 41,
-    "totalUnions": 63,
+    "totalUnions": 64,
     "totalOperations": 193,
     "totalEventuallyConsistent": 90,
     "totalDeprecatedEnumSchemas": 2,

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -93,6 +93,10 @@ public enum AuditLogSearchQuerySortRequestField
     ProcessDefinitionKey,
     [JsonPropertyName("processInstanceKey")]
     ProcessInstanceKey,
+    [JsonPropertyName("inboundChannelType")]
+    InboundChannelType,
+    [JsonPropertyName("inboundChannelToolName")]
+    InboundChannelToolName,
     [JsonPropertyName("result")]
     Result,
     [JsonPropertyName("tenantId")]
@@ -5169,6 +5173,18 @@ public sealed class AuditLogFilter
     [JsonPropertyName("entityDescription")]
     public StringFilterProperty? EntityDescription { get; set; }
 
+    /// <summary>
+    /// The inbound channel type search filter (e.g. MCP).
+    /// </summary>
+    [JsonPropertyName("inboundChannelType")]
+    public StringFilterProperty? InboundChannelType { get; set; }
+
+    /// <summary>
+    /// The inbound channel tool name search filter.
+    /// </summary>
+    [JsonPropertyName("inboundChannelToolName")]
+    public StringFilterProperty? InboundChannelToolName { get; set; }
+
 }
 
 /// <summary>
@@ -5499,6 +5515,18 @@ public sealed class AuditLogResult
     /// </summary>
     [JsonPropertyName("entityDescription")]
     public string? EntityDescription { get; set; }
+
+    /// <summary>
+    /// The type of the inbound channel that triggered the operation (e.g. MCP).
+    /// </summary>
+    [JsonPropertyName("inboundChannelType")]
+    public string? InboundChannelType { get; set; }
+
+    /// <summary>
+    /// The tool name of the inbound channel (e.g. the MCP tool that triggered the operation).
+    /// </summary>
+    [JsonPropertyName("inboundChannelToolName")]
+    public string? InboundChannelToolName { get; set; }
 
 }
 
@@ -6071,6 +6099,19 @@ public sealed class BaseProcessInstanceFilterFields
     /// </summary>
     [JsonPropertyName("businessId")]
     public StringFilterProperty? BusinessId { get; set; }
+
+}
+
+/// <summary>
+/// Common fields shared by all wait-state details variants.
+/// </summary>
+public sealed class BaseWaitStateDetails
+{
+    /// <summary>
+    /// The wait state type discriminator.
+    /// </summary>
+    [JsonPropertyName("waitStateType")]
+    public string WaitStateType { get; set; } = null!;
 
 }
 
@@ -10900,12 +10941,6 @@ public sealed class ElementInstanceWaitStateQuerySortRequest
 public sealed class ElementInstanceWaitStateResult
 {
     /// <summary>
-    /// The type of waiting state an element instance is in.
-    /// </summary>
-    [JsonPropertyName("waitStateType")]
-    public WaitStateTypeEnum WaitStateType { get; set; }
-
-    /// <summary>
     /// Key of the root process instance.
     /// </summary>
     [JsonPropertyName("rootProcessInstanceKey")]
@@ -10942,16 +10977,10 @@ public sealed class ElementInstanceWaitStateResult
     public TenantId TenantId { get; set; }
 
     /// <summary>
-    /// Job details, present when waitStateType is JOB.
+    /// Wait-state-specific details, resolved by waitStateType.
     /// </summary>
-    [JsonPropertyName("jobDetails")]
-    public JobWaitStateDetails? JobDetails { get; set; }
-
-    /// <summary>
-    /// Message details, present when waitStateType is MESSAGE.
-    /// </summary>
-    [JsonPropertyName("messageDetails")]
-    public MessageWaitStateDetails? MessageDetails { get; set; }
+    [JsonPropertyName("details")]
+    public WaitStateDetails Details { get; set; } = null!;
 
 }
 
@@ -14658,7 +14687,7 @@ public sealed class JobUpdateRequest
 /// <summary>
 /// JobWaitStateDetails
 /// </summary>
-public sealed class JobWaitStateDetails
+public sealed class JobWaitStateDetails : WaitStateDetails
 {
     /// <summary>
     /// The key of the job.
@@ -15983,7 +16012,7 @@ public sealed class MessageSubscriptionTypeFilterProperty
 /// <summary>
 /// MessageWaitStateDetails
 /// </summary>
-public sealed class MessageWaitStateDetails
+public sealed class MessageWaitStateDetails : WaitStateDetails
 {
     /// <summary>
     /// The name of the message being awaited.
@@ -21973,6 +22002,23 @@ public sealed class VariableValueFilterProperty
     public StringFilterProperty Value { get; set; } = null!;
 
 }
+
+/// <summary>
+/// Wait-state-specific details of an element instance.
+/// </summary>
+/// <remarks>
+/// Use one of the following concrete types:
+/// <list type="bullet">
+/// <item><description><see cref="JobWaitStateDetails"/></description></item>
+/// <item><description><see cref="MessageWaitStateDetails"/></description></item>
+/// </list>
+/// </remarks>
+/// <seealso cref="JobWaitStateDetails"/>
+/// <seealso cref="MessageWaitStateDetails"/>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "waitStateType")]
+[JsonDerivedType(typeof(JobWaitStateDetails), "JOB")]
+[JsonDerivedType(typeof(MessageWaitStateDetails), "MESSAGE")]
+public abstract class WaitStateDetails { }
 
 /// <summary>
 /// The BPMN element type of a waiting element instance.

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:61f14b16b2e19192bcdb9b0748d03729298cdfad7fdf9c72fd177ffa82d57a56";
+    public const string SpecHash = "sha256:f89b800d7e8f2358254a1f389803e1bd146426b4fb71ec83cec33c9ecde234e8";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -932,6 +932,8 @@ TYPE Camunda.Orchestration.Sdk.AuditLogFilter : sealed class
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? DecisionDefinitionId { get; set; } [JsonPropertyName("decisionDefinitionId")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? DecisionRequirementsId { get; set; } [JsonPropertyName("decisionRequirementsId")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? EntityDescription { get; set; } [JsonPropertyName("entityDescription")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? InboundChannelToolName { get; set; } [JsonPropertyName("inboundChannelToolName")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? InboundChannelType { get; set; } [JsonPropertyName("inboundChannelType")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? TenantId { get; set; } [JsonPropertyName("tenantId")]
 
@@ -1012,6 +1014,8 @@ TYPE Camunda.Orchestration.Sdk.AuditLogResult : sealed class
   PROP System.String? AgentElementId { get; set; } [JsonPropertyName("agentElementId")]
   PROP System.String? DecisionRequirementsId { get; set; } [JsonPropertyName("decisionRequirementsId")]
   PROP System.String? EntityDescription { get; set; } [JsonPropertyName("entityDescription")]
+  PROP System.String? InboundChannelToolName { get; set; } [JsonPropertyName("inboundChannelToolName")]
+  PROP System.String? InboundChannelType { get; set; } [JsonPropertyName("inboundChannelType")]
 
 TYPE Camunda.Orchestration.Sdk.AuditLogResultEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
@@ -1074,10 +1078,12 @@ TYPE Camunda.Orchestration.Sdk.AuditLogSearchQuerySortRequestField : enum interf
   MEMBER ProcessDefinitionId = 16 json="processDefinitionId"
   MEMBER ProcessDefinitionKey = 17 json="processDefinitionKey"
   MEMBER ProcessInstanceKey = 18 json="processInstanceKey"
-  MEMBER Result = 19 json="result"
-  MEMBER TenantId = 20 json="tenantId"
-  MEMBER Timestamp = 21 json="timestamp"
-  MEMBER UserTaskKey = 22 json="userTaskKey"
+  MEMBER InboundChannelType = 19 json="inboundChannelType"
+  MEMBER InboundChannelToolName = 20 json="inboundChannelToolName"
+  MEMBER Result = 21 json="result"
+  MEMBER TenantId = 22 json="tenantId"
+  MEMBER Timestamp = 23 json="timestamp"
+  MEMBER UserTaskKey = 24 json="userTaskKey"
 
 TYPE Camunda.Orchestration.Sdk.AuthConfig : sealed class
   CTOR ()
@@ -1212,6 +1218,10 @@ TYPE Camunda.Orchestration.Sdk.BaseProcessInstanceFilterFields : sealed class
   PROP System.Boolean? HasRetriesLeft { get; set; } [JsonPropertyName("hasRetriesLeft")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.Tag>? Tags { get; set; } [JsonPropertyName("tags")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableValueFilterProperty>? Variables { get; set; } [JsonPropertyName("variables")]
+
+TYPE Camunda.Orchestration.Sdk.BaseWaitStateDetails : sealed class
+  CTOR ()
+  PROP System.String WaitStateType { get; set; } [JsonPropertyName("waitStateType")]
 
 TYPE Camunda.Orchestration.Sdk.BasicAuthConfig : sealed class
   CTOR ()
@@ -2885,13 +2895,11 @@ TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ElementId ElementId { get; set; } [JsonPropertyName("elementId")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
-  PROP Camunda.Orchestration.Sdk.JobWaitStateDetails? JobDetails { get; set; } [JsonPropertyName("jobDetails")]
-  PROP Camunda.Orchestration.Sdk.MessageWaitStateDetails? MessageDetails { get; set; } [JsonPropertyName("messageDetails")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? RootProcessInstanceKey { get; set; } [JsonPropertyName("rootProcessInstanceKey")]
   PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
+  PROP Camunda.Orchestration.Sdk.WaitStateDetails Details { get; set; } [JsonPropertyName("details")]
   PROP Camunda.Orchestration.Sdk.WaitStateElementTypeEnum ElementType { get; set; } [JsonPropertyName("elementType")]
-  PROP Camunda.Orchestration.Sdk.WaitStateTypeEnum WaitStateType { get; set; } [JsonPropertyName("waitStateType")]
 
 TYPE Camunda.Orchestration.Sdk.EndCursor : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.EndCursor>]
   PROP System.String Value { get; }
@@ -3922,7 +3930,7 @@ TYPE Camunda.Orchestration.Sdk.JobUpdateRequest : sealed class
   PROP Camunda.Orchestration.Sdk.JobChangeset Changeset { get; set; } [JsonPropertyName("changeset")]
   PROP Camunda.Orchestration.Sdk.OperationReference? OperationReference { get; set; } [JsonPropertyName("operationReference")]
 
-TYPE Camunda.Orchestration.Sdk.JobWaitStateDetails : sealed class
+TYPE Camunda.Orchestration.Sdk.JobWaitStateDetails : sealed class base=Camunda.Orchestration.Sdk.WaitStateDetails
   CTOR ()
   PROP Camunda.Orchestration.Sdk.JobKey JobKey { get; set; } [JsonPropertyName("jobKey")]
   PROP Camunda.Orchestration.Sdk.JobKindEnum JobKind { get; set; } [JsonPropertyName("jobKind")]
@@ -4285,7 +4293,7 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionTypeFilterProperty : sealed cl
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
 
-TYPE Camunda.Orchestration.Sdk.MessageWaitStateDetails : sealed class
+TYPE Camunda.Orchestration.Sdk.MessageWaitStateDetails : sealed class base=Camunda.Orchestration.Sdk.WaitStateDetails
   CTOR ()
   PROP System.String MessageName { get; set; } [JsonPropertyName("messageName")]
   PROP System.String? CorrelationKey { get; set; } [JsonPropertyName("correlationKey")]
@@ -5940,6 +5948,11 @@ TYPE Camunda.Orchestration.Sdk.VariableValueFilterProperty : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.StringFilterProperty Value { get; set; } [JsonPropertyName("value")]
   PROP System.String Name { get; set; } [JsonPropertyName("name")]
+
+TYPE Camunda.Orchestration.Sdk.WaitStateDetails : abstract class
+  ATTR JsonPolymorphic discriminator=waitStateType
+  ATTR JsonDerivedType Camunda.Orchestration.Sdk.JobWaitStateDetails tag=JOB
+  ATTR JsonDerivedType Camunda.Orchestration.Sdk.MessageWaitStateDetails tag=MESSAGE
 
 TYPE Camunda.Orchestration.Sdk.WaitStateElementTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter


### PR DESCRIPTION
## Problem

Every `main`-targeted PR (including all open dependabot PRs) was failing CI at the **Build Examples** step:

```
examples/VariableElement.cs: error CS1061:
'ElementInstanceWaitStateResult' does not contain a definition for 'WaitStateType'
```

This is **not** a dependency problem. CI regenerates the SDK from the live upstream spec on every run (`.github/workflows/ci.yml` → *Fetch & Bundle spec* + *Generate SDK*), then builds the hand-written examples against that fresh output. Upstream `camunda/camunda@main` restructured `ElementInstanceWaitStateResult`:

| Before (committed) | After (upstream now) |
|---|---|
| `…, waitStateType, jobDetails, messageDetails` | `…, details` |

`waitStateType`/`jobDetails`/`messageDetails` were collapsed into a single polymorphic `details` (`WaitStateDetails`) union with `JOB`/`MESSAGE` subtypes. The committed example still referenced `waitState.WaitStateType`, so it stopped compiling against the regenerated SDK — failing identically on every PR branched off `main`.

## Fix

- Regenerate `Generated/` + bundled spec against current upstream `main`.
- Rewrite the `SearchElementInstanceWaitStates` example to switch on the `JobWaitStateDetails` / `MessageWaitStateDetails` subtypes.
- Refresh the public API baseline (`PublicApi.shipped.txt`) for the new surface.

## Verification (local)

- ✅ `dotnet build` SDK + `docs/examples/Examples.csproj` (Release)
- ✅ Unit tests: 1065 passed, 0 failed (incl. `PublicApiSurface_MatchesShippedBaseline`)
- ✅ `check-example-coverage.js` — full coverage
- ✅ `check-overwrite-completeness.js` — all checks pass
- ✅ README snippet sync — up to date

## Notes

- This unblocks **all** open `main`-targeted dependabot PRs, which were red for this same reason (not their dependency).
- The public surface changes (`WaitStateType` removed; `Details` + `WaitStateDetails`/`JobWaitStateDetails`/`MessageWaitStateDetails` added), so the **breaking-change-guard** may flag it — this is the SDK tracking an intentional upstream change (pre-GA, `9.0.0-alpha`).
- The sibling **JS** and **Python** SDKs have the same stale example (`waitStateType` / `wait_state_type`) and regenerate from the same spec, so they will need equivalent fixes in their own repos. Go and Java do not appear to generate this operation and look unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)