### PR TITLE
fix(gen): suppress discriminator-only oneOf union base types

### DIFF
--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -547,6 +547,30 @@ internal static class CSharpClientGenerator
             }
         }
 
+        // A base used directly as an operation parameter, request body, or response
+        // schema is a genuine use too — walk the paths so it is not suppressed.
+        if (doc.Paths != null)
+        {
+            foreach (var (_, pathItem) in doc.Paths)
+            {
+                if (pathItem.Operations is not { } pathOps)
+                    continue;
+                foreach (var (_, op) in pathOps)
+                {
+                    foreach (var p in op.Parameters ?? (IList<IOpenApiParameter>)Array.Empty<IOpenApiParameter>())
+                        Collect(p.Schema);
+                    if (op.RequestBody?.Content != null)
+                        foreach (var (_, mt) in op.RequestBody.Content)
+                            Collect(mt.Schema);
+                    if (op.Responses != null)
+                        foreach (var (_, resp) in op.Responses)
+                            if (resp.Content != null)
+                                foreach (var (_, mt) in resp.Content)
+                                    Collect(mt.Schema);
+                }
+            }
+        }
+
         foreach (var c in candidates)
         {
             if (referencedElsewhere.Contains(c))

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -450,6 +450,107 @@ internal static class CSharpClientGenerator
     }
 
     /// <summary>
+    /// Identifies component schemas that exist only to carry the discriminator of a
+    /// <c>oneOf</c> polymorphic union. Each variant pulls such a base in via
+    /// <c>allOf</c>, but the generator folds those fields into the variant and makes
+    /// it inherit the abstract union parent (with the discriminator handled by
+    /// <c>[JsonPolymorphic]</c>). Emitting the base as a standalone type therefore
+    /// produces an unused, confusing public class (e.g. <c>BaseWaitStateDetails</c>).
+    /// A base is reported only when it is referenced exclusively as the <c>allOf</c>
+    /// base of union variants and nowhere else, so genuinely-shared bases are kept.
+    /// </summary>
+    private static HashSet<string> ComputeOrphanUnionBases(
+        OpenApiDocument doc,
+        Dictionary<string, List<string>> oneOfParents,
+        Dictionary<string, string> variantToParent,
+        HashSet<string> requestSchemaNames)
+    {
+        var orphans = new HashSet<string>(StringComparer.Ordinal);
+        if (doc.Components?.Schemas == null)
+            return orphans;
+
+        // Candidate bases: schemas pulled in via the top-level allOf of a union variant.
+        var candidates = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (name, schema) in doc.Components.Schemas)
+        {
+            if (!variantToParent.ContainsKey(SanitizeTypeName(name)))
+                continue;
+            foreach (var allOf in schema.AllOf ?? [])
+            {
+                var refId = GetRefId(allOf);
+                if (refId != null)
+                    candidates.Add(SanitizeTypeName(refId));
+            }
+        }
+        if (candidates.Count == 0)
+            return orphans;
+
+        // Collect every schema reference EXCEPT a union variant's top-level allOf base;
+        // any such reference is a "real" use that disqualifies suppression.
+        var referencedElsewhere = new HashSet<string>(StringComparer.Ordinal);
+        void Collect(IOpenApiSchema? s)
+        {
+            if (s == null)
+                return;
+            // A $ref node is a proxy that forwards member access to its target. Record
+            // the reference and stop — the target component is walked on its own in the
+            // outer loop, where the union-variant allOf exclusion is applied. Recursing
+            // here would traverse into the target and defeat that exclusion.
+            var rid = GetRefId(s);
+            if (rid != null)
+            {
+                referencedElsewhere.Add(SanitizeTypeName(rid));
+                return;
+            }
+            if (s.Properties != null)
+                foreach (var p in s.Properties.Values)
+                    Collect(p);
+            Collect(s.Items);
+            foreach (var v in s.OneOf ?? [])
+                Collect(v);
+            foreach (var v in s.AnyOf ?? [])
+                Collect(v);
+            foreach (var a in s.AllOf ?? [])
+                Collect(a);
+        }
+
+        foreach (var (name, schema) in doc.Components.Schemas)
+        {
+            var isVariant = variantToParent.ContainsKey(SanitizeTypeName(name));
+            if (schema.Properties != null)
+                foreach (var p in schema.Properties.Values)
+                    Collect(p);
+            Collect(schema.Items);
+            foreach (var v in schema.OneOf ?? [])
+                Collect(v);
+            foreach (var v in schema.AnyOf ?? [])
+                Collect(v);
+            foreach (var a in schema.AllOf ?? [])
+            {
+                // A union variant's top-level `allOf: [{$ref: base}]` is the only
+                // suppressible reference — skip it; count every other allOf usage.
+                if (isVariant && GetRefId(a) != null)
+                    continue;
+                Collect(a);
+            }
+        }
+
+        foreach (var c in candidates)
+        {
+            if (referencedElsewhere.Contains(c))
+                continue;                       // used as a real type somewhere → keep
+            if (requestSchemaNames.Contains(c))
+                continue;                       // used directly as a request body → keep
+            if (oneOfParents.ContainsKey(c))
+                continue;                       // it is itself a union parent → keep
+            if (variantToParent.ContainsKey(c))
+                continue;                       // it is itself a union variant → keep
+            orphans.Add(c);
+        }
+        return orphans;
+    }
+
+    /// <summary>
     /// For an inline oneOf body schema, find a matching component oneOf schema
     /// by comparing the required fields of inline variants to component variants.
     /// </summary>
@@ -590,6 +691,7 @@ internal static class CSharpClientGenerator
             return sb.ToString();
 
         var (oneOfParents, variantToParent, discriminators) = BuildOneOfMaps(doc);
+        var orphanUnionBases = ComputeOrphanUnionBases(doc, oneOfParents, variantToParent, requestSchemaNames);
 
         // Collect inline string enum properties across all schemas so we can
         // emit them as typed enums and reference them in property declarations.
@@ -607,6 +709,11 @@ internal static class CSharpClientGenerator
 
             // Skip array-type component schemas — they are resolved inline in MapType
             if (SchemaTypeName(schema) == "array")
+                continue;
+
+            // Skip discriminator-only bases of a oneOf union: their fields are folded
+            // into each variant, so emitting them yields an unused public type.
+            if (orphanUnionBases.Contains(typeName))
                 continue;
 
             // Union of semantic keys — generate with implicit conversion operators and cross-type equality

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -463,30 +463,42 @@ internal static class CSharpClientGenerator
         OpenApiDocument doc,
         Dictionary<string, List<string>> oneOfParents,
         Dictionary<string, string> variantToParent,
+        Dictionary<string, (string PropertyName, Dictionary<string, string> ValueToVariant)> discriminators,
         HashSet<string> requestSchemaNames)
     {
         var orphans = new HashSet<string>(StringComparer.Ordinal);
         if (doc.Components?.Schemas == null)
             return orphans;
 
-        // Candidate bases: schemas pulled in via the top-level allOf of a union variant.
+        // Candidate bases: schemas pulled in via a union variant's top-level allOf that
+        // are *discriminator-only* — i.e. their sole property is the union's
+        // discriminator. A composed mixin that contributes real fields is NOT a
+        // candidate (its fields matter), so it is never suppressed here.
         var candidates = new HashSet<string>(StringComparer.Ordinal);
         foreach (var (name, schema) in doc.Components.Schemas)
         {
-            if (!variantToParent.ContainsKey(SanitizeTypeName(name)))
+            if (!variantToParent.TryGetValue(SanitizeTypeName(name), out var parent))
                 continue;
+            if (!discriminators.TryGetValue(parent, out var disc))
+                continue;   // no discriminator → cannot identify a discriminator-only base
             foreach (var allOf in schema.AllOf ?? [])
             {
                 var refId = GetRefId(allOf);
-                if (refId != null)
+                if (refId == null)
+                    continue;
+                if (doc.Components.Schemas.TryGetValue(refId, out var baseSchema)
+                    && IsDiscriminatorOnlyBase(baseSchema, disc.PropertyName))
+                {
                     candidates.Add(SanitizeTypeName(refId));
+                }
             }
         }
         if (candidates.Count == 0)
             return orphans;
 
-        // Collect every schema reference EXCEPT a union variant's top-level allOf base;
-        // any such reference is a "real" use that disqualifies suppression.
+        // Collect every schema reference EXCEPT a variant's allOf ref to one of the
+        // discriminator-only bases above; any other reference (including a variant's
+        // allOf ref to a real mixin) is a genuine use that disqualifies suppression.
         var referencedElsewhere = new HashSet<string>(StringComparer.Ordinal);
         void Collect(IOpenApiSchema? s)
         {
@@ -494,7 +506,7 @@ internal static class CSharpClientGenerator
                 return;
             // A $ref node is a proxy that forwards member access to its target. Record
             // the reference and stop — the target component is walked on its own in the
-            // outer loop, where the union-variant allOf exclusion is applied. Recursing
+            // outer loop, where the discriminator-base exclusion is applied. Recursing
             // here would traverse into the target and defeat that exclusion.
             var rid = GetRefId(s);
             if (rid != null)
@@ -527,9 +539,9 @@ internal static class CSharpClientGenerator
                 Collect(v);
             foreach (var a in schema.AllOf ?? [])
             {
-                // A union variant's top-level `allOf: [{$ref: base}]` is the only
-                // suppressible reference — skip it; count every other allOf usage.
-                if (isVariant && GetRefId(a) != null)
+                // Only a variant's allOf ref to a discriminator-only base is suppressible;
+                // skip exactly those and count everything else (e.g. composed mixins).
+                if (isVariant && GetRefId(a) is { } rid && candidates.Contains(SanitizeTypeName(rid)))
                     continue;
                 Collect(a);
             }
@@ -549,6 +561,18 @@ internal static class CSharpClientGenerator
         }
         return orphans;
     }
+
+    /// <summary>
+    /// True when <paramref name="schema"/> is a plain object whose only property is the
+    /// union discriminator <paramref name="discriminatorProperty"/> and which composes
+    /// nothing else — i.e. it exists purely to carry the discriminator.
+    /// </summary>
+    private static bool IsDiscriminatorOnlyBase(IOpenApiSchema schema, string discriminatorProperty)
+        => (schema.AllOf is null || schema.AllOf.Count == 0)
+            && (schema.OneOf is null || schema.OneOf.Count == 0)
+            && (schema.AnyOf is null || schema.AnyOf.Count == 0)
+            && schema.Properties is { Count: 1 }
+            && schema.Properties.ContainsKey(discriminatorProperty);
 
     /// <summary>
     /// For an inline oneOf body schema, find a matching component oneOf schema
@@ -691,7 +715,7 @@ internal static class CSharpClientGenerator
             return sb.ToString();
 
         var (oneOfParents, variantToParent, discriminators) = BuildOneOfMaps(doc);
-        var orphanUnionBases = ComputeOrphanUnionBases(doc, oneOfParents, variantToParent, requestSchemaNames);
+        var orphanUnionBases = ComputeOrphanUnionBases(doc, oneOfParents, variantToParent, discriminators, requestSchemaNames);
 
         // Collect inline string enum properties across all schemas so we can
         // emit them as typed enums and reference them in property declarations.

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -6103,19 +6103,6 @@ public sealed class BaseProcessInstanceFilterFields
 }
 
 /// <summary>
-/// Common fields shared by all wait-state details variants.
-/// </summary>
-public sealed class BaseWaitStateDetails
-{
-    /// <summary>
-    /// The wait state type discriminator.
-    /// </summary>
-    [JsonPropertyName("waitStateType")]
-    public string WaitStateType { get; set; } = null!;
-
-}
-
-/// <summary>
 /// Basic advanced string filter.
 /// </summary>
 public sealed class BasicStringFilter

--- a/test/Camunda.Orchestration.Sdk.Tests/GeneratorSafeEmitTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/GeneratorSafeEmitTests.cs
@@ -529,6 +529,11 @@ public class GeneratorSafeEmitTests
 
         // A base referenced outside the union (Garage.spec) is preserved.
         Assert.Contains("class BaseVehicle", models);
+
+        // A shared mixin composed via a variant's allOf (alongside the discriminator
+        // base) carries real fields, so it is NOT a discriminator-only base and must be
+        // preserved — even though it is only referenced through that variant's allOf.
+        Assert.Contains("class Timestamped", models);
     }
 
     // Two discriminated oneOf unions, each with an allOf base carrying only the
@@ -558,8 +563,9 @@ public class GeneratorSafeEmitTests
                 "oneOf": [ { "$ref": "#/components/schemas/Cat" }, { "$ref": "#/components/schemas/Dog" } ]
               },
               "BasePet": { "type": "object", "required": ["petType"], "properties": { "petType": { "type": "string" } } },
-              "Cat": { "type": "object", "required": ["petType", "meow"], "allOf": [ { "$ref": "#/components/schemas/BasePet" } ], "properties": { "meow": { "type": "string" } } },
+              "Cat": { "type": "object", "required": ["petType", "meow"], "allOf": [ { "$ref": "#/components/schemas/BasePet" }, { "$ref": "#/components/schemas/Timestamped" } ], "properties": { "meow": { "type": "string" } } },
               "Dog": { "type": "object", "required": ["petType", "bark"], "allOf": [ { "$ref": "#/components/schemas/BasePet" } ], "properties": { "bark": { "type": "string" } } },
+              "Timestamped": { "type": "object", "required": ["createdAt"], "properties": { "createdAt": { "type": "string" }, "updatedAt": { "type": "string" } } },
               "Vehicle": {
                 "discriminator": { "propertyName": "vehicleType", "mapping": { "CAR": "#/components/schemas/Car", "TRUCK": "#/components/schemas/Truck" } },
                 "oneOf": [ { "$ref": "#/components/schemas/Car" }, { "$ref": "#/components/schemas/Truck" } ]

--- a/test/Camunda.Orchestration.Sdk.Tests/GeneratorSafeEmitTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/GeneratorSafeEmitTests.cs
@@ -503,6 +503,76 @@ public class GeneratorSafeEmitTests
         }
     }
 
+    [Fact]
+    public void Generator_suppresses_discriminator_only_union_base_but_keeps_referenced_bases()
+    {
+        // A schema that exists only as the allOf base of a oneOf union's variants
+        // (carrying just the discriminator) must NOT be emitted as a standalone public
+        // type — its fields are folded into each variant and the variant inherits the
+        // abstract union parent. A base that is ALSO referenced elsewhere (e.g. as a
+        // property type) must still be emitted.
+        using var tmp = TempDir.Create();
+        File.WriteAllText(tmp.SpecPath, OrphanUnionBaseSpec);
+        File.WriteAllText(tmp.MetadataPath, MinimalBundledSpec.MinimalMetadata);
+
+        CSharpClientGenerator.Generate(tmp.SpecPath, tmp.MetadataPath, tmp.OutputDir);
+
+        var models = File.ReadAllText(Path.Combine(tmp.OutputDir, "Models.Generated.cs"));
+
+        // Orphan discriminator-only base is suppressed.
+        Assert.DoesNotContain("class BasePet", models);
+
+        // Union parent + variants are still emitted.
+        Assert.Contains("abstract class Pet", models);
+        Assert.Contains("class Cat : Pet", models);
+        Assert.Contains("class Dog : Pet", models);
+
+        // A base referenced outside the union (Garage.spec) is preserved.
+        Assert.Contains("class BaseVehicle", models);
+    }
+
+    // Two discriminated oneOf unions, each with an allOf base carrying only the
+    // discriminator. BasePet is referenced solely by the Pet variants (orphan →
+    // suppressed); BaseVehicle is also referenced by Garage.spec (→ kept).
+    private const string OrphanUnionBaseSpec = """
+        {
+          "openapi": "3.0.3",
+          "info": { "title": "Test", "version": "1.0.0" },
+          "paths": {
+            "/pets": {
+              "get": {
+                "operationId": "listPets",
+                "responses": {
+                  "200": {
+                    "description": "ok",
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } } }
+                  }
+                }
+              }
+            }
+          },
+          "components": {
+            "schemas": {
+              "Pet": {
+                "discriminator": { "propertyName": "petType", "mapping": { "CAT": "#/components/schemas/Cat", "DOG": "#/components/schemas/Dog" } },
+                "oneOf": [ { "$ref": "#/components/schemas/Cat" }, { "$ref": "#/components/schemas/Dog" } ]
+              },
+              "BasePet": { "type": "object", "required": ["petType"], "properties": { "petType": { "type": "string" } } },
+              "Cat": { "type": "object", "required": ["petType", "meow"], "allOf": [ { "$ref": "#/components/schemas/BasePet" } ], "properties": { "meow": { "type": "string" } } },
+              "Dog": { "type": "object", "required": ["petType", "bark"], "allOf": [ { "$ref": "#/components/schemas/BasePet" } ], "properties": { "bark": { "type": "string" } } },
+              "Vehicle": {
+                "discriminator": { "propertyName": "vehicleType", "mapping": { "CAR": "#/components/schemas/Car", "TRUCK": "#/components/schemas/Truck" } },
+                "oneOf": [ { "$ref": "#/components/schemas/Car" }, { "$ref": "#/components/schemas/Truck" } ]
+              },
+              "BaseVehicle": { "type": "object", "required": ["vehicleType"], "properties": { "vehicleType": { "type": "string" } } },
+              "Car": { "type": "object", "required": ["vehicleType", "doors"], "allOf": [ { "$ref": "#/components/schemas/BaseVehicle" } ], "properties": { "doors": { "type": "integer" } } },
+              "Truck": { "type": "object", "required": ["vehicleType", "axles"], "allOf": [ { "$ref": "#/components/schemas/BaseVehicle" } ], "properties": { "axles": { "type": "integer" } } },
+              "Garage": { "type": "object", "properties": { "spec": { "$ref": "#/components/schemas/BaseVehicle" } } }
+            }
+          }
+        }
+        """;
+
     /// <summary>
     /// Roslyn structural assertion (follow-up item 3 from the security finding):
     /// parse the generated source and verify that only the expected top-level

--- a/test/Camunda.Orchestration.Sdk.Tests/GeneratorSafeEmitTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/GeneratorSafeEmitTests.cs
@@ -534,6 +534,10 @@ public class GeneratorSafeEmitTests
         // base) carries real fields, so it is NOT a discriminator-only base and must be
         // preserved — even though it is only referenced through that variant's allOf.
         Assert.Contains("class Timestamped", models);
+
+        // A discriminator-only base referenced only via an operation response body
+        // (BaseShape, returned by GET /shapes/base) is a genuine use and must be kept.
+        Assert.Contains("class BaseShape", models);
     }
 
     // Two discriminated oneOf unions, each with an allOf base carrying only the
@@ -551,6 +555,17 @@ public class GeneratorSafeEmitTests
                   "200": {
                     "description": "ok",
                     "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } } }
+                  }
+                }
+              }
+            },
+            "/shapes/base": {
+              "get": {
+                "operationId": "getShapeBase",
+                "responses": {
+                  "200": {
+                    "description": "ok",
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/BaseShape" } } }
                   }
                 }
               }
@@ -573,7 +588,14 @@ public class GeneratorSafeEmitTests
               "BaseVehicle": { "type": "object", "required": ["vehicleType"], "properties": { "vehicleType": { "type": "string" } } },
               "Car": { "type": "object", "required": ["vehicleType", "doors"], "allOf": [ { "$ref": "#/components/schemas/BaseVehicle" } ], "properties": { "doors": { "type": "integer" } } },
               "Truck": { "type": "object", "required": ["vehicleType", "axles"], "allOf": [ { "$ref": "#/components/schemas/BaseVehicle" } ], "properties": { "axles": { "type": "integer" } } },
-              "Garage": { "type": "object", "properties": { "spec": { "$ref": "#/components/schemas/BaseVehicle" } } }
+              "Garage": { "type": "object", "properties": { "spec": { "$ref": "#/components/schemas/BaseVehicle" } } },
+              "Shape": {
+                "discriminator": { "propertyName": "shapeType", "mapping": { "BOX": "#/components/schemas/Box", "SPHERE": "#/components/schemas/Sphere" } },
+                "oneOf": [ { "$ref": "#/components/schemas/Box" }, { "$ref": "#/components/schemas/Sphere" } ]
+              },
+              "BaseShape": { "type": "object", "required": ["shapeType"], "properties": { "shapeType": { "type": "string" } } },
+              "Box": { "type": "object", "required": ["shapeType"], "allOf": [ { "$ref": "#/components/schemas/BaseShape" } ], "properties": { "width": { "type": "integer" } } },
+              "Sphere": { "type": "object", "required": ["shapeType"], "allOf": [ { "$ref": "#/components/schemas/BaseShape" } ], "properties": { "radius": { "type": "integer" } } }
             }
           }
         }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -1219,10 +1219,6 @@ TYPE Camunda.Orchestration.Sdk.BaseProcessInstanceFilterFields : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.Tag>? Tags { get; set; } [JsonPropertyName("tags")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableValueFilterProperty>? Variables { get; set; } [JsonPropertyName("variables")]
 
-TYPE Camunda.Orchestration.Sdk.BaseWaitStateDetails : sealed class
-  CTOR ()
-  PROP System.String WaitStateType { get; set; } [JsonPropertyName("waitStateType")]
-
 TYPE Camunda.Orchestration.Sdk.BasicAuthConfig : sealed class
   CTOR ()
   PROP System.String? Password { get; init; }


### PR DESCRIPTION
Closes #255.

## Problem

The generator emitted the `allOf` base of a discriminated `oneOf` union as a standalone public type even though nothing referenced it. Concretely, `BaseWaitStateDetails` was generated as a public `sealed class` carrying only the `waitStateType` discriminator, but:

- no property uses it;
- `JobWaitStateDetails` / `MessageWaitStateDetails` inherit from the abstract union type `WaitStateDetails`, not from `BaseWaitStateDetails`;
- the discriminator is already handled by `[JsonPolymorphic(TypeDiscriminatorPropertyName = "waitStateType")]`.

So it was dead, confusing public surface (flagged by the Copilot reviewer on #254).

## Fix

Add `ComputeOrphanUnionBases` to `CSharpClientGenerator`. A component schema is suppressed only when it is referenced **exclusively** as the `allOf` base of `oneOf`-union variants and nowhere else (property type, body, array item, `oneOf`/`anyOf` variant, or `allOf` base of a non-variant). This preserves genuinely-shared bases — e.g. `BaseProcessInstanceFilterFields`, which is used for `$or` filter composition.

Implementation note: Microsoft.OpenApi's `OpenApiSchemaReference` is a proxy that forwards member access to its target, so the reference-collection walker records a `$ref` and **stops** rather than recursing through it — otherwise it would traverse into a variant's `allOf` and defeat the exclusion.

## Changes

- `CSharpClientGenerator.cs` — `ComputeOrphanUnionBases` + emit-loop skip.
- `Models.Generated.cs` — regenerated; `BaseWaitStateDetails` removed (only change).
- `PublicApi.shipped.txt` — baseline refreshed for the removed type.
- `GeneratorSafeEmitTests.cs` — regression test: a two-union synthetic spec asserting the orphan base (`BasePet`) is suppressed while a base referenced elsewhere (`BaseVehicle`, via `Garage.spec`) is kept, and the union parent/variants are emitted.

## Verification (local)

- ✅ Generator builds; regeneration removes only `BaseWaitStateDetails` and keeps `BaseProcessInstanceFilterFields`.
- ✅ Unit tests: 1065 passed, 0 failed (incl. the new test + `PublicApiSurface_MatchesShippedBaseline`).
- ✅ `check-example-coverage.js` / `check-overwrite-completeness.js` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)