### PR TITLE
chore(gen): regenerate for user-task wait-state spec additions

### DIFF
--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -4398,7 +4398,7 @@
           }
         ],
         "summary": "Deploy resources",
-        "description": "Deploys one or more resources (e.g. processes, decision models, or forms).\nThis is an atomic call, i.e. either all resources are deployed or none of them are.\n",
+        "description": "Deploys one or more resources, including BPMN processes, DMN decision models, forms, RPA resources, and generic files.\nA deployment can contain any file type. Files that are not interpreted as BPMN, DMN, form, or RPA resources are stored as deployable generic resources in the engine.\nThis is an atomic call, i.e. either all resources are deployed or none of them are.\n",
         "requestBody": {
           "required": true,
           "content": {
@@ -26477,6 +26477,7 @@
         "description": "An element instance waiting state.",
         "type": "object",
         "required": [
+          "bpmnProcessId",
           "details",
           "elementId",
           "elementInstanceKey",
@@ -26535,6 +26536,10 @@
               }
             ]
           },
+          "bpmnProcessId": {
+            "description": "The BPMN process ID of the process definition associated to this element instance.",
+            "type": "string"
+          },
           "details": {
             "description": "Wait-state-specific details, resolved by waitStateType.",
             "allOf": [
@@ -26552,7 +26557,8 @@
           "propertyName": "waitStateType",
           "mapping": {
             "JOB": "#/components/schemas/JobWaitStateDetails",
-            "MESSAGE": "#/components/schemas/MessageWaitStateDetails"
+            "MESSAGE": "#/components/schemas/MessageWaitStateDetails",
+            "USER_TASK": "#/components/schemas/UserTaskWaitStateDetails"
           }
         },
         "oneOf": [
@@ -26561,6 +26567,9 @@
           },
           {
             "$ref": "#/components/schemas/MessageWaitStateDetails"
+          },
+          {
+            "$ref": "#/components/schemas/UserTaskWaitStateDetails"
           }
         ]
       },
@@ -26569,7 +26578,8 @@
         "type": "string",
         "enum": [
           "JOB",
-          "MESSAGE"
+          "MESSAGE",
+          "USER_TASK"
         ]
       },
       "BaseWaitStateDetails": {
@@ -26659,6 +26669,35 @@
             "description": "The correlation key for the message subscription (null for start events).",
             "nullable": true,
             "type": "string"
+          }
+        }
+      },
+      "UserTaskWaitStateDetails": {
+        "type": "object",
+        "required": [
+          "dueDate",
+          "taskKey",
+          "waitStateType"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseWaitStateDetails"
+          }
+        ],
+        "properties": {
+          "taskKey": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserTaskKey"
+              }
+            ],
+            "description": "The key of the user task."
+          },
+          "dueDate": {
+            "description": "The due date of the user task, if set.",
+            "nullable": true,
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
@@ -32853,7 +32892,7 @@
         ]
       },
       "MessageSubscriptionStateEnum": {
-        "description": "The state of message subscription.",
+        "description": "The state of message subscription.\n\n**Note for `START_EVENT` subscriptions:** The `CORRELATED` and `MIGRATED` states are not\ntracked for these subscriptions. To query correlation history for process start events,\nuse the `/correlated-message-subscriptions/search` endpoint.\n",
         "type": "string",
         "enum": [
           "CORRELATED",

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:770d623d4c5488aa1faedcad52f8e04711ee1ccfa3db6bd85a4d15b1a3ddc4d0",
+  "specHash": "sha256:26f2149071b5d3b472ac5cbebadeed03e4eac7ee29f5f90cb2d9f54fd2f0c16a",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -2184,6 +2184,10 @@
         {
           "branchType": "ref",
           "ref": "MessageWaitStateDetails"
+        },
+        {
+          "branchType": "ref",
+          "ref": "UserTaskWaitStateDetails"
         }
       ],
       "stableId": "wait-state-details"
@@ -4353,7 +4357,7 @@
         "Resource"
       ],
       "summary": "Deploy resources",
-      "description": "Deploys one or more resources (e.g. processes, decision models, or forms).\nThis is an atomic call, i.e. either all resources are deployed or none of them are.\n",
+      "description": "Deploys one or more resources, including BPMN processes, DMN decision models, forms, RPA resources, and generic files.\nA deployment can contain any file type. Files that are not interpreted as BPMN, DMN, form, or RPA resources are stored as deployable generic resources in the engine.\nThis is an atomic call, i.e. either all resources are deployed or none of them are.\n",
       "eventuallyConsistent": false,
       "hasRequestBody": true,
       "requestBodyUnion": false,

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -1095,7 +1095,8 @@ public partial class CamundaClient
 
     /// <summary>
     /// Deploy resources
-    /// Deploys one or more resources (e.g. processes, decision models, or forms).
+    /// Deploys one or more resources, including BPMN processes, DMN decision models, forms, RPA resources, and generic files.
+    /// A deployment can contain any file type. Files that are not interpreted as BPMN, DMN, form, or RPA resources are stored as deployable generic resources in the engine.
     /// This is an atomic call, i.e. either all resources are deployed or none of them are.
     /// 
     /// </summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -10964,6 +10964,12 @@ public sealed class ElementInstanceWaitStateResult
     public TenantId TenantId { get; set; }
 
     /// <summary>
+    /// The BPMN process ID of the process definition associated to this element instance.
+    /// </summary>
+    [JsonPropertyName("bpmnProcessId")]
+    public string BpmnProcessId { get; set; } = null!;
+
+    /// <summary>
     /// Wait-state-specific details, resolved by waitStateType.
     /// </summary>
     [JsonPropertyName("details")]
@@ -15676,6 +15682,11 @@ public sealed class MessageSubscriptionResult
 
     /// <summary>
     /// The state of message subscription.
+    /// 
+    /// **Note for `START_EVENT` subscriptions:** The `CORRELATED` and `MIGRATED` states are not
+    /// tracked for these subscriptions. To query correlation history for process start events,
+    /// use the `/correlated-message-subscriptions/search` endpoint.
+    /// 
     /// </summary>
     [JsonPropertyName("messageSubscriptionState")]
     public MessageSubscriptionStateEnum MessageSubscriptionState { get; set; }
@@ -15819,6 +15830,11 @@ public sealed class MessageSubscriptionSearchQuerySortRequest
 
 /// <summary>
 /// The state of message subscription.
+/// 
+/// **Note for `START_EVENT` subscriptions:** The `CORRELATED` and `MIGRATED` states are not
+/// tracked for these subscriptions. To query correlation history for process start events,
+/// use the `/correlated-message-subscriptions/search` endpoint.
+/// 
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MessageSubscriptionStateEnum
@@ -21528,6 +21544,25 @@ public sealed class UserTaskVariableSearchQuerySortRequest
 }
 
 /// <summary>
+/// UserTaskWaitStateDetails
+/// </summary>
+public sealed class UserTaskWaitStateDetails : WaitStateDetails
+{
+    /// <summary>
+    /// The key of the user task.
+    /// </summary>
+    [JsonPropertyName("taskKey")]
+    public UserTaskKey TaskKey { get; set; }
+
+    /// <summary>
+    /// The due date of the user task, if set.
+    /// </summary>
+    [JsonPropertyName("dueDate")]
+    public DateTimeOffset? DueDate { get; set; }
+
+}
+
+/// <summary>
 /// UserUpdateRequest
 /// </summary>
 public sealed class UserUpdateRequest
@@ -21998,13 +22033,16 @@ public sealed class VariableValueFilterProperty
 /// <list type="bullet">
 /// <item><description><see cref="JobWaitStateDetails"/></description></item>
 /// <item><description><see cref="MessageWaitStateDetails"/></description></item>
+/// <item><description><see cref="UserTaskWaitStateDetails"/></description></item>
 /// </list>
 /// </remarks>
 /// <seealso cref="JobWaitStateDetails"/>
 /// <seealso cref="MessageWaitStateDetails"/>
+/// <seealso cref="UserTaskWaitStateDetails"/>
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "waitStateType")]
 [JsonDerivedType(typeof(JobWaitStateDetails), "JOB")]
 [JsonDerivedType(typeof(MessageWaitStateDetails), "MESSAGE")]
+[JsonDerivedType(typeof(UserTaskWaitStateDetails), "USER_TASK")]
 public abstract class WaitStateDetails { }
 
 /// <summary>
@@ -22152,6 +22190,8 @@ public enum WaitStateTypeEnum
     JOB,
     [JsonPropertyName("MESSAGE")]
     MESSAGE,
+    [JsonPropertyName("USER_TASK")]
+    USERTASK,
 }
 
 /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:770d623d4c5488aa1faedcad52f8e04711ee1ccfa3db6bd85a4d15b1a3ddc4d0";
+    public const string SpecHash = "sha256:26f2149071b5d3b472ac5cbebadeed03e4eac7ee29f5f90cb2d9f54fd2f0c16a";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -2896,6 +2896,7 @@ TYPE Camunda.Orchestration.Sdk.ElementInstanceWaitStateResult : sealed class
   PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP Camunda.Orchestration.Sdk.WaitStateDetails Details { get; set; } [JsonPropertyName("details")]
   PROP Camunda.Orchestration.Sdk.WaitStateElementTypeEnum ElementType { get; set; } [JsonPropertyName("elementType")]
+  PROP System.String BpmnProcessId { get; set; } [JsonPropertyName("bpmnProcessId")]
 
 TYPE Camunda.Orchestration.Sdk.EndCursor : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.EndCursor>]
   PROP System.String Value { get; }
@@ -5793,6 +5794,11 @@ TYPE Camunda.Orchestration.Sdk.UserTaskVariableSearchQuerySortRequestField : enu
   MEMBER ScopeKey = 4 json="scopeKey"
   MEMBER ProcessInstanceKey = 5 json="processInstanceKey"
 
+TYPE Camunda.Orchestration.Sdk.UserTaskWaitStateDetails : sealed class base=Camunda.Orchestration.Sdk.WaitStateDetails
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.UserTaskKey TaskKey { get; set; } [JsonPropertyName("taskKey")]
+  PROP System.DateTimeOffset? DueDate { get; set; } [JsonPropertyName("dueDate")]
+
 TYPE Camunda.Orchestration.Sdk.UserUpdateRequest : sealed class
   CTOR ()
   PROP System.String? Email { get; set; } [JsonPropertyName("email")]
@@ -5949,6 +5955,7 @@ TYPE Camunda.Orchestration.Sdk.WaitStateDetails : abstract class
   ATTR JsonPolymorphic discriminator=waitStateType
   ATTR JsonDerivedType Camunda.Orchestration.Sdk.JobWaitStateDetails tag=JOB
   ATTR JsonDerivedType Camunda.Orchestration.Sdk.MessageWaitStateDetails tag=MESSAGE
+  ATTR JsonDerivedType Camunda.Orchestration.Sdk.UserTaskWaitStateDetails tag=USER_TASK
 
 TYPE Camunda.Orchestration.Sdk.WaitStateElementTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
@@ -6003,6 +6010,7 @@ TYPE Camunda.Orchestration.Sdk.WaitStateTypeEnum : enum interfaces=[System.IComp
   underlying=System.Int32
   MEMBER JOB = 0 json="JOB"
   MEMBER MESSAGE = 1 json="MESSAGE"
+  MEMBER USERTASK = 2 json="USER_TASK"
 
 TYPE Camunda.Orchestration.Sdk.WaitStateTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.WaitStateTypeExactMatch>]
   PROP System.String Value { get; }


### PR DESCRIPTION
## What

Refreshes the generated SDK + public-API baseline against the current upstream OpenAPI spec, resolving the **Public API drift** CI failure.

## Why

CI fetches the latest `camunda/camunda` spec on every run, regenerates, and runs the `PublicApiSurfaceTests` lock test. Upstream added **user-task wait-state** support after the last baseline refresh, so the checked-in `PublicApi.shipped.txt` no longer matched the regenerated surface — failing on any branch regardless of its own changes.

> Note: this is distinct from the `IterationId`/`ICamundaLongKey` int-vs-long generator bug, which was already fixed on `main`.

## Surface added (additive, backward-compatible)

| Type | Addition |
| --- | --- |
| `ElementInstanceWaitStateResult` | `BpmnProcessId` (`string`) |
| **new** `UserTaskWaitStateDetails : WaitStateDetails` | `TaskKey` (`UserTaskKey`), `DueDate` (`DateTimeOffset?`) |
| `WaitStateDetails` | polymorphic subtype `JsonDerivedType … tag=USER_TASK` |
| `WaitStateTypeEnum` | `USERTASK = 2` (`json="USER_TASK"`) |

No removals or signature changes.

## Contents

Pure spec-driven regeneration (no generator source change):
- `external-spec/bundled/*` — refreshed spec snapshot + hash
- `src/Camunda.Orchestration.Sdk/Generated/*` — regenerated output
- `test/.../PublicApi.shipped.txt` — refreshed baseline

## Verification

- `dotnet build` ✅
- `dotnet format --verify-no-changes` ✅
- `PublicApiSurfaceTests` ✅
- Full unit suite: 1068 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)