### PR TITLE
feat: regenerate SDK for upstream wait-state details and job priority-updated state

### DIFF
--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -19944,8 +19944,7 @@
             }
           },
           "metrics": {
-            "description": "Per-call token and latency metrics. Present on ASSISTANT items only.",
-            "nullable": true,
+            "description": "Per-call token and latency metrics. Zero-valued when not available.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/AgentInstanceHistoryItemMetrics"
@@ -26558,7 +26557,9 @@
           "mapping": {
             "JOB": "#/components/schemas/JobWaitStateDetails",
             "MESSAGE": "#/components/schemas/MessageWaitStateDetails",
-            "USER_TASK": "#/components/schemas/UserTaskWaitStateDetails"
+            "USER_TASK": "#/components/schemas/UserTaskWaitStateDetails",
+            "TIMER": "#/components/schemas/TimerWaitStateDetails",
+            "SIGNAL": "#/components/schemas/SignalWaitStateDetails"
           }
         },
         "oneOf": [
@@ -26570,6 +26571,12 @@
           },
           {
             "$ref": "#/components/schemas/UserTaskWaitStateDetails"
+          },
+          {
+            "$ref": "#/components/schemas/TimerWaitStateDetails"
+          },
+          {
+            "$ref": "#/components/schemas/SignalWaitStateDetails"
           }
         ]
       },
@@ -26579,7 +26586,9 @@
         "enum": [
           "JOB",
           "MESSAGE",
-          "USER_TASK"
+          "USER_TASK",
+          "TIMER",
+          "SIGNAL"
         ]
       },
       "BaseWaitStateDetails": {
@@ -26700,6 +26709,52 @@
             "format": "date-time"
           }
         }
+      },
+      "TimerWaitStateDetails": {
+        "type": "object",
+        "required": [
+          "dueDate",
+          "repetitions",
+          "waitStateType"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseWaitStateDetails"
+          }
+        ],
+        "properties": {
+          "dueDate": {
+            "description": "When the timer is due, as a UNIX epoch timestamp in milliseconds.",
+            "nullable": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          "repetitions": {
+            "description": "The number of remaining timer repetitions (-1 for infinite, 0 for non-repeating).",
+            "nullable": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "SignalWaitStateDetails": {
+        "type": "object",
+        "required": [
+          "signalName",
+          "waitStateType"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseWaitStateDetails"
+          }
+        ],
+        "properties": {
+          "signalName": {
+            "description": "The name of the signal being awaited.",
+            "type": "string"
+          }
+        },
+        "x-added-in-version": "8.10"
       },
       "AdHocSubProcessActivateActivityReference": {
         "type": "object",
@@ -30592,6 +30647,7 @@
           "ERROR_THROWN",
           "FAILED",
           "MIGRATED",
+          "PRIORITY_UPDATED",
           "RETRIES_UPDATED",
           "TIMED_OUT"
         ]

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:26f2149071b5d3b472ac5cbebadeed03e4eac7ee29f5f90cb2d9f54fd2f0c16a",
+  "specHash": "sha256:49625da077b57255a2b40d23f9df017147d77cd72a4b4f59b2dcb60b52f81934",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -2188,6 +2188,14 @@
         {
           "branchType": "ref",
           "ref": "UserTaskWaitStateDetails"
+        },
+        {
+          "branchType": "ref",
+          "ref": "TimerWaitStateDetails"
+        },
+        {
+          "branchType": "ref",
+          "ref": "SignalWaitStateDetails"
         }
       ],
       "stableId": "wait-state-details"

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -3950,10 +3950,10 @@ public sealed class AgentInstanceHistoryItemResult
     public List<AgentInstanceToolCall> ToolCalls { get; set; } = null!;
 
     /// <summary>
-    /// Per-call token and latency metrics. Present on ASSISTANT items only.
+    /// Per-call token and latency metrics. Zero-valued when not available.
     /// </summary>
     [JsonPropertyName("metrics")]
-    public AgentInstanceHistoryItemMetrics? Metrics { get; set; }
+    public AgentInstanceHistoryItemMetrics Metrics { get; set; } = null!;
 
     /// <summary>
     /// The commit status of this history item.
@@ -14369,6 +14369,8 @@ public enum JobStateEnum
     FAILED,
     [JsonPropertyName("MIGRATED")]
     MIGRATED,
+    [JsonPropertyName("PRIORITY_UPDATED")]
+    PRIORITYUPDATED,
     [JsonPropertyName("RETRIES_UPDATED")]
     RETRIESUPDATED,
     [JsonPropertyName("TIMED_OUT")]
@@ -19692,6 +19694,19 @@ public readonly record struct SignalKey : global::Camunda.Orchestration.Sdk.ICam
 }
 
 /// <summary>
+/// SignalWaitStateDetails
+/// </summary>
+public sealed class SignalWaitStateDetails : WaitStateDetails
+{
+    /// <summary>
+    /// The name of the signal being awaited.
+    /// </summary>
+    [JsonPropertyName("signalName")]
+    public string SignalName { get; set; } = null!;
+
+}
+
+/// <summary>
 /// The order in which to sort the related field.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -20409,6 +20424,25 @@ public sealed class TenantUserSearchResult
     /// </summary>
     [JsonPropertyName("page")]
     public SearchQueryPageResponse Page { get; set; } = null!;
+
+}
+
+/// <summary>
+/// TimerWaitStateDetails
+/// </summary>
+public sealed class TimerWaitStateDetails : WaitStateDetails
+{
+    /// <summary>
+    /// When the timer is due, as a UNIX epoch timestamp in milliseconds.
+    /// </summary>
+    [JsonPropertyName("dueDate")]
+    public long? DueDate { get; set; }
+
+    /// <summary>
+    /// The number of remaining timer repetitions (-1 for infinite, 0 for non-repeating).
+    /// </summary>
+    [JsonPropertyName("repetitions")]
+    public int? Repetitions { get; set; }
 
 }
 
@@ -22034,15 +22068,21 @@ public sealed class VariableValueFilterProperty
 /// <item><description><see cref="JobWaitStateDetails"/></description></item>
 /// <item><description><see cref="MessageWaitStateDetails"/></description></item>
 /// <item><description><see cref="UserTaskWaitStateDetails"/></description></item>
+/// <item><description><see cref="TimerWaitStateDetails"/></description></item>
+/// <item><description><see cref="SignalWaitStateDetails"/></description></item>
 /// </list>
 /// </remarks>
 /// <seealso cref="JobWaitStateDetails"/>
 /// <seealso cref="MessageWaitStateDetails"/>
 /// <seealso cref="UserTaskWaitStateDetails"/>
+/// <seealso cref="TimerWaitStateDetails"/>
+/// <seealso cref="SignalWaitStateDetails"/>
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "waitStateType")]
 [JsonDerivedType(typeof(JobWaitStateDetails), "JOB")]
 [JsonDerivedType(typeof(MessageWaitStateDetails), "MESSAGE")]
 [JsonDerivedType(typeof(UserTaskWaitStateDetails), "USER_TASK")]
+[JsonDerivedType(typeof(TimerWaitStateDetails), "TIMER")]
+[JsonDerivedType(typeof(SignalWaitStateDetails), "SIGNAL")]
 public abstract class WaitStateDetails { }
 
 /// <summary>
@@ -22192,6 +22232,10 @@ public enum WaitStateTypeEnum
     MESSAGE,
     [JsonPropertyName("USER_TASK")]
     USERTASK,
+    [JsonPropertyName("TIMER")]
+    TIMER,
+    [JsonPropertyName("SIGNAL")]
+    SIGNAL,
 }
 
 /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:26f2149071b5d3b472ac5cbebadeed03e4eac7ee29f5f90cb2d9f54fd2f0c16a";
+    public const string SpecHash = "sha256:49625da077b57255a2b40d23f9df017147d77cd72a4b4f59b2dcb60b52f81934";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -589,7 +589,7 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey HistoryItemKey { get; set; } [JsonPropertyName("historyItemKey")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum CommitStatus { get; set; } [JsonPropertyName("commitStatus")]
-  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics? Metrics { get; set; } [JsonPropertyName("metrics")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics Metrics { get; set; } [JsonPropertyName("metrics")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum Role { get; set; } [JsonPropertyName("role")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceKey AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
@@ -3854,8 +3854,9 @@ TYPE Camunda.Orchestration.Sdk.JobStateEnum : enum interfaces=[System.IComparabl
   MEMBER ERRORTHROWN = 3 json="ERROR_THROWN"
   MEMBER FAILED = 4 json="FAILED"
   MEMBER MIGRATED = 5 json="MIGRATED"
-  MEMBER RETRIESUPDATED = 6 json="RETRIES_UPDATED"
-  MEMBER TIMEDOUT = 7 json="TIMED_OUT"
+  MEMBER PRIORITYUPDATED = 6 json="PRIORITY_UPDATED"
+  MEMBER RETRIESUPDATED = 7 json="RETRIES_UPDATED"
+  MEMBER TIMEDOUT = 8 json="TIMED_OUT"
 
 TYPE Camunda.Orchestration.Sdk.JobStateExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.JobStateExactMatch>]
   PROP System.String Value { get; }
@@ -5278,6 +5279,10 @@ TYPE Camunda.Orchestration.Sdk.SignalKey : struct interfaces=[Camunda.Orchestrat
   METHOD virtual System.Int32 GetHashCode()
   METHOD virtual System.String ToString()
 
+TYPE Camunda.Orchestration.Sdk.SignalWaitStateDetails : sealed class base=Camunda.Orchestration.Sdk.WaitStateDetails
+  CTOR ()
+  PROP System.String SignalName { get; set; } [JsonPropertyName("signalName")]
+
 TYPE Camunda.Orchestration.Sdk.SortOrderEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
   underlying=System.Int32
@@ -5500,6 +5505,11 @@ TYPE Camunda.Orchestration.Sdk.TenantUserSearchResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.TenantUserResult> Items { get; set; } [JsonPropertyName("items")]
+
+TYPE Camunda.Orchestration.Sdk.TimerWaitStateDetails : sealed class base=Camunda.Orchestration.Sdk.WaitStateDetails
+  CTOR ()
+  PROP System.Int32? Repetitions { get; set; } [JsonPropertyName("repetitions")]
+  PROP System.Int64? DueDate { get; set; } [JsonPropertyName("dueDate")]
 
 TYPE Camunda.Orchestration.Sdk.TlsConfig : sealed class
   CTOR ()
@@ -5955,6 +5965,8 @@ TYPE Camunda.Orchestration.Sdk.WaitStateDetails : abstract class
   ATTR JsonPolymorphic discriminator=waitStateType
   ATTR JsonDerivedType Camunda.Orchestration.Sdk.JobWaitStateDetails tag=JOB
   ATTR JsonDerivedType Camunda.Orchestration.Sdk.MessageWaitStateDetails tag=MESSAGE
+  ATTR JsonDerivedType Camunda.Orchestration.Sdk.SignalWaitStateDetails tag=SIGNAL
+  ATTR JsonDerivedType Camunda.Orchestration.Sdk.TimerWaitStateDetails tag=TIMER
   ATTR JsonDerivedType Camunda.Orchestration.Sdk.UserTaskWaitStateDetails tag=USER_TASK
 
 TYPE Camunda.Orchestration.Sdk.WaitStateElementTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
@@ -6011,6 +6023,8 @@ TYPE Camunda.Orchestration.Sdk.WaitStateTypeEnum : enum interfaces=[System.IComp
   MEMBER JOB = 0 json="JOB"
   MEMBER MESSAGE = 1 json="MESSAGE"
   MEMBER USERTASK = 2 json="USER_TASK"
+  MEMBER TIMER = 3 json="TIMER"
+  MEMBER SIGNAL = 4 json="SIGNAL"
 
 TYPE Camunda.Orchestration.Sdk.WaitStateTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.WaitStateTypeExactMatch>]
   PROP System.String Value { get; }


### PR DESCRIPTION
## What

Refreshes the bundled OpenAPI spec and regenerated SDK sources to track upstream additions from `camunda/camunda`, and refreshes the public API baseline accordingly. Rebased on top of `437f6df2e` (which already landed the user-task wait-state additions), so this PR only carries what is still missing.

## Why

CI fetches the upstream spec fresh on every run, while the committed spec and `Generated/*` had fallen behind. This surfaced as `PublicApiSurfaceTests.PublicApiSurface_MatchesShippedBaseline` drift (first reported diff: a new `PRIORITY_UPDATED` member in `JobStateEnum` shifting subsequent enum values).

## Public API surface delta (vs current main)

All additive except one nullability tighten:

- **`JobStateEnum`** — new `PRIORITY_UPDATED` member
- **`WaitStateTypeEnum`** — new `TIMER`, `SIGNAL` members (`USER_TASK` already on main)
- **New `WaitStateDetails` subtypes** — `TimerWaitStateDetails`, `SignalWaitStateDetails` (with matching `JsonDerivedType` TIMER/SIGNAL tags)
- **`AgentInstanceHistoryItemResult.Metrics`** — tightened from nullable to non-nullable (upstream now marks the field required)

## Verification

- `PublicApiSurfaceTests` ✅ green after baseline refresh
- Full `Camunda.Orchestration.Sdk.Tests` suite ✅ 1074/1074 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)