### PR TITLE
fix: backport transitive allOf flatten to stable/9 (8.9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.0.3",
         "@semantic-release/git": "^10.0.1",
-        "camunda-schema-bundler": "^1.6.1",
+        "camunda-schema-bundler": "1.6.1",
         "semantic-release": "^25.0.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.0.3",
     "@semantic-release/git": "^10.0.1",
-    "camunda-schema-bundler": "^1.6.1",
+    "camunda-schema-bundler": "1.6.1",
     "semantic-release": "^25.0.5"
   }
 }

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -325,24 +325,9 @@ internal static class CSharpClientGenerator
             schema.Properties ?? new Dictionary<string, IOpenApiSchema>());
         var required = new HashSet<string>(
             schema.Required ?? new HashSet<string>());
-        foreach (var allOf in schema.AllOf ?? [])
-        {
-            // Resolve `allOf: [{$ref: ...}]` against the document — Microsoft.OpenApi
-            // does not auto-resolve refs into the AllOf entry. Without this, a schema
-            // that composes `tenantIds` via a referenced component would be missed.
-            // Matches the pattern used elsewhere in this file (e.g. GetConstraints).
-            var resolved = GetRefId(allOf) != null
-                && doc?.Components?.Schemas != null
-                && doc.Components.Schemas.TryGetValue(GetRefId(allOf)!, out var refSchema)
-                ? refSchema
-                : allOf;
-            if (resolved.Properties != null)
-                foreach (var (k, v) in resolved.Properties)
-                    properties.TryAdd(k, v);
-            if (resolved.Required != null)
-                foreach (var r in resolved.Required)
-                    required.Add(r);
-        }
+        // Resolve and flatten allOf transitively — a schema that composes
+        // `tenantIds` through a nested allOf chain would otherwise be missed.
+        FlattenAllOf(schema, doc, properties, required);
         if (!properties.TryGetValue("tenantIds", out var tenantIdsProp))
             return false;
         if (required.Contains("tenantIds"))
@@ -689,31 +674,18 @@ internal static class CSharpClientGenerator
                     sb.AppendLine($"public sealed class {typeName}");
                     sb.AppendLine("{");
 
-                    var filterRequired = classVariantSchema.Required ?? new HashSet<string>();
+                    var filterRequired = new HashSet<string>(
+                        classVariantSchema.Required ?? new HashSet<string>());
                     var filterProperties = new Dictionary<string, IOpenApiSchema>();
 
                     // Collect properties from the variant, including allOf composition
+                    // (transitively — see FlattenAllOf).
                     if (classVariantSchema.Properties != null)
                     {
                         foreach (var (propName, propSchema) in classVariantSchema.Properties)
                             filterProperties.TryAdd(propName, propSchema);
                     }
-                    foreach (var allOf in classVariantSchema.AllOf ?? [])
-                    {
-                        var resolved = GetRefId(allOf) != null && doc.Components?.Schemas != null
-                            && doc.Components.Schemas.TryGetValue(GetRefId(allOf)!, out var refSchema)
-                            ? refSchema : allOf;
-                        if (resolved.Properties != null)
-                        {
-                            foreach (var (propName, propSchema) in resolved.Properties)
-                                filterProperties.TryAdd(propName, propSchema);
-                        }
-                        if (resolved.Required != null)
-                        {
-                            foreach (var r in resolved.Required)
-                                filterRequired.Add(r);
-                        }
-                    }
+                    FlattenAllOf(classVariantSchema, doc, filterProperties, filterRequired);
 
                     foreach (var (propName, propSchema) in filterProperties)
                     {
@@ -748,7 +720,7 @@ internal static class CSharpClientGenerator
             var baseClass = variantToParent.TryGetValue(typeName, out var parent) ? $" : {parent}" : "";
 
             // Check if this class has an optional tenantId property AND is used as a request body
-            var tenantIdInfo = requestSchemaNames.Contains(typeName) ? GetOptionalTenantIdInfo(schema) : null;
+            var tenantIdInfo = requestSchemaNames.Contains(typeName) ? GetOptionalTenantIdInfo(schema, doc) : null;
             var tenantIdsInfo = requestSchemaNames.Contains(typeName) ? GetOptionalTenantIdsInfo(schema, doc) : null;
             var ifaceList = new List<string>();
             if (tenantIdInfo != null)
@@ -766,26 +738,12 @@ internal static class CSharpClientGenerator
             sb.AppendLine($"public sealed class {typeName}{baseClass}{interfaces}");
             sb.AppendLine("{");
 
-            var required = schema.Required ?? new HashSet<string>();
-            var properties = schema.Properties ?? new Dictionary<string, IOpenApiSchema>();
+            var required = new HashSet<string>(schema.Required ?? new HashSet<string>());
+            var properties = new Dictionary<string, IOpenApiSchema>(
+                schema.Properties ?? new Dictionary<string, IOpenApiSchema>());
 
-            // Handle allOf composition
-            foreach (var allOf in schema.AllOf ?? [])
-            {
-                if (allOf.Properties != null)
-                {
-                    foreach (var (propName, propSchema) in allOf.Properties)
-                    {
-                        if (!properties.ContainsKey(propName))
-                            properties[propName] = propSchema;
-                    }
-                }
-                if (allOf.Required != null)
-                {
-                    foreach (var r in allOf.Required)
-                        required.Add(r);
-                }
-            }
+            // Handle allOf composition (transitively — see FlattenAllOf).
+            FlattenAllOf(schema, doc, properties, required);
 
             // If this type is a variant of a polymorphic parent, skip the discriminator
             // property — it is managed by [JsonPolymorphic] on the base class and
@@ -840,7 +798,7 @@ internal static class CSharpClientGenerator
 
     private static void GenerateClass(StringBuilder sb, string typeName, IOpenApiSchema schema, OpenApiDocument? doc = null, bool isRequestSchema = false)
     {
-        var tenantIdInfo = isRequestSchema ? GetOptionalTenantIdInfo(schema) : null;
+        var tenantIdInfo = isRequestSchema ? GetOptionalTenantIdInfo(schema, doc) : null;
         var tenantIdsInfo = isRequestSchema ? GetOptionalTenantIdsInfo(schema, doc) : null;
         var ifaceList = new List<string>();
         if (tenantIdInfo != null)
@@ -855,26 +813,12 @@ internal static class CSharpClientGenerator
         sb.AppendLine($"public sealed class {typeName}{interfaces}");
         sb.AppendLine("{");
 
-        var required = schema.Required ?? new HashSet<string>();
-        var properties = schema.Properties ?? new Dictionary<string, IOpenApiSchema>();
+        var required = new HashSet<string>(schema.Required ?? new HashSet<string>());
+        var properties = new Dictionary<string, IOpenApiSchema>(
+            schema.Properties ?? new Dictionary<string, IOpenApiSchema>());
 
-        // Handle allOf composition
-        foreach (var allOf in schema.AllOf ?? [])
-        {
-            if (allOf.Properties != null)
-            {
-                foreach (var (propName, propSchema) in allOf.Properties)
-                {
-                    if (!properties.ContainsKey(propName))
-                        properties[propName] = propSchema;
-                }
-            }
-            if (allOf.Required != null)
-            {
-                foreach (var r in allOf.Required)
-                    required.Add(r);
-            }
-        }
+        // Handle allOf composition (transitively — see FlattenAllOf).
+        FlattenAllOf(schema, doc, properties, required);
 
         foreach (var (propName, propSchema) in properties)
         {
@@ -1538,22 +1482,15 @@ internal static class CSharpClientGenerator
     /// Returns the C# type of the optional tenantId property if present, or null if not.
     /// Used to determine the SetDefaultTenantId implementation.
     /// </summary>
-    private static (string CSharpType, bool IsBrandedKey)? GetOptionalTenantIdInfo(IOpenApiSchema schema)
+    private static (string CSharpType, bool IsBrandedKey)? GetOptionalTenantIdInfo(IOpenApiSchema schema, OpenApiDocument? doc = null)
     {
-        // Collect all properties including allOf composition
+        // Collect all properties including allOf composition (transitively — see
+        // FlattenAllOf).
         var properties = new Dictionary<string, IOpenApiSchema>(
             schema.Properties ?? new Dictionary<string, IOpenApiSchema>());
         var required = new HashSet<string>(
             schema.Required ?? new HashSet<string>());
-        foreach (var allOf in schema.AllOf ?? [])
-        {
-            if (allOf.Properties != null)
-                foreach (var (k, v) in allOf.Properties)
-                    properties.TryAdd(k, v);
-            if (allOf.Required != null)
-                foreach (var r in allOf.Required)
-                    required.Add(r);
-        }
+        FlattenAllOf(schema, doc, properties, required);
 
         if (!properties.TryGetValue("tenantId", out var tenantProp))
             return null;
@@ -1609,22 +1546,8 @@ internal static class CSharpClientGenerator
             schema.Properties ?? new Dictionary<string, IOpenApiSchema>());
         var required = new HashSet<string>(
             schema.Required ?? new HashSet<string>());
-        foreach (var allOf in schema.AllOf ?? [])
-        {
-            // Resolve `allOf: [{$ref: ...}]` against the document — see
-            // HasOptionalTenantIdsArrayDirect for rationale.
-            var resolved = GetRefId(allOf) != null
-                && doc?.Components?.Schemas != null
-                && doc.Components.Schemas.TryGetValue(GetRefId(allOf)!, out var refSchema)
-                ? refSchema
-                : allOf;
-            if (resolved.Properties != null)
-                foreach (var (k, v) in resolved.Properties)
-                    properties.TryAdd(k, v);
-            if (resolved.Required != null)
-                foreach (var r in resolved.Required)
-                    required.Add(r);
-        }
+        // Resolve and flatten allOf transitively — see FlattenAllOf.
+        FlattenAllOf(schema, doc, properties, required);
 
         if (!properties.TryGetValue("tenantIds", out var tenantIdsProp))
             return null;
@@ -1838,6 +1761,59 @@ internal static class CSharpClientGenerator
     /// </summary>
     private static string? GetRefId(IOpenApiSchema? schema) =>
         (schema as OpenApiSchemaReference)?.Reference?.Id;
+
+    /// <summary>
+    /// Flattens a schema's <c>allOf</c> composition into <paramref name="properties"/>
+    /// and <paramref name="required"/>, resolving <c>$ref</c> entries against the
+    /// document and recursing into nested <c>allOf</c>.
+    ///
+    /// Microsoft.OpenApi's reference proxy surfaces only a referenced schema's
+    /// <em>direct</em> members, so a schema composed of another schema that is
+    /// <em>itself</em> an <c>allOf</c> (e.g. <c>Filter → Fields → BaseFields</c>)
+    /// would otherwise silently drop every transitively-inherited member — the
+    /// exact shape of the orchestration-cluster filter schemas (issue #265).
+    /// Flattening must therefore be transitive, not one level deep.
+    ///
+    /// First writer wins: properties pre-seeded by the caller (the schema's own
+    /// declarations) take precedence, and among <c>allOf</c> entries the earliest
+    /// contributor wins (via <see cref="IDictionary{TKey,TValue}.TryAdd"/>),
+    /// preserving the behaviour of the per-site loops this consolidates.
+    /// </summary>
+    private static void FlattenAllOf(
+        IOpenApiSchema schema,
+        OpenApiDocument? doc,
+        IDictionary<string, IOpenApiSchema> properties,
+        ISet<string> required,
+        HashSet<string>? visitedRefs = null)
+    {
+        visitedRefs ??= new HashSet<string>(StringComparer.Ordinal);
+        foreach (var allOf in schema.AllOf ?? [])
+        {
+            var refId = GetRefId(allOf);
+            var resolved = allOf;
+            if (refId != null)
+            {
+                // Cycle guard: a component already merged on this path must not be
+                // re-entered (self/mutual allOf references would otherwise recurse
+                // without end).
+                if (!visitedRefs.Add(refId))
+                    continue;
+                if (doc?.Components?.Schemas != null
+                    && doc.Components.Schemas.TryGetValue(refId, out var refSchema))
+                    resolved = refSchema;
+            }
+
+            if (resolved.Properties != null)
+                foreach (var (propName, propSchema) in resolved.Properties)
+                    properties.TryAdd(propName, propSchema);
+            if (resolved.Required != null)
+                foreach (var r in resolved.Required)
+                    required.Add(r);
+
+            // Recurse — the resolved schema may itself compose via allOf.
+            FlattenAllOf(resolved, doc, properties, required, visitedRefs);
+        }
+    }
 
     /// <summary>
     /// OpenAPI requires every parameter to have a non-empty <c>name</c>. The v3

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -4877,6 +4877,30 @@ public sealed class CreateGlobalTaskListenerRequest
     [JsonPropertyName("eventTypes")]
     public List<GlobalTaskListenerEventTypeEnum> EventTypes { get; set; } = null!;
 
+    /// <summary>
+    /// The name of the job type, used as a reference to specify which job workers request the respective listener job.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = null!;
+
+    /// <summary>
+    /// Number of retries for the listener job.
+    /// </summary>
+    [JsonPropertyName("retries")]
+    public int? Retries { get; set; }
+
+    /// <summary>
+    /// Whether the listener should run after model-level listeners.
+    /// </summary>
+    [JsonPropertyName("afterNonGlobal")]
+    public bool? AfterNonGlobal { get; set; }
+
+    /// <summary>
+    /// The priority of the listener. Higher priority listeners are executed before lower priority ones.
+    /// </summary>
+    [JsonPropertyName("priority")]
+    public int? Priority { get; set; }
+
 }
 
 /// <summary>
@@ -13869,6 +13893,122 @@ public sealed class ProcessInstanceFilter
     /// </summary>
     [JsonPropertyName("processDefinitionKey")]
     public ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; }
+
+    /// <summary>
+    /// The start date.
+    /// </summary>
+    [JsonPropertyName("startDate")]
+    public DateTimeFilterProperty? StartDate { get; set; }
+
+    /// <summary>
+    /// The end date.
+    /// </summary>
+    [JsonPropertyName("endDate")]
+    public DateTimeFilterProperty? EndDate { get; set; }
+
+    /// <summary>
+    /// The process instance state.
+    /// </summary>
+    [JsonPropertyName("state")]
+    public ProcessInstanceStateFilterProperty? State { get; set; }
+
+    /// <summary>
+    /// Whether this process instance has a related incident or not.
+    /// </summary>
+    [JsonPropertyName("hasIncident")]
+    public bool? HasIncident { get; set; }
+
+    /// <summary>
+    /// The tenant id.
+    /// </summary>
+    [JsonPropertyName("tenantId")]
+    public StringFilterProperty? TenantId { get; set; }
+
+    /// <summary>
+    /// The process instance variables.
+    /// </summary>
+    [JsonPropertyName("variables")]
+    public List<VariableValueFilterProperty>? Variables { get; set; }
+
+    /// <summary>
+    /// The key of this process instance.
+    /// </summary>
+    [JsonPropertyName("processInstanceKey")]
+    public ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The parent process instance key.
+    /// </summary>
+    [JsonPropertyName("parentProcessInstanceKey")]
+    public ProcessInstanceKeyFilterProperty? ParentProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The parent element instance key.
+    /// </summary>
+    [JsonPropertyName("parentElementInstanceKey")]
+    public ElementInstanceKeyFilterProperty? ParentElementInstanceKey { get; set; }
+
+    /// <summary>
+    /// The batch operation id.
+    /// **Deprecated**: Use `batchOperationKey` instead. This field will be removed in a future release. If both `batchOperationId` and `batchOperationKey` are provided, the request will be rejected with a 400 error.
+    /// 
+    /// </summary>
+    [JsonPropertyName("batchOperationId")]
+    public StringFilterProperty? BatchOperationId { get; set; }
+
+    /// <summary>
+    /// The batch operation key.
+    /// </summary>
+    [JsonPropertyName("batchOperationKey")]
+    public StringFilterProperty? BatchOperationKey { get; set; }
+
+    /// <summary>
+    /// The error message related to the process.
+    /// </summary>
+    [JsonPropertyName("errorMessage")]
+    public StringFilterProperty? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Whether the process has failed jobs with retries left.
+    /// </summary>
+    [JsonPropertyName("hasRetriesLeft")]
+    public bool? HasRetriesLeft { get; set; }
+
+    /// <summary>
+    /// The state of the element instances associated with the process instance.
+    /// </summary>
+    [JsonPropertyName("elementInstanceState")]
+    public ElementInstanceStateFilterProperty? ElementInstanceState { get; set; }
+
+    /// <summary>
+    /// The element id associated with the process instance.
+    /// </summary>
+    [JsonPropertyName("elementId")]
+    public StringFilterProperty? ElementId { get; set; }
+
+    /// <summary>
+    /// Whether the element instance has an incident or not.
+    /// </summary>
+    [JsonPropertyName("hasElementInstanceIncident")]
+    public bool? HasElementInstanceIncident { get; set; }
+
+    /// <summary>
+    /// The incident error hash code, associated with this process.
+    /// </summary>
+    [JsonPropertyName("incidentErrorHashCode")]
+    public IntegerFilterProperty? IncidentErrorHashCode { get; set; }
+
+    /// <summary>
+    /// List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.
+    /// </summary>
+    [JsonPropertyName("tags")]
+    public List<Tag>? Tags { get; set; }
+
+    /// <summary>
+    /// The business id associated with the process instance.
+    /// </summary>
+    [JsonPropertyName("businessId")]
+    public StringFilterProperty? BusinessId { get; set; }
 
     /// <summary>
     /// Defines a list of alternative filter groups combined using OR logic. Each object in the array is evaluated independently, and the filter matches if any one of them is satisfied.

--- a/test/Camunda.Orchestration.Sdk.Tests/GeneratorAllOfFlattenTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/GeneratorAllOfFlattenTests.cs
@@ -1,0 +1,169 @@
+using Camunda.Orchestration.Sdk.Generator;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Defect-class regression guard for <c>allOf</c> flattening.
+///
+/// The defect: the generator merged a referenced schema's <em>direct</em>
+/// properties into a composing class but did not recurse into that referenced
+/// schema's own <c>allOf</c>. So a schema shaped as
+/// <c>Filter = allOf[Fields] + {$or}</c>, where <c>Fields = allOf[BaseFields] + {…}</c>,
+/// silently dropped every property contributed by <c>BaseFields</c>. This is the
+/// exact shape of the orchestration-cluster filter schemas (e.g.
+/// <c>ProcessInstanceFilter → ProcessInstanceFilterFields → BaseProcessInstanceFilterFields</c>),
+/// which is why <c>tenantId</c>, <c>startDate</c>, <c>state</c>, … were missing
+/// from <c>ProcessInstanceFilter</c> (see issue #265).
+///
+/// The test targets the defect <em>class</em>: any class composed via <c>allOf</c>
+/// of an <c>allOf</c>-based schema must carry the transitively-inherited members
+/// (and their <c>required</c> flag), at arbitrary nesting depth.
+/// </summary>
+public class GeneratorAllOfFlattenTests
+{
+    // Mirrors the real Filter/Fields/BaseFields shape, plus a third nesting
+    // level (Root → Mid → BaseFields) to prove the flatten is transitive and
+    // not merely two-deep.
+    //
+    //   BaseFilterFields : { baseField (required), baseTenant }
+    //   MidFilterFields  : allOf[BaseFilterFields] + { midField }
+    //   FilterFields     : allOf[MidFilterFields]  + { ownField }
+    //   Filter           : allOf[FilterFields]     + { $or: FilterFields[] }
+    private const string NestedAllOfSpec = """
+        {
+          "openapi": "3.0.3",
+          "info": { "title": "Test", "version": "1.0.0" },
+          "paths": {
+            "/filter": {
+              "get": {
+                "operationId": "searchFilter",
+                "responses": {
+                  "200": {
+                    "description": "ok",
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Filter" } } }
+                  }
+                }
+              }
+            }
+          },
+          "components": {
+            "schemas": {
+              "BaseFilterFields": {
+                "type": "object",
+                "required": ["baseField"],
+                "properties": {
+                  "baseField": { "type": "string" },
+                  "baseTenant": { "type": "string" }
+                }
+              },
+              "MidFilterFields": {
+                "type": "object",
+                "allOf": [ { "$ref": "#/components/schemas/BaseFilterFields" } ],
+                "properties": { "midField": { "type": "string" } }
+              },
+              "FilterFields": {
+                "type": "object",
+                "allOf": [ { "$ref": "#/components/schemas/MidFilterFields" } ],
+                "properties": { "ownField": { "type": "string" } }
+              },
+              "Filter": {
+                "type": "object",
+                "allOf": [
+                  { "$ref": "#/components/schemas/FilterFields" },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "$or": { "type": "array", "items": { "$ref": "#/components/schemas/FilterFields" } }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """;
+
+    [Fact]
+    public void Model_class_flattens_transitively_inherited_allOf_members()
+    {
+        using var tmp = TempSpecDir.Create();
+        File.WriteAllText(tmp.SpecPath, NestedAllOfSpec);
+        File.WriteAllText(tmp.MetadataPath, MinimalBundledSpec.MinimalMetadata);
+
+        CSharpClientGenerator.Generate(tmp.SpecPath, tmp.MetadataPath, tmp.OutputDir);
+
+        var models = File.ReadAllText(Path.Combine(tmp.OutputDir, "Models.Generated.cs"));
+        var root = CSharpSyntaxTree.ParseText(models).GetCompilationUnitRoot();
+
+        // FilterFields is itself a two-level chain (FilterFields → MidFilterFields
+        // → BaseFilterFields), so it already exercises the recursion: BaseField is
+        // contributed two hops away and must still appear.
+        var fields = PropertiesOf(root, "FilterFields");
+        Assert.Contains("OwnField", fields.Keys);
+        Assert.Contains("MidField", fields.Keys);
+        Assert.Contains("BaseField", fields.Keys);
+
+        // The defect: Filter composes FilterFields (itself an allOf chain), so it
+        // must expose every transitively-inherited member — not just FilterFields'
+        // direct property. On the unfixed generator BaseField/BaseTenant/MidField
+        // are absent.
+        var filter = PropertiesOf(root, "Filter");
+        Assert.Contains("OwnField", filter.Keys);   // FilterFields direct (1 level)
+        Assert.Contains("MidField", filter.Keys);    // MidFilterFields (2 levels)
+        Assert.Contains("BaseField", filter.Keys);   // BaseFilterFields (3 levels)
+        Assert.Contains("BaseTenant", filter.Keys);  // BaseFilterFields (3 levels)
+        Assert.Contains("Or", filter.Keys);          // inline allOf fragment
+
+        // required must also propagate transitively: baseField is required on
+        // BaseFilterFields, so on Filter it is a non-nullable reference type
+        // (emitted without a trailing '?').
+        Assert.Equal("string", filter["BaseField"]);
+        Assert.Equal("string?", filter["BaseTenant"]);
+    }
+
+    /// <summary>
+    /// Returns a map of property name → declared C# type string for the named
+    /// class in the parsed compilation unit.
+    /// </summary>
+    private static Dictionary<string, string> PropertiesOf(CompilationUnitSyntax root, string className)
+    {
+        var cls = root.DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .SingleOrDefault(c => c.Identifier.ValueText == className);
+        Assert.True(cls != null, $"Expected a generated class named '{className}'.");
+
+        return cls!.Members
+            .OfType<PropertyDeclarationSyntax>()
+            .ToDictionary(p => p.Identifier.ValueText, p => p.Type.ToString());
+    }
+
+    private sealed class TempSpecDir : IDisposable
+    {
+        public string Root { get; }
+        public string SpecPath => Path.Combine(Root, "spec.json");
+        public string MetadataPath => Path.Combine(Root, "metadata.json");
+        public string OutputDir => Path.Combine(Root, "out");
+
+        private TempSpecDir(string root)
+        {
+            Root = root;
+            Directory.CreateDirectory(OutputDir);
+        }
+
+        public static TempSpecDir Create()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "csharp-gen-allof-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            return new TempSpecDir(dir);
+        }
+
+        public void Dispose()
+        {
+            try
+            { Directory.Delete(Root, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -1437,7 +1437,11 @@ TYPE Camunda.Orchestration.Sdk.CreateClusterVariableRequest : sealed class
 TYPE Camunda.Orchestration.Sdk.CreateGlobalTaskListenerRequest : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.GlobalListenerId Id { get; set; } [JsonPropertyName("id")]
+  PROP System.Boolean? AfterNonGlobal { get; set; } [JsonPropertyName("afterNonGlobal")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.GlobalTaskListenerEventTypeEnum> EventTypes { get; set; } [JsonPropertyName("eventTypes")]
+  PROP System.Int32? Priority { get; set; } [JsonPropertyName("priority")]
+  PROP System.Int32? Retries { get; set; } [JsonPropertyName("retries")]
+  PROP System.String Type { get; set; } [JsonPropertyName("type")]
 
 TYPE Camunda.Orchestration.Sdk.CreateMappingRuleResponse : sealed class
   CTOR ()
@@ -3681,12 +3685,31 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceElementStatisticsQueryResult : sea
 
 TYPE Camunda.Orchestration.Sdk.ProcessInstanceFilter : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? EndDate { get; set; } [JsonPropertyName("endDate")]
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? StartDate { get; set; } [JsonPropertyName("startDate")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ParentElementInstanceKey { get; set; } [JsonPropertyName("parentElementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceStateFilterProperty? ElementInstanceState { get; set; } [JsonPropertyName("elementInstanceState")]
+  PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? IncidentErrorHashCode { get; set; } [JsonPropertyName("incidentErrorHashCode")]
   PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? ProcessDefinitionVersion { get; set; } [JsonPropertyName("processDefinitionVersion")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ParentProcessInstanceKey { get; set; } [JsonPropertyName("parentProcessInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceStateFilterProperty? State { get; set; } [JsonPropertyName("state")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? BatchOperationId { get; set; } [JsonPropertyName("batchOperationId")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? BatchOperationKey { get; set; } [JsonPropertyName("batchOperationKey")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? BusinessId { get; set; } [JsonPropertyName("businessId")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ElementId { get; set; } [JsonPropertyName("elementId")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? ErrorMessage { get; set; } [JsonPropertyName("errorMessage")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionName { get; set; } [JsonPropertyName("processDefinitionName")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionVersionTag { get; set; } [JsonPropertyName("processDefinitionVersionTag")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? TenantId { get; set; } [JsonPropertyName("tenantId")]
+  PROP System.Boolean? HasElementInstanceIncident { get; set; } [JsonPropertyName("hasElementInstanceIncident")]
+  PROP System.Boolean? HasIncident { get; set; } [JsonPropertyName("hasIncident")]
+  PROP System.Boolean? HasRetriesLeft { get; set; } [JsonPropertyName("hasRetriesLeft")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessInstanceFilterFields>? Or { get; set; } [JsonPropertyName("$or")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.Tag>? Tags { get; set; } [JsonPropertyName("tags")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableValueFilterProperty>? Variables { get; set; } [JsonPropertyName("variables")]
 
 TYPE Camunda.Orchestration.Sdk.ProcessInstanceFilterFields : sealed class
   CTOR ()


### PR DESCRIPTION
## What this does

Backports the generator fix from #266 to `stable/9` so **Camunda 8.9 users get the filter bugfix without any 8.10 spec changes**. The bug (#265 class): filter models drop members inherited through a nested `allOf` chain — e.g. `ProcessInstanceFilter` was missing `tenantId`, `startDate`, `state`, `processInstanceKey`, … Confirmed present on `stable/9`.

## Contents (3 commits)

1. **Generator fix** (cherry-picked from #266): a recursive `FlattenAllOf` helper (`$ref` resolution + cycle guard) applied to the model-emission and tenant-detection sites, plus a defect-class regression test. Conflicts from stable/9's older generator were resolved (the inline-enum site that exists only on `main` was omitted).
2. **Regenerated artifacts + baseline**: `Generated/Models.Generated.cs` and `PublicApi.shipped.txt`, regenerated against stable/9's `stable/8.9` spec using the **pinned `camunda-schema-bundler` 1.6.1**. The entire diff is the inherited properties the fix restores (`ProcessInstanceFilter` + `CreateGlobalTaskListenerRequest`) — **+140 in Models, +23 in the baseline, 0 removals/renames**.
3. **Pin `camunda-schema-bundler` to exact `1.6.1`**: a 1.x→2.x bump changes `--deref-path-local` handling of response component refs and would rename generated response types (e.g. `GetUserResponse` → `UserResult`) — a breaking change for 9.x consumers. Pinned so it can only be bumped deliberately.

## Deliberately **not** included
- The 8.10 spec change — this builds against the 8.9 spec only, so no API surface from 8.10 leaks in.
- The constraint-resolver fix from #266 — unrelated to the filter issue and it doesn't port cleanly to stable/9's older domain-struct emission.

## Verification
- Full unit suite green (815/815 on net8.0 + net10.0); `PublicApiSurfaceTests` passes against the refreshed baseline.
- CI `test (simple)` + `test (full)` green.

> Note: this supersedes the original "generator-only" description. The artifacts and baseline are regenerated **in this PR** (with the pinned bundler) so it is self-contained and green, rather than relying on a later pipeline regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)