### PR TITLE
ci: guard releases against unintended major-version drift

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -8,6 +8,49 @@ CSPROJ="src/Camunda.Orchestration.Sdk/Camunda.Orchestration.Sdk.csproj"
 
 echo "Preparing release v${VERSION}"
 
+# --- Version line guard -------------------------------------------------------
+# The SDK major tracks the Camunda server minor (README "Versioning": SDK n.x ->
+# Camunda 8.n). semantic-release derives the version from commit history, so a
+# stray "breaking change" note in any commit body can silently bump the line
+# across a major — this is exactly how stable/9 once published v10.0.0. Refuse to
+# release when the computed major does not match the branch's intended line:
+#
+#   stable/<N>  -> major N                  (the 8.N stable/maintenance line; exact)
+#   main        -> CURRENT_STABLE_MAJOR + 1 (alpha for the next server minor)
+#
+# A genuinely-intended new major must be introduced deliberately (cut/seed the
+# matching branch; for main, advance CAMUNDA_SDK_CURRENT_STABLE_MAJOR) — never via
+# an accidental marker.
+MAJOR="${VERSION%%.*}"
+BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)}"
+guard_fail() {
+  echo "::error::Refusing to release v${VERSION}: computed major ${MAJOR} does not match the expected major ${1} for branch '${BRANCH}'." >&2
+  echo "The SDK major tracks the Camunda server minor (README 'Versioning': SDK n.x -> Camunda 8.n)." >&2
+  echo "A stray 'breaking change' commit note must not cross a major. If this major is intended, introduce it deliberately (cut/seed the matching branch; for main advance CAMUNDA_SDK_CURRENT_STABLE_MAJOR)." >&2
+  exit 1
+}
+if [[ "$BRANCH" =~ ^stable/([0-9]+)$ ]]; then
+  # A stable line never crosses its major.
+  EXPECTED_MAJOR="${BASH_REMATCH[1]}"
+  [[ "$MAJOR" == "$EXPECTED_MAJOR" ]] || guard_fail "$EXPECTED_MAJOR"
+  echo "Version line guard OK: v${VERSION} matches stable line ${EXPECTED_MAJOR}.x (branch '${BRANCH}')."
+elif [[ "$BRANCH" == "main" && "${CAMUNDA_SDK_CURRENT_STABLE_MAJOR:-}" =~ ^[0-9]+$ ]]; then
+  # Alpha line should be the next server minor. Block an upward drift past it;
+  # tolerate a lower major (line not yet transitioned) with a warning so this
+  # guard can land before main is seeded onto the next major.
+  EXPECTED_MAJOR=$(( CAMUNDA_SDK_CURRENT_STABLE_MAJOR + 1 ))
+  if (( MAJOR > EXPECTED_MAJOR )); then
+    guard_fail "$EXPECTED_MAJOR"
+  elif (( MAJOR < EXPECTED_MAJOR )); then
+    echo "::warning::Releasing v${VERSION} on 'main' but the expected alpha major is ${EXPECTED_MAJOR} (CURRENT_STABLE_MAJOR+1). main has not yet been moved onto the next server line." >&2
+  else
+    echo "Version line guard OK: v${VERSION} matches the alpha line ${EXPECTED_MAJOR}.x (branch '${BRANCH}')."
+  fi
+else
+  echo "Version line guard: no expected major resolved for branch '${BRANCH}'; skipping."
+fi
+# -----------------------------------------------------------------------------
+
 # Update <Version> in the .csproj
 sed -i "s#<Version>.*</Version>#<Version>${VERSION}</Version>#" "$CSPROJ"
 echo "Updated ${CSPROJ} to version ${VERSION}"


### PR DESCRIPTION
## Problem

The SDK major is supposed to track the Camunda server minor (README *Versioning*: SDK `n.x` -> Camunda `8.n`), but nothing enforced it. `semantic-release` derives the version purely from commit history, so a commit body that *mentions* a major-bump marker is parsed as one and bumps the line across a major.

That is exactly what happened on `stable/9`: a `chore(deps)` commit whose body explained why a *future* bundler change would be incompatible was read as a major-bump note, and the 8.9 line published **v10.0.0** — which the README mapping then implies is 8.10. The 8.9 SDK and the 8.10 (`main`) SDK ended up with inverted majors.

## Fix

`scripts/prepare-release.sh` (called by `@semantic-release/exec` `prepareCmd`, before tag/publish) now refuses to release when the computed major doesn't match the branch's intended line:

| Branch | Expected major | Behaviour on mismatch |
|---|---|---|
| `stable/<N>` | `N` (exact) | **fail** — a stable line never crosses its major |
| `main` | `CURRENT_STABLE_MAJOR + 1` | **fail** if higher (drift); **warn** if lower (line not yet moved onto the next server minor) |

It runs in the prepare step, so a mismatch aborts with no tag, commit, or NuGet push.

It is config-agnostic: both `main` (shared `@camunda8/sdk-infra` base config) and `stable/*` (local config) go through this same script, so the same guard protects both regardless of how the version is computed. No new inputs — `GITHUB_REF_NAME` and `CAMUNDA_SDK_CURRENT_STABLE_MAJOR` are already in the release env.

## Verified

Logic checked across cases:

- `stable/9` + `10.0.0` -> **fail** (the incident)
- `stable/9` + `9.1.3` -> ok
- `main` + `9.0.0-alpha.25` -> warn (allows landing before `main` is moved to the next major)
- `main` + `10.0.0-alpha.1` -> ok
- `main` + `11.0.0-alpha.1` -> **fail**
- `stable/10` + `10.0.0` -> ok

The `main`-side warn (not fail) is deliberate so this can merge before the separate version-state cleanup (re-line `main` to `10.0.0-alpha`, reset `stable/9` to `9.x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
