### PR TITLE
feat!: advance main to the 10.x alpha line (Camunda 8.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Using an earlier SDK version, for example: SDK version 9.y.z with Camunda 8.10, 
 
 In the vast majority of use-cases, this will not be an issue; but you should be aware that using the matching SDK major version for the server minor version provides the strongest compiler guarantees about runtime reliability. 
 
+**Release lines** map to branches. Stable releases for a given server minor come from the `stable/<major>` branch — `stable/9` publishes the `9.x` line for Camunda 8.9. The `main` branch publishes alpha prereleases for the **next** server minor — currently the `10.0.0-alpha.N` line for Camunda 8.10. Pick the line that matches your server: the latest `9.x` for 8.9, or opt into `10.x-alpha` to preview 8.10.
+
 **Recommended approach**:
 
 - Check the [CHANGELOG](https://github.com/camunda/orchestration-cluster-api-csharp/releases).


### PR DESCRIPTION
## Why

The README *Versioning* model maps SDK `n.x` → Camunda `8.n`, and the migration section already advertises **`10.0.0-alpha.N` on NuGet** for Camunda 8.10. But `main`'s release lineage was never advanced off the `9.x` major, so it has actually been publishing **`9.0.0-alpha.N`** — the 8.9 number — for 8.10 content. Combined with the accidental `v10.0.0` on `stable/9`, the two lines ended up with inverted majors.

This PR advances `main` onto the **`10.x` alpha line** so the published alpha matches documented intent, and documents the branch → release-line mapping in the README.

## What

- Adds a *Release lines* note to the README versioning section: `stable/<major>` → that server minor's stable line; `main` → next minor's alpha line (currently `10.0.0-alpha.N` for 8.10).
- Carries the deliberate major bump via a `feat!:` commit + `BREAKING CHANGE:` footer, so semantic-release moves `main` from `9.0.0-alpha.N` → `10.0.0-alpha.1`.

```
BREAKING CHANGE: main now publishes the 10.x alpha line targeting Camunda 8.10.
Consumers on the main/alpha channel move from 9.0.0-alpha.N to 10.0.0-alpha.N;
pin to the 9.x line to stay on Camunda 8.9.
```

## ⚠️ Merging this publishes `10.0.0-alpha.1`

This is an intentional major bump on the alpha channel — merging triggers a real NuGet prerelease publish.

- Requires the **`breaking-change-approved`** label to pass the sdk-infra breaking-change guard (this bump is intentional and accurate).
- Pairs with #274 (the version-line guard): once `main` is on `10.x`, that guard expects `CURRENT_STABLE_MAJOR + 1` and will keep it there.
- Independent of the separate `stable/9` → `9.x` reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
