### PR TITLE
feat: regenerate SDK for upstream main spec sync

### DIFF
--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -36979,7 +36979,8 @@
               "followUpDate",
               "dueDate",
               "priority",
-              "name"
+              "name",
+              "businessId"
             ]
           },
           "order": {
@@ -37036,6 +37037,14 @@
               }
             ],
             "description": "The assignee of the user task."
+          },
+          "businessId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ],
+            "description": "The business ID of the owning process instance the user task belongs to. This only works for user tasks created with 8.10 and onwards. Tasks from prior versions don't contain this data and cannot be found.\n"
           },
           "priority": {
             "allOf": [
@@ -37223,6 +37232,10 @@
           {
             "propertyName": "tags",
             "addedInVersion": "8.9"
+          },
+          {
+            "propertyName": "businessId",
+            "addedInVersion": "8.10"
           }
         ]
       },
@@ -37251,6 +37264,7 @@
         "type": "object",
         "required": [
           "assignee",
+          "businessId",
           "candidateGroups",
           "candidateUsers",
           "completionDate",
@@ -37415,6 +37429,15 @@
               }
             ]
           },
+          "businessId": {
+            "description": "The business ID of the owning process instance, inherited when the user task was\ncreated. This is `null` for user tasks created before version 8.10, and for user tasks\nwhose owning process instance has no business ID.\n",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BusinessId"
+              }
+            ]
+          },
           "formKey": {
             "description": "The key of the form.",
             "nullable": true,
@@ -37516,6 +37539,10 @@
           {
             "propertyName": "rootProcessInstanceKey",
             "addedInVersion": "8.9"
+          },
+          {
+            "propertyName": "businessId",
+            "addedInVersion": "8.10"
           },
           {
             "propertyName": "formKey",

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:88bd20db4e8d7a1f3c9341dfe2e6c4f832d1ca213f11ef5ac5574210dd230b24",
+  "specHash": "sha256:3109b2bbf804c57e74e0f4726bb7fa69d81a8b5f1fc331f5d2ceaf34b8cc6622",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -1041,6 +1041,8 @@ public enum UserTaskSearchQuerySortRequestField
     Priority,
     [JsonPropertyName("name")]
     Name,
+    [JsonPropertyName("businessId")]
+    BusinessId,
 }
 
 /// <summary>
@@ -21170,6 +21172,13 @@ public sealed class UserTaskFilter
     public StringFilterProperty? Assignee { get; set; }
 
     /// <summary>
+    /// The business ID of the owning process instance the user task belongs to. This only works for user tasks created with 8.10 and onwards. Tasks from prior versions don&apos;t contain this data and cannot be found.
+    /// 
+    /// </summary>
+    [JsonPropertyName("businessId")]
+    public StringFilterProperty? BusinessId { get; set; }
+
+    /// <summary>
     /// The priority of the user task.
     /// </summary>
     [JsonPropertyName("priority")]
@@ -21518,6 +21527,15 @@ public sealed class UserTaskResult
     /// </summary>
     [JsonPropertyName("rootProcessInstanceKey")]
     public ProcessInstanceKey? RootProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The business ID of the owning process instance, inherited when the user task was
+    /// created. This is `null` for user tasks created before version 8.10, and for user tasks
+    /// whose owning process instance has no business ID.
+    /// 
+    /// </summary>
+    [JsonPropertyName("businessId")]
+    public BusinessId? BusinessId { get; set; }
 
     /// <summary>
     /// The key of the form.

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:88bd20db4e8d7a1f3c9341dfe2e6c4f832d1ca213f11ef5ac5574210dd230b24";
+    public const string SpecHash = "sha256:3109b2bbf804c57e74e0f4726bb7fa69d81a8b5f1fc331f5d2ceaf34b8cc6622";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -5694,6 +5694,7 @@ TYPE Camunda.Orchestration.Sdk.UserTaskFilter : sealed class
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterProperty? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? Assignee { get; set; } [JsonPropertyName("assignee")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? BusinessId { get; set; } [JsonPropertyName("businessId")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? CandidateGroup { get; set; } [JsonPropertyName("candidateGroup")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? CandidateUser { get; set; } [JsonPropertyName("candidateUser")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? Name { get; set; } [JsonPropertyName("name")]
@@ -5728,6 +5729,7 @@ TYPE Camunda.Orchestration.Sdk.UserTaskProperties : sealed class
 
 TYPE Camunda.Orchestration.Sdk.UserTaskResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.BusinessId? BusinessId { get; set; } [JsonPropertyName("businessId")]
   PROP Camunda.Orchestration.Sdk.ElementId ElementId { get; set; } [JsonPropertyName("elementId")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.FormKey? FormKey { get; set; } [JsonPropertyName("formKey")]
@@ -5778,6 +5780,7 @@ TYPE Camunda.Orchestration.Sdk.UserTaskSearchQuerySortRequestField : enum interf
   MEMBER DueDate = 3 json="dueDate"
   MEMBER Priority = 4 json="priority"
   MEMBER Name = 5 json="name"
+  MEMBER BusinessId = 6 json="businessId"
 
 TYPE Camunda.Orchestration.Sdk.UserTaskStateEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter


### PR DESCRIPTION
## Why

CI's `test` job regenerates from the **live** `camunda/camunda main` spec on every run and compares the result to the committed `PublicApi.shipped.txt`. Upstream added a user-task `businessId` filter/sort field after the 2026-06-23 release, so the baseline now lags and **every open PR fails** `PublicApiSurfaceTests.PublicApiSurface_MatchesShippedBaseline` (e.g. #274, #275) — through no fault of their diffs. The next Release would hit the same gate.

## What

Output-only regen against current upstream `main` (**no generator changes**):

- `external-spec/bundled/` — re-bundled spec (+ metadata)
- `src/.../Generated/Models.Generated.cs` — new `BusinessId` domain type, the `StringFilterProperty? BusinessId` filter, and the sort enum member
- `test/.../PublicApi.shipped.txt` — refreshed baseline (**+3 lines**, 0 removed)

The new field is a Camunda 8.10 addition (only populated for user tasks created on 8.10+).

## Verified

- `PublicApiSurfaceTests` passes locally without `UPDATE_PUBLIC_API_BASELINE`.
- Diff is minimal and free of line-ending noise (generated `.cs` normalized to LF, `PublicApi.shipped.txt` kept CRLF per repo convention).

Merging this unblocks #274 / #275 and the next release. If upstream drifts again before merge, this branch's own CI will catch it and I'll re-regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
