### PR TITLE
fix(gen): surface the exact-match branch of advanced-filter oneOf properties

### DIFF
--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -23732,6 +23732,7 @@
             "description": "The field to sort by.",
             "type": "string",
             "enum": [
+              "businessId",
               "decisionDefinitionId",
               "decisionDefinitionKey",
               "decisionDefinitionName",
@@ -23867,6 +23868,14 @@
             ],
             "description": "The key of the process instance."
           },
+          "businessId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ],
+            "description": "The business ID of the owning process instance the decision instance belongs to. This only works for decision instances created with 8.10 and onwards. Decision instances from prior versions and standalone evaluations don't contain this data and cannot be found.\n"
+          },
           "decisionDefinitionKey": {
             "description": "The key of the decision.",
             "allOf": [
@@ -23964,6 +23973,10 @@
           {
             "propertyName": "decisionRequirementsKey",
             "addedInVersion": "8.9"
+          },
+          {
+            "propertyName": "businessId",
+            "addedInVersion": "8.10"
           }
         ]
       },
@@ -24000,6 +24013,7 @@
       "DecisionInstanceResult": {
         "type": "object",
         "required": [
+          "businessId",
           "decisionDefinitionId",
           "decisionDefinitionKey",
           "decisionDefinitionName",
@@ -24019,6 +24033,15 @@
           "tenantId"
         ],
         "properties": {
+          "businessId": {
+            "description": "The business ID of the owning process instance, inherited when the decision instance was\nevaluated. This is `null` for decision instances created before version 8.10, for\nstandalone decision evaluations, and for decision instances whose owning process instance\nhas no business ID.\n",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BusinessId"
+              }
+            ]
+          },
           "decisionDefinitionId": {
             "allOf": [
               {
@@ -24129,6 +24152,10 @@
           }
         },
         "x-properties-added-in-version": [
+          {
+            "propertyName": "businessId",
+            "addedInVersion": "8.10"
+          },
           {
             "propertyName": "decisionDefinitionId",
             "addedInVersion": "8.6"

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:3109b2bbf804c57e74e0f4726bb7fa69d81a8b5f1fc331f5d2ceaf34b8cc6622",
+  "specHash": "sha256:58b138a72a997a92677d7303929b2ff3acd80d14726313fd87eb6e9625d38bd4",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -682,9 +682,9 @@ internal static class CSharpClientGenerator
 
     /// <summary>
     /// The primitive (exact-match) variant of a 2-way <c>oneOf</c>, returned as the
-    /// original variant (i.e. the <c>$ref</c>) so it maps to its declared type name.
-    /// Used as a fallback for the exact-match value type when the advanced variant has
-    /// no <c>$eq</c> operator to borrow the type from.
+    /// original variant (a <c>$ref</c> or an inline primitive schema) so it maps to its
+    /// declared/underlying type. Used as a fallback for the exact-match value type when
+    /// the advanced variant has no <c>$eq</c> operator to borrow the type from.
     /// </summary>
     private static IOpenApiSchema? FindPrimitiveOneOfVariantRef(IOpenApiSchema schema, OpenApiDocument doc)
     {
@@ -1069,7 +1069,9 @@ internal static class CSharpClientGenerator
         sb.AppendLine($"    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, {typeName} value, global::System.Text.Json.JsonSerializerOptions options)");
         sb.AppendLine("    {");
         sb.AppendLine($"        var hasAdvanced = {hasAdvanced};");
-        sb.AppendLine("        if (value.ExactMatch is not null && !hasAdvanced)");
+        sb.AppendLine("        if (value.ExactMatch is not null && hasAdvanced)");
+        sb.AppendLine($"            throw new global::System.Text.Json.JsonException(\"{typeName}: set either ExactMatch (a bare value) or advanced operators, not both.\");");
+        sb.AppendLine("        if (value.ExactMatch is not null)");
         sb.AppendLine("        {");
         sb.AppendLine("            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);");
         sb.AppendLine("            return;");

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -681,6 +681,30 @@ internal static class CSharpClientGenerator
     }
 
     /// <summary>
+    /// The primitive (exact-match) variant of a 2-way <c>oneOf</c>, returned as the
+    /// original variant (i.e. the <c>$ref</c>) so it maps to its declared type name.
+    /// Used as a fallback for the exact-match value type when the advanced variant has
+    /// no <c>$eq</c> operator to borrow the type from.
+    /// </summary>
+    private static IOpenApiSchema? FindPrimitiveOneOfVariantRef(IOpenApiSchema schema, OpenApiDocument doc)
+    {
+        if (schema.OneOf is not { Count: 2 })
+            return null;
+
+        foreach (var variant in schema.OneOf)
+        {
+            var resolved = GetRefId(variant) != null && doc.Components?.Schemas != null
+                && doc.Components.Schemas.TryGetValue(GetRefId(variant)!, out var refSchema)
+                ? refSchema : variant;
+
+            if (IsPrimitiveSchemaResolved(resolved, doc))
+                return variant;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Build a set of schema type names that are used as request bodies.
     /// Includes oneOf variant names when a parent is used as a body type.
     /// </summary>
@@ -825,19 +849,19 @@ internal static class CSharpClientGenerator
                 continue;
             }
 
-            // oneOf with mixed primitive/class variants (FilterProperty pattern)
-            // → generate class using properties from the non-primitive (advanced filter) variant
+            // oneOf with mixed primitive/class variants (the advanced-filter pattern):
+            //   XFilterProperty = oneOf[ XExactMatch (a bare scalar), AdvancedXFilter ({ $eq, … }) ]
+            // The wire accepts EITHER form, so emit a class carrying the advanced operators
+            // AND an ExactMatch member for the scalar branch, plus an implicit conversion
+            // from the value type and a converter that serialises the bare value when only
+            // the exact match is set. Dropping the scalar branch (the old behaviour) made the
+            // bare form unreachable and broke newer-SDK ↔ older-server calls for these
+            // fields (see #267).
             if (schema.OneOf is { Count: > 0 } && !oneOfParents.ContainsKey(typeName))
             {
                 var classVariantSchema = FindNonPrimitiveOneOfVariant(schema, doc);
                 if (classVariantSchema != null)
                 {
-                    sb.AppendLine($"/// <summary>");
-                    AppendXmlDocLines(sb, schema.Description ?? name, "");
-                    sb.AppendLine($"/// </summary>");
-                    sb.AppendLine($"public sealed class {typeName}");
-                    sb.AppendLine("{");
-
                     var filterRequired = new HashSet<string>(
                         classVariantSchema.Required ?? new HashSet<string>());
                     var filterProperties = new Dictionary<string, IOpenApiSchema>();
@@ -851,6 +875,38 @@ internal static class CSharpClientGenerator
                     }
                     FlattenAllOf(classVariantSchema, doc, filterProperties, filterRequired);
 
+                    // Value type of the exact-match branch: prefer the equality operator's
+                    // type so ExactMatch and $eq agree; else the primitive variant's type.
+                    string? exactType = null;
+                    if (filterProperties.TryGetValue("$eq", out var eqSchema))
+                        exactType = ResolvePropertyType(eqSchema, doc, inlineEnums, typeName, "$eq");
+                    if (string.IsNullOrEmpty(exactType))
+                    {
+                        var primVariant = FindPrimitiveOneOfVariantRef(schema, doc);
+                        if (primVariant != null)
+                            exactType = ResolvePropertyType(primVariant, doc, inlineEnums, typeName, "exactMatch");
+                    }
+                    exactType = string.IsNullOrEmpty(exactType) ? null : exactType.TrimEnd('?');
+
+                    sb.AppendLine($"/// <summary>");
+                    AppendXmlDocLines(sb, schema.Description ?? name, "");
+                    sb.AppendLine($"/// </summary>");
+                    if (exactType != null)
+                        sb.AppendLine($"[JsonConverter(typeof({typeName}JsonConverter))]");
+                    sb.AppendLine($"public sealed class {typeName}");
+                    sb.AppendLine("{");
+
+                    if (exactType != null)
+                    {
+                        sb.AppendLine($"    /// <summary>");
+                        sb.AppendLine($"    /// Matches the value exactly. Serialized as the bare value — the form");
+                        sb.AppendLine($"    /// servers that predate advanced filtering on this field accept.");
+                        sb.AppendLine($"    /// </summary>");
+                        sb.AppendLine($"    public {exactType}? ExactMatch {{ get; set; }}");
+                        sb.AppendLine();
+                    }
+
+                    var advancedOps = new List<(string Json, string Name, string Type)>();
                     foreach (var (propName, propSchema) in filterProperties)
                     {
                         var csharpType = ResolvePropertyType(propSchema, doc, inlineEnums, typeName, propName);
@@ -860,6 +916,8 @@ internal static class CSharpClientGenerator
 
                         if ((!isRequired || isNullable) && !csharpType.EndsWith('?'))
                             csharpType += "?";
+
+                        advancedOps.Add((propName, csharpPropName, csharpType));
 
                         if (!string.IsNullOrEmpty(propSchema.Description))
                         {
@@ -874,8 +932,19 @@ internal static class CSharpClientGenerator
                         sb.AppendLine();
                     }
 
+                    if (exactType != null)
+                    {
+                        sb.AppendLine($"    /// <summary>Wraps a bare value as an exact-match filter.</summary>");
+                        sb.AppendLine($"    public static implicit operator {typeName}({exactType} value) => new() {{ ExactMatch = value }};");
+                        sb.AppendLine();
+                    }
+
                     sb.AppendLine("}");
                     sb.AppendLine();
+
+                    if (exactType != null)
+                        EmitFilterPropertyConverter(sb, typeName, exactType, advancedOps);
+
                     continue;
                 }
             }
@@ -958,6 +1027,66 @@ internal static class CSharpClientGenerator
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Emits a <see cref="System.Text.Json.Serialization.JsonConverter{T}"/> for an
+    /// advanced-filter property so it round-trips its <c>oneOf</c> faithfully: a bare
+    /// scalar when only <c>ExactMatch</c> is set, otherwise the <c>{ $eq, … }</c> object.
+    /// Fully-qualified names keep this self-contained (no extra <c>using</c>).
+    /// </summary>
+    private static void EmitFilterPropertyConverter(
+        StringBuilder sb, string typeName, string exactType, List<(string Json, string Name, string Type)> ops)
+    {
+        var hasAdvanced = ops.Count == 0
+            ? "false"
+            : string.Join(" || ", ops.Select(o => $"value.{o.Name} is not null"));
+
+        sb.AppendLine($"/// <summary>Serializes <see cref=\"{typeName}\"/> as a bare exact-match value or an advanced filter object.</summary>");
+        sb.AppendLine($"internal sealed class {typeName}JsonConverter : global::System.Text.Json.Serialization.JsonConverter<{typeName}>");
+        sb.AppendLine("{");
+        sb.AppendLine($"    public override {typeName}? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;");
+        sb.AppendLine("        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)");
+        sb.AppendLine($"            return new {typeName} {{ ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<{exactType}?>(ref reader, options) }};");
+        sb.AppendLine($"        var result = new {typeName}();");
+        sb.AppendLine("        while (reader.Read())");
+        sb.AppendLine("        {");
+        sb.AppendLine("            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;");
+        sb.AppendLine("            var prop = reader.GetString();");
+        sb.AppendLine("            reader.Read();");
+        sb.AppendLine("            switch (prop)");
+        sb.AppendLine("            {");
+        foreach (var o in ops)
+            sb.AppendLine($"                case \"{SafeEmit.SafeCSharpStringLiteral(o.Json)}\": result.{o.Name} = global::System.Text.Json.JsonSerializer.Deserialize<{o.Type}>(ref reader, options); break;");
+        sb.AppendLine("                default: reader.Skip(); break;");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine("        return result;");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine($"    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, {typeName} value, global::System.Text.Json.JsonSerializerOptions options)");
+        sb.AppendLine("    {");
+        sb.AppendLine($"        var hasAdvanced = {hasAdvanced};");
+        sb.AppendLine("        if (value.ExactMatch is not null && !hasAdvanced)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);");
+        sb.AppendLine("            return;");
+        sb.AppendLine("        }");
+        sb.AppendLine("        writer.WriteStartObject();");
+        foreach (var o in ops)
+        {
+            sb.AppendLine($"        if (value.{o.Name} is not null)");
+            sb.AppendLine("        {");
+            sb.AppendLine($"            writer.WritePropertyName(\"{SafeEmit.SafeCSharpStringLiteral(o.Json)}\");");
+            sb.AppendLine($"            global::System.Text.Json.JsonSerializer.Serialize(writer, value.{o.Name}, options);");
+            sb.AppendLine("        }");
+        }
+        sb.AppendLine("        writer.WriteEndObject();");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        sb.AppendLine();
     }
 
     private static void GenerateClass(StringBuilder sb, string typeName, IOpenApiSchema schema, OpenApiDocument? doc = null, Dictionary<string, InlineEnumEntry>? inlineEnums = null, HashSet<string>? inlineEnumTypeNames = null, bool isRequestSchema = false)

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -277,6 +277,8 @@ public enum DecisionDefinitionSearchQuerySortRequestField
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum DecisionInstanceSearchQuerySortRequestField
 {
+    [JsonPropertyName("businessId")]
+    BusinessId,
     [JsonPropertyName("decisionDefinitionId")]
     DecisionDefinitionId,
     [JsonPropertyName("decisionDefinitionKey")]
@@ -10265,6 +10267,13 @@ public sealed class DecisionInstanceFilter
     public ProcessInstanceKey? ProcessInstanceKey { get; set; }
 
     /// <summary>
+    /// The business ID of the owning process instance the decision instance belongs to. This only works for decision instances created with 8.10 and onwards. Decision instances from prior versions and standalone evaluations don&apos;t contain this data and cannot be found.
+    /// 
+    /// </summary>
+    [JsonPropertyName("businessId")]
+    public StringFilterProperty? BusinessId { get; set; }
+
+    /// <summary>
     /// The key of the decision.
     /// </summary>
     [JsonPropertyName("decisionDefinitionKey")]
@@ -10295,6 +10304,16 @@ public sealed class DecisionInstanceFilter
 /// </summary>
 public sealed class DecisionInstanceGetQueryResult
 {
+    /// <summary>
+    /// The business ID of the owning process instance, inherited when the decision instance was
+    /// evaluated. This is `null` for decision instances created before version 8.10, for
+    /// standalone decision evaluations, and for decision instances whose owning process instance
+    /// has no business ID.
+    /// 
+    /// </summary>
+    [JsonPropertyName("businessId")]
+    public BusinessId? BusinessId { get; set; }
+
     /// <summary>
     /// The ID of the DMN decision.
     /// </summary>
@@ -10452,6 +10471,16 @@ public readonly record struct DecisionInstanceKey : global::Camunda.Orchestratio
 /// </summary>
 public sealed class DecisionInstanceResult
 {
+    /// <summary>
+    /// The business ID of the owning process instance, inherited when the decision instance was
+    /// evaluated. This is `null` for decision instances created before version 8.10, for
+    /// standalone decision evaluations, and for decision instances whose owning process instance
+    /// has no business ID.
+    /// 
+    /// </summary>
+    [JsonPropertyName("businessId")]
+    public BusinessId? BusinessId { get; set; }
+
     /// <summary>
     /// The ID of the DMN decision.
     /// </summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -3449,8 +3449,15 @@ public readonly record struct AgentHistoryItemKeyExactMatch : global::Camunda.Or
 /// <summary>
 /// AgentHistoryItemKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(AgentHistoryItemKeyFilterPropertyJsonConverter))]
 public sealed class AgentHistoryItemKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AgentHistoryItemKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -3481,6 +3488,74 @@ public sealed class AgentHistoryItemKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<AgentHistoryItemKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator AgentHistoryItemKeyFilterProperty(AgentHistoryItemKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="AgentHistoryItemKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class AgentHistoryItemKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<AgentHistoryItemKeyFilterProperty>
+{
+    public override AgentHistoryItemKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new AgentHistoryItemKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AgentHistoryItemKey?>(ref reader, options) };
+        var result = new AgentHistoryItemKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AgentHistoryItemKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AgentHistoryItemKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AgentHistoryItemKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<AgentHistoryItemKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AgentHistoryItemKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -3708,8 +3783,15 @@ public readonly record struct AgentInstanceHistoryCommitStatusExactMatch : globa
 /// <summary>
 /// AgentInstanceHistoryCommitStatusEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(AgentInstanceHistoryCommitStatusFilterPropertyJsonConverter))]
 public sealed class AgentInstanceHistoryCommitStatusFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AgentInstanceHistoryCommitStatusEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -3734,6 +3816,68 @@ public sealed class AgentInstanceHistoryCommitStatusFilterProperty
     [JsonPropertyName("$in")]
     public List<AgentInstanceHistoryCommitStatusEnum>? In { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator AgentInstanceHistoryCommitStatusFilterProperty(AgentInstanceHistoryCommitStatusEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="AgentInstanceHistoryCommitStatusFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class AgentInstanceHistoryCommitStatusFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<AgentInstanceHistoryCommitStatusFilterProperty>
+{
+    public override AgentInstanceHistoryCommitStatusFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new AgentInstanceHistoryCommitStatusFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceHistoryCommitStatusEnum?>(ref reader, options) };
+        var result = new AgentInstanceHistoryCommitStatusFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceHistoryCommitStatusEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceHistoryCommitStatusEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AgentInstanceHistoryCommitStatusEnum>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AgentInstanceHistoryCommitStatusFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -4018,8 +4162,15 @@ public readonly record struct AgentInstanceHistoryRoleExactMatch : global::Camun
 /// <summary>
 /// AgentInstanceHistoryRoleEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(AgentInstanceHistoryRoleFilterPropertyJsonConverter))]
 public sealed class AgentInstanceHistoryRoleFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AgentInstanceHistoryRoleEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -4044,6 +4195,68 @@ public sealed class AgentInstanceHistoryRoleFilterProperty
     [JsonPropertyName("$in")]
     public List<AgentInstanceHistoryRoleEnum>? In { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator AgentInstanceHistoryRoleFilterProperty(AgentInstanceHistoryRoleEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="AgentInstanceHistoryRoleFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class AgentInstanceHistoryRoleFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<AgentInstanceHistoryRoleFilterProperty>
+{
+    public override AgentInstanceHistoryRoleFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new AgentInstanceHistoryRoleFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceHistoryRoleEnum?>(ref reader, options) };
+        var result = new AgentInstanceHistoryRoleFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceHistoryRoleEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceHistoryRoleEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AgentInstanceHistoryRoleEnum>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AgentInstanceHistoryRoleFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -4168,8 +4381,15 @@ public readonly record struct AgentInstanceKeyExactMatch : global::Camunda.Orche
 /// <summary>
 /// AgentInstanceKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(AgentInstanceKeyFilterPropertyJsonConverter))]
 public sealed class AgentInstanceKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AgentInstanceKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -4200,6 +4420,74 @@ public sealed class AgentInstanceKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<AgentInstanceKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator AgentInstanceKeyFilterProperty(AgentInstanceKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="AgentInstanceKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class AgentInstanceKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<AgentInstanceKeyFilterProperty>
+{
+    public override AgentInstanceKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new AgentInstanceKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceKey?>(ref reader, options) };
+        var result = new AgentInstanceKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AgentInstanceKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<AgentInstanceKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AgentInstanceKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -4572,8 +4860,15 @@ public readonly record struct AgentInstanceStatusExactMatch : global::Camunda.Or
 /// <summary>
 /// AgentInstanceStatusEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(AgentInstanceStatusFilterPropertyJsonConverter))]
 public sealed class AgentInstanceStatusFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AgentInstanceStatusEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -4612,6 +4907,74 @@ public sealed class AgentInstanceStatusFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator AgentInstanceStatusFilterProperty(AgentInstanceStatusEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="AgentInstanceStatusFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class AgentInstanceStatusFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<AgentInstanceStatusFilterProperty>
+{
+    public override AgentInstanceStatusFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new AgentInstanceStatusFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceStatusEnum?>(ref reader, options) };
+        var result = new AgentInstanceStatusFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceStatusEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AgentInstanceStatusEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AgentInstanceStatusEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AgentInstanceStatusFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -4811,8 +5174,15 @@ public readonly record struct AuditLogActorTypeExactMatch : global::Camunda.Orch
 /// <summary>
 /// AuditLogActorTypeEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(AuditLogActorTypeFilterPropertyJsonConverter))]
 public sealed class AuditLogActorTypeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AuditLogActorTypeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -4851,6 +5221,74 @@ public sealed class AuditLogActorTypeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator AuditLogActorTypeFilterProperty(AuditLogActorTypeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="AuditLogActorTypeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class AuditLogActorTypeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<AuditLogActorTypeFilterProperty>
+{
+    public override AuditLogActorTypeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new AuditLogActorTypeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogActorTypeEnum?>(ref reader, options) };
+        var result = new AuditLogActorTypeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogActorTypeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogActorTypeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AuditLogActorTypeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AuditLogActorTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -4926,8 +5364,15 @@ public readonly record struct AuditLogEntityKeyExactMatch : global::Camunda.Orch
 /// <summary>
 /// EntityKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(AuditLogEntityKeyFilterPropertyJsonConverter))]
 public sealed class AuditLogEntityKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AuditLogEntityKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -4958,6 +5403,74 @@ public sealed class AuditLogEntityKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<AuditLogEntityKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator AuditLogEntityKeyFilterProperty(AuditLogEntityKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="AuditLogEntityKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class AuditLogEntityKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<AuditLogEntityKeyFilterProperty>
+{
+    public override AuditLogEntityKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new AuditLogEntityKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogEntityKey?>(ref reader, options) };
+        var result = new AuditLogEntityKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogEntityKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogEntityKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AuditLogEntityKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<AuditLogEntityKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AuditLogEntityKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -5250,8 +5763,15 @@ public readonly record struct AuditLogKeyExactMatch : global::Camunda.Orchestrat
 /// <summary>
 /// AuditLogKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(AuditLogKeyFilterPropertyJsonConverter))]
 public sealed class AuditLogKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AuditLogKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -5282,6 +5802,74 @@ public sealed class AuditLogKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<AuditLogKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator AuditLogKeyFilterProperty(AuditLogKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="AuditLogKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class AuditLogKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<AuditLogKeyFilterProperty>
+{
+    public override AuditLogKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new AuditLogKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogKey?>(ref reader, options) };
+        var result = new AuditLogKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AuditLogKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<AuditLogKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AuditLogKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -5577,8 +6165,15 @@ public readonly record struct AuditLogResultExactMatch : global::Camunda.Orchest
 /// <summary>
 /// AuditLogResultEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(AuditLogResultFilterPropertyJsonConverter))]
 public sealed class AuditLogResultFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AuditLogResultEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -5617,6 +6212,74 @@ public sealed class AuditLogResultFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator AuditLogResultFilterProperty(AuditLogResultEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="AuditLogResultFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class AuditLogResultFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<AuditLogResultFilterProperty>
+{
+    public override AuditLogResultFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new AuditLogResultFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogResultEnum?>(ref reader, options) };
+        var result = new AuditLogResultFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogResultEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogResultEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AuditLogResultEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AuditLogResultFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -6146,8 +6809,15 @@ public sealed class BasicStringFilter
 /// <summary>
 /// String property with basic advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(BasicStringFilterPropertyJsonConverter))]
 public sealed class BasicStringFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public string? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -6178,6 +6848,74 @@ public sealed class BasicStringFilterProperty
     [JsonPropertyName("$notIn")]
     public List<string>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator BasicStringFilterProperty(string value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="BasicStringFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class BasicStringFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<BasicStringFilterProperty>
+{
+    public override BasicStringFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new BasicStringFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<string?>(ref reader, options) };
+        var result = new BasicStringFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<string?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<string?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<string>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<string>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, BasicStringFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -6471,8 +7209,15 @@ public readonly record struct BatchOperationItemStateExactMatch : global::Camund
 /// <summary>
 /// BatchOperationItemStateEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(BatchOperationItemStateFilterPropertyJsonConverter))]
 public sealed class BatchOperationItemStateFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public BatchOperationItemStateEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -6511,6 +7256,74 @@ public sealed class BatchOperationItemStateFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator BatchOperationItemStateFilterProperty(BatchOperationItemStateEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="BatchOperationItemStateFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class BatchOperationItemStateFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<BatchOperationItemStateFilterProperty>
+{
+    public override BatchOperationItemStateFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new BatchOperationItemStateFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<BatchOperationItemStateEnum?>(ref reader, options) };
+        var result = new BatchOperationItemStateFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<BatchOperationItemStateEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<BatchOperationItemStateEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<BatchOperationItemStateEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, BatchOperationItemStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -6737,8 +7550,15 @@ public readonly record struct BatchOperationStateExactMatch : global::Camunda.Or
 /// <summary>
 /// BatchOperationStateEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(BatchOperationStateFilterPropertyJsonConverter))]
 public sealed class BatchOperationStateFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public BatchOperationStateEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -6777,6 +7597,74 @@ public sealed class BatchOperationStateFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator BatchOperationStateFilterProperty(BatchOperationStateEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="BatchOperationStateFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class BatchOperationStateFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<BatchOperationStateFilterProperty>
+{
+    public override BatchOperationStateFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new BatchOperationStateFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<BatchOperationStateEnum?>(ref reader, options) };
+        var result = new BatchOperationStateFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<BatchOperationStateEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<BatchOperationStateEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<BatchOperationStateEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, BatchOperationStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -6838,8 +7726,15 @@ public readonly record struct BatchOperationTypeExactMatch : global::Camunda.Orc
 /// <summary>
 /// BatchOperationTypeEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(BatchOperationTypeFilterPropertyJsonConverter))]
 public sealed class BatchOperationTypeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public BatchOperationTypeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -6878,6 +7773,74 @@ public sealed class BatchOperationTypeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator BatchOperationTypeFilterProperty(BatchOperationTypeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="BatchOperationTypeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class BatchOperationTypeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<BatchOperationTypeFilterProperty>
+{
+    public override BatchOperationTypeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new BatchOperationTypeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<BatchOperationTypeEnum?>(ref reader, options) };
+        var result = new BatchOperationTypeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<BatchOperationTypeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<BatchOperationTypeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<BatchOperationTypeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, BatchOperationTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -7063,8 +8026,15 @@ public readonly record struct CategoryExactMatch : global::Camunda.Orchestration
 /// <summary>
 /// AuditLogCategoryEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(CategoryFilterPropertyJsonConverter))]
 public sealed class CategoryFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AuditLogCategoryEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -7103,6 +8073,74 @@ public sealed class CategoryFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator CategoryFilterProperty(AuditLogCategoryEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="CategoryFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class CategoryFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<CategoryFilterProperty>
+{
+    public override CategoryFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new CategoryFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogCategoryEnum?>(ref reader, options) };
+        var result = new CategoryFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogCategoryEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogCategoryEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AuditLogCategoryEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, CategoryFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -7358,8 +8396,15 @@ public readonly record struct ClusterVariableScopeExactMatch : global::Camunda.O
 /// <summary>
 /// ClusterVariableScopeEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(ClusterVariableScopeFilterPropertyJsonConverter))]
 public sealed class ClusterVariableScopeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ClusterVariableScopeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -7398,6 +8443,74 @@ public sealed class ClusterVariableScopeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ClusterVariableScopeFilterProperty(ClusterVariableScopeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ClusterVariableScopeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ClusterVariableScopeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ClusterVariableScopeFilterProperty>
+{
+    public override ClusterVariableScopeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ClusterVariableScopeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ClusterVariableScopeEnum?>(ref reader, options) };
+        var result = new ClusterVariableScopeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ClusterVariableScopeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ClusterVariableScopeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ClusterVariableScopeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ClusterVariableScopeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -8048,8 +9161,15 @@ public sealed class CursorForwardPagination : SearchQueryPageRequest
 /// <summary>
 /// Date-time property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(DateTimeFilterPropertyJsonConverter))]
 public sealed class DateTimeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public DateTimeOffset? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -8098,6 +9218,92 @@ public sealed class DateTimeFilterProperty
     [JsonPropertyName("$in")]
     public List<DateTimeOffset>? In { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator DateTimeFilterProperty(DateTimeOffset value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="DateTimeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class DateTimeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<DateTimeFilterProperty>
+{
+    public override DateTimeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new DateTimeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<DateTimeOffset?>(ref reader, options) };
+        var result = new DateTimeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<DateTimeOffset?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<DateTimeOffset?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$gt": result.Gt = global::System.Text.Json.JsonSerializer.Deserialize<DateTimeOffset?>(ref reader, options); break;
+                case "$gte": result.Gte = global::System.Text.Json.JsonSerializer.Deserialize<DateTimeOffset?>(ref reader, options); break;
+                case "$lt": result.Lt = global::System.Text.Json.JsonSerializer.Deserialize<DateTimeOffset?>(ref reader, options); break;
+                case "$lte": result.Lte = global::System.Text.Json.JsonSerializer.Deserialize<DateTimeOffset?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<DateTimeOffset>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DateTimeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.Gt is not null || value.Gte is not null || value.Lt is not null || value.Lte is not null || value.In is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.Gt is not null)
+        {
+            writer.WritePropertyName("$gt");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Gt, options);
+        }
+        if (value.Gte is not null)
+        {
+            writer.WritePropertyName("$gte");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Gte, options);
+        }
+        if (value.Lt is not null)
+        {
+            writer.WritePropertyName("$lt");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Lt, options);
+        }
+        if (value.Lte is not null)
+        {
+            writer.WritePropertyName("$lte");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Lte, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -8257,8 +9463,15 @@ public readonly record struct DecisionDefinitionKeyExactMatch : global::Camunda.
 /// <summary>
 /// DecisionDefinitionKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(DecisionDefinitionKeyFilterPropertyJsonConverter))]
 public sealed class DecisionDefinitionKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public DecisionDefinitionKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -8289,6 +9502,74 @@ public sealed class DecisionDefinitionKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<DecisionDefinitionKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator DecisionDefinitionKeyFilterProperty(DecisionDefinitionKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="DecisionDefinitionKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class DecisionDefinitionKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<DecisionDefinitionKeyFilterProperty>
+{
+    public override DecisionDefinitionKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new DecisionDefinitionKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<DecisionDefinitionKey?>(ref reader, options) };
+        var result = new DecisionDefinitionKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<DecisionDefinitionKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<DecisionDefinitionKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<DecisionDefinitionKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<DecisionDefinitionKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DecisionDefinitionKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -8553,8 +9834,15 @@ public readonly record struct DecisionEvaluationInstanceKeyExactMatch : global::
 /// <summary>
 /// DecisionEvaluationInstanceKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(DecisionEvaluationInstanceKeyFilterPropertyJsonConverter))]
 public sealed class DecisionEvaluationInstanceKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public DecisionEvaluationInstanceKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -8585,6 +9873,74 @@ public sealed class DecisionEvaluationInstanceKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<DecisionEvaluationInstanceKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator DecisionEvaluationInstanceKeyFilterProperty(DecisionEvaluationInstanceKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="DecisionEvaluationInstanceKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class DecisionEvaluationInstanceKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<DecisionEvaluationInstanceKeyFilterProperty>
+{
+    public override DecisionEvaluationInstanceKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new DecisionEvaluationInstanceKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<DecisionEvaluationInstanceKey?>(ref reader, options) };
+        var result = new DecisionEvaluationInstanceKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<DecisionEvaluationInstanceKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<DecisionEvaluationInstanceKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<DecisionEvaluationInstanceKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<DecisionEvaluationInstanceKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DecisionEvaluationInstanceKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -8662,8 +10018,15 @@ public readonly record struct DecisionEvaluationKeyExactMatch : global::Camunda.
 /// <summary>
 /// DecisionEvaluationKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(DecisionEvaluationKeyFilterPropertyJsonConverter))]
 public sealed class DecisionEvaluationKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public DecisionEvaluationKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -8694,6 +10057,74 @@ public sealed class DecisionEvaluationKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<DecisionEvaluationKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator DecisionEvaluationKeyFilterProperty(DecisionEvaluationKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="DecisionEvaluationKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class DecisionEvaluationKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<DecisionEvaluationKeyFilterProperty>
+{
+    public override DecisionEvaluationKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new DecisionEvaluationKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<DecisionEvaluationKey?>(ref reader, options) };
+        var result = new DecisionEvaluationKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<DecisionEvaluationKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<DecisionEvaluationKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<DecisionEvaluationKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<DecisionEvaluationKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DecisionEvaluationKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -9205,8 +10636,15 @@ public readonly record struct DecisionInstanceStateExactMatch : global::Camunda.
 /// <summary>
 /// DecisionInstanceStateEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(DecisionInstanceStateFilterPropertyJsonConverter))]
 public sealed class DecisionInstanceStateFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public DecisionInstanceStateEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -9251,6 +10689,80 @@ public sealed class DecisionInstanceStateFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator DecisionInstanceStateFilterProperty(DecisionInstanceStateEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="DecisionInstanceStateFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class DecisionInstanceStateFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<DecisionInstanceStateFilterProperty>
+{
+    public override DecisionInstanceStateFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new DecisionInstanceStateFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<DecisionInstanceStateEnum?>(ref reader, options) };
+        var result = new DecisionInstanceStateFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<DecisionInstanceStateEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<DecisionInstanceStateEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<DecisionInstanceStateEnum>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<DecisionInstanceStateEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DecisionInstanceStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -9355,8 +10867,15 @@ public readonly record struct DecisionRequirementsKeyExactMatch : global::Camund
 /// <summary>
 /// DecisionRequirementsKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(DecisionRequirementsKeyFilterPropertyJsonConverter))]
 public sealed class DecisionRequirementsKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public DecisionRequirementsKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -9387,6 +10906,74 @@ public sealed class DecisionRequirementsKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<DecisionRequirementsKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator DecisionRequirementsKeyFilterProperty(DecisionRequirementsKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="DecisionRequirementsKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class DecisionRequirementsKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<DecisionRequirementsKeyFilterProperty>
+{
+    public override DecisionRequirementsKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new DecisionRequirementsKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<DecisionRequirementsKey?>(ref reader, options) };
+        var result = new DecisionRequirementsKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<DecisionRequirementsKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<DecisionRequirementsKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<DecisionRequirementsKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<DecisionRequirementsKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DecisionRequirementsKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -9792,8 +11379,15 @@ public readonly record struct DeploymentKeyExactMatch : global::Camunda.Orchestr
 /// <summary>
 /// DeploymentKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(DeploymentKeyFilterPropertyJsonConverter))]
 public sealed class DeploymentKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public DeploymentKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -9824,6 +11418,74 @@ public sealed class DeploymentKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<DeploymentKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator DeploymentKeyFilterProperty(DeploymentKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="DeploymentKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class DeploymentKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<DeploymentKeyFilterProperty>
+{
+    public override DeploymentKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new DeploymentKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<DeploymentKey?>(ref reader, options) };
+        var result = new DeploymentKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<DeploymentKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<DeploymentKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<DeploymentKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<DeploymentKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DeploymentKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -10285,8 +11947,15 @@ public readonly record struct ElementIdExactMatch : global::Camunda.Orchestratio
 /// <summary>
 /// ElementId property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(ElementIdFilterPropertyJsonConverter))]
 public sealed class ElementIdFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ElementId? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -10331,6 +12000,80 @@ public sealed class ElementIdFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ElementIdFilterProperty(ElementId value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ElementIdFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ElementIdFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ElementIdFilterProperty>
+{
+    public override ElementIdFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ElementIdFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ElementId?>(ref reader, options) };
+        var result = new ElementIdFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ElementId?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ElementId?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ElementId>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<ElementId>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ElementIdFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -10607,8 +12350,15 @@ public readonly record struct ElementInstanceKeyExactMatch : global::Camunda.Orc
 /// <summary>
 /// ElementInstanceKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(ElementInstanceKeyFilterPropertyJsonConverter))]
 public sealed class ElementInstanceKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ElementInstanceKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -10639,6 +12389,74 @@ public sealed class ElementInstanceKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<ElementInstanceKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ElementInstanceKeyFilterProperty(ElementInstanceKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ElementInstanceKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ElementInstanceKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ElementInstanceKeyFilterProperty>
+{
+    public override ElementInstanceKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ElementInstanceKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ElementInstanceKey?>(ref reader, options) };
+        var result = new ElementInstanceKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ElementInstanceKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ElementInstanceKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ElementInstanceKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<ElementInstanceKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ElementInstanceKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -10843,8 +12661,15 @@ public readonly record struct ElementInstanceStateExactMatch : global::Camunda.O
 /// <summary>
 /// ElementInstanceStateEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(ElementInstanceStateFilterPropertyJsonConverter))]
 public sealed class ElementInstanceStateFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ElementInstanceStateEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -10883,6 +12708,74 @@ public sealed class ElementInstanceStateFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ElementInstanceStateFilterProperty(ElementInstanceStateEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ElementInstanceStateFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ElementInstanceStateFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ElementInstanceStateFilterProperty>
+{
+    public override ElementInstanceStateFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ElementInstanceStateFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ElementInstanceStateEnum?>(ref reader, options) };
+        var result = new ElementInstanceStateFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ElementInstanceStateEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ElementInstanceStateEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ElementInstanceStateEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ElementInstanceStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -11105,8 +12998,15 @@ public readonly record struct EntityTypeExactMatch : global::Camunda.Orchestrati
 /// <summary>
 /// AuditLogEntityTypeEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(EntityTypeFilterPropertyJsonConverter))]
 public sealed class EntityTypeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AuditLogEntityTypeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -11145,6 +13045,74 @@ public sealed class EntityTypeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator EntityTypeFilterProperty(AuditLogEntityTypeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="EntityTypeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class EntityTypeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<EntityTypeFilterProperty>
+{
+    public override EntityTypeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new EntityTypeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogEntityTypeEnum?>(ref reader, options) };
+        var result = new EntityTypeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogEntityTypeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogEntityTypeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AuditLogEntityTypeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, EntityTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -11552,8 +13520,15 @@ public readonly record struct FormKeyExactMatch : global::Camunda.Orchestration.
 /// <summary>
 /// FormKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(FormKeyFilterPropertyJsonConverter))]
 public sealed class FormKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public FormKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -11584,6 +13559,74 @@ public sealed class FormKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<FormKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator FormKeyFilterProperty(FormKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="FormKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class FormKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<FormKeyFilterProperty>
+{
+    public override FormKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new FormKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<FormKey?>(ref reader, options) };
+        var result = new FormKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<FormKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<FormKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<FormKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<FormKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, FormKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -11756,8 +13799,15 @@ public readonly record struct GlobalListenerSourceExactMatch : global::Camunda.O
 /// <summary>
 /// Global listener source property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(GlobalListenerSourceFilterPropertyJsonConverter))]
 public sealed class GlobalListenerSourceFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public GlobalListenerSourceEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -11796,6 +13846,74 @@ public sealed class GlobalListenerSourceFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator GlobalListenerSourceFilterProperty(GlobalListenerSourceEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="GlobalListenerSourceFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class GlobalListenerSourceFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<GlobalListenerSourceFilterProperty>
+{
+    public override GlobalListenerSourceFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new GlobalListenerSourceFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<GlobalListenerSourceEnum?>(ref reader, options) };
+        var result = new GlobalListenerSourceFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<GlobalListenerSourceEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<GlobalListenerSourceEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<GlobalListenerSourceEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, GlobalListenerSourceFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -11886,8 +14004,15 @@ public readonly record struct GlobalTaskListenerEventTypeExactMatch : global::Ca
 /// <summary>
 /// Global listener event type property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(GlobalTaskListenerEventTypeFilterPropertyJsonConverter))]
 public sealed class GlobalTaskListenerEventTypeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public GlobalTaskListenerEventTypeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -11926,6 +14051,74 @@ public sealed class GlobalTaskListenerEventTypeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator GlobalTaskListenerEventTypeFilterProperty(GlobalTaskListenerEventTypeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="GlobalTaskListenerEventTypeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class GlobalTaskListenerEventTypeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<GlobalTaskListenerEventTypeFilterProperty>
+{
+    public override GlobalTaskListenerEventTypeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new GlobalTaskListenerEventTypeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<GlobalTaskListenerEventTypeEnum?>(ref reader, options) };
+        var result = new GlobalTaskListenerEventTypeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<GlobalTaskListenerEventTypeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<GlobalTaskListenerEventTypeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<GlobalTaskListenerEventTypeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, GlobalTaskListenerEventTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -12567,8 +14760,15 @@ public readonly record struct IncidentErrorTypeExactMatch : global::Camunda.Orch
 /// <summary>
 /// IncidentErrorTypeEnum with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(IncidentErrorTypeFilterPropertyJsonConverter))]
 public sealed class IncidentErrorTypeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public IncidentErrorTypeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -12613,6 +14813,80 @@ public sealed class IncidentErrorTypeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator IncidentErrorTypeFilterProperty(IncidentErrorTypeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="IncidentErrorTypeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class IncidentErrorTypeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<IncidentErrorTypeFilterProperty>
+{
+    public override IncidentErrorTypeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new IncidentErrorTypeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<IncidentErrorTypeEnum?>(ref reader, options) };
+        var result = new IncidentErrorTypeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<IncidentErrorTypeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<IncidentErrorTypeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<IncidentErrorTypeEnum>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<IncidentErrorTypeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, IncidentErrorTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -13146,8 +15420,15 @@ public readonly record struct IncidentStateExactMatch : global::Camunda.Orchestr
 /// <summary>
 /// IncidentStateEnum with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(IncidentStateFilterPropertyJsonConverter))]
 public sealed class IncidentStateFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public IncidentStateEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -13192,6 +15473,80 @@ public sealed class IncidentStateFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator IncidentStateFilterProperty(IncidentStateEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="IncidentStateFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class IncidentStateFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<IncidentStateFilterProperty>
+{
+    public override IncidentStateFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new IncidentStateFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<IncidentStateEnum?>(ref reader, options) };
+        var result = new IncidentStateFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<IncidentStateEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<IncidentStateEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<IncidentStateEnum>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<IncidentStateEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, IncidentStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -13205,8 +15560,15 @@ public sealed class InferredAncestorKeyInstruction : AncestorScopeInstruction
 /// <summary>
 /// Integer property with advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(IntegerFilterPropertyJsonConverter))]
 public sealed class IntegerFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public int? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -13255,6 +15617,92 @@ public sealed class IntegerFilterProperty
     [JsonPropertyName("$in")]
     public List<int>? In { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator IntegerFilterProperty(int value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="IntegerFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class IntegerFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<IntegerFilterProperty>
+{
+    public override IntegerFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new IntegerFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<int?>(ref reader, options) };
+        var result = new IntegerFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<int?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<int?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$gt": result.Gt = global::System.Text.Json.JsonSerializer.Deserialize<int?>(ref reader, options); break;
+                case "$gte": result.Gte = global::System.Text.Json.JsonSerializer.Deserialize<int?>(ref reader, options); break;
+                case "$lt": result.Lt = global::System.Text.Json.JsonSerializer.Deserialize<int?>(ref reader, options); break;
+                case "$lte": result.Lte = global::System.Text.Json.JsonSerializer.Deserialize<int?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<int>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, IntegerFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.Gt is not null || value.Gte is not null || value.Lt is not null || value.Lte is not null || value.In is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.Gt is not null)
+        {
+            writer.WritePropertyName("$gt");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Gt, options);
+        }
+        if (value.Gte is not null)
+        {
+            writer.WritePropertyName("$gte");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Gte, options);
+        }
+        if (value.Lt is not null)
+        {
+            writer.WritePropertyName("$lt");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Lt, options);
+        }
+        if (value.Lte is not null)
+        {
+            writer.WritePropertyName("$lte");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Lte, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -13774,8 +16222,15 @@ public readonly record struct JobKeyExactMatch : global::Camunda.Orchestration.S
 /// <summary>
 /// JobKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(JobKeyFilterPropertyJsonConverter))]
 public sealed class JobKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public JobKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -13806,6 +16261,74 @@ public sealed class JobKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<JobKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator JobKeyFilterProperty(JobKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="JobKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class JobKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<JobKeyFilterProperty>
+{
+    public override JobKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new JobKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<JobKey?>(ref reader, options) };
+        var result = new JobKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<JobKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<JobKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<JobKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<JobKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, JobKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -13855,8 +16378,15 @@ public readonly record struct JobKindExactMatch : global::Camunda.Orchestration.
 /// <summary>
 /// JobKindEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(JobKindFilterPropertyJsonConverter))]
 public sealed class JobKindFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public JobKindEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -13895,6 +16425,74 @@ public sealed class JobKindFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator JobKindFilterProperty(JobKindEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="JobKindFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class JobKindFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<JobKindFilterProperty>
+{
+    public override JobKindFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new JobKindFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<JobKindEnum?>(ref reader, options) };
+        var result = new JobKindFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<JobKindEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<JobKindEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<JobKindEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, JobKindFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -13956,8 +16554,15 @@ public readonly record struct JobListenerEventTypeExactMatch : global::Camunda.O
 /// <summary>
 /// JobListenerEventTypeEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(JobListenerEventTypeFilterPropertyJsonConverter))]
 public sealed class JobListenerEventTypeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public JobListenerEventTypeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -13996,6 +16601,74 @@ public sealed class JobListenerEventTypeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator JobListenerEventTypeFilterProperty(JobListenerEventTypeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="JobListenerEventTypeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class JobListenerEventTypeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<JobListenerEventTypeFilterProperty>
+{
+    public override JobListenerEventTypeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new JobListenerEventTypeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<JobListenerEventTypeEnum?>(ref reader, options) };
+        var result = new JobListenerEventTypeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<JobListenerEventTypeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<JobListenerEventTypeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<JobListenerEventTypeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, JobListenerEventTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -14483,8 +17156,15 @@ public readonly record struct JobStateExactMatch : global::Camunda.Orchestration
 /// <summary>
 /// JobStateEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(JobStateFilterPropertyJsonConverter))]
 public sealed class JobStateFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public JobStateEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -14523,6 +17203,74 @@ public sealed class JobStateFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator JobStateFilterProperty(JobStateEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="JobStateFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class JobStateFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<JobStateFilterProperty>
+{
+    public override JobStateFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new JobStateFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<JobStateEnum?>(ref reader, options) };
+        var result = new JobStateFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<JobStateEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<JobStateEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<JobStateEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, JobStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -15691,8 +18439,15 @@ public readonly record struct MessageSubscriptionKeyExactMatch : global::Camunda
 /// <summary>
 /// MessageSubscriptionKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(MessageSubscriptionKeyFilterPropertyJsonConverter))]
 public sealed class MessageSubscriptionKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public MessageSubscriptionKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -15723,6 +18478,74 @@ public sealed class MessageSubscriptionKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<MessageSubscriptionKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator MessageSubscriptionKeyFilterProperty(MessageSubscriptionKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="MessageSubscriptionKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class MessageSubscriptionKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<MessageSubscriptionKeyFilterProperty>
+{
+    public override MessageSubscriptionKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new MessageSubscriptionKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<MessageSubscriptionKey?>(ref reader, options) };
+        var result = new MessageSubscriptionKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<MessageSubscriptionKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<MessageSubscriptionKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<MessageSubscriptionKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<MessageSubscriptionKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, MessageSubscriptionKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -15979,8 +18802,15 @@ public readonly record struct MessageSubscriptionStateExactMatch : global::Camun
 /// <summary>
 /// MessageSubscriptionStateEnum with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(MessageSubscriptionStateFilterPropertyJsonConverter))]
 public sealed class MessageSubscriptionStateFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public MessageSubscriptionStateEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -16019,6 +18849,74 @@ public sealed class MessageSubscriptionStateFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator MessageSubscriptionStateFilterProperty(MessageSubscriptionStateEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="MessageSubscriptionStateFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class MessageSubscriptionStateFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<MessageSubscriptionStateFilterProperty>
+{
+    public override MessageSubscriptionStateFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new MessageSubscriptionStateFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<MessageSubscriptionStateEnum?>(ref reader, options) };
+        var result = new MessageSubscriptionStateFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<MessageSubscriptionStateEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<MessageSubscriptionStateEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<MessageSubscriptionStateEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, MessageSubscriptionStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -16069,8 +18967,15 @@ public readonly record struct MessageSubscriptionTypeExactMatch : global::Camund
 /// <summary>
 /// MessageSubscriptionTypeEnum with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(MessageSubscriptionTypeFilterPropertyJsonConverter))]
 public sealed class MessageSubscriptionTypeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public MessageSubscriptionTypeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -16109,6 +19014,74 @@ public sealed class MessageSubscriptionTypeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator MessageSubscriptionTypeFilterProperty(MessageSubscriptionTypeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="MessageSubscriptionTypeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class MessageSubscriptionTypeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<MessageSubscriptionTypeFilterProperty>
+{
+    public override MessageSubscriptionTypeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new MessageSubscriptionTypeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<MessageSubscriptionTypeEnum?>(ref reader, options) };
+        var result = new MessageSubscriptionTypeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<MessageSubscriptionTypeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<MessageSubscriptionTypeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<MessageSubscriptionTypeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, MessageSubscriptionTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -16248,8 +19221,15 @@ public readonly record struct OperationTypeExactMatch : global::Camunda.Orchestr
 /// <summary>
 /// AuditLogOperationTypeEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(OperationTypeFilterPropertyJsonConverter))]
 public sealed class OperationTypeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public AuditLogOperationTypeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -16288,6 +19268,74 @@ public sealed class OperationTypeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator OperationTypeFilterProperty(AuditLogOperationTypeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="OperationTypeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class OperationTypeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<OperationTypeFilterProperty>
+{
+    public override OperationTypeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new OperationTypeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogOperationTypeEnum?>(ref reader, options) };
+        var result = new OperationTypeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogOperationTypeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<AuditLogOperationTypeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<AuditLogOperationTypeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, OperationTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -16615,8 +19663,15 @@ public readonly record struct ProcessDefinitionIdExactMatch : global::Camunda.Or
 /// <summary>
 /// ProcessDefinitionId property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(ProcessDefinitionIdFilterPropertyJsonConverter))]
 public sealed class ProcessDefinitionIdFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ProcessDefinitionId? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -16661,6 +19716,80 @@ public sealed class ProcessDefinitionIdFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ProcessDefinitionIdFilterProperty(ProcessDefinitionId value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ProcessDefinitionIdFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ProcessDefinitionIdFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ProcessDefinitionIdFilterProperty>
+{
+    public override ProcessDefinitionIdFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ProcessDefinitionIdFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ProcessDefinitionId?>(ref reader, options) };
+        var result = new ProcessDefinitionIdFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ProcessDefinitionId?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ProcessDefinitionId?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ProcessDefinitionId>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<ProcessDefinitionId>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ProcessDefinitionIdFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -16953,8 +20082,15 @@ public readonly record struct ProcessDefinitionKeyExactMatch : global::Camunda.O
 /// <summary>
 /// ProcessDefinitionKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(ProcessDefinitionKeyFilterPropertyJsonConverter))]
 public sealed class ProcessDefinitionKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ProcessDefinitionKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -16985,6 +20121,74 @@ public sealed class ProcessDefinitionKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<ProcessDefinitionKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ProcessDefinitionKeyFilterProperty(ProcessDefinitionKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ProcessDefinitionKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ProcessDefinitionKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ProcessDefinitionKeyFilterProperty>
+{
+    public override ProcessDefinitionKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ProcessDefinitionKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ProcessDefinitionKey?>(ref reader, options) };
+        var result = new ProcessDefinitionKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ProcessDefinitionKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ProcessDefinitionKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ProcessDefinitionKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<ProcessDefinitionKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ProcessDefinitionKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -18169,8 +21373,15 @@ public readonly record struct ProcessInstanceKeyExactMatch : global::Camunda.Orc
 /// <summary>
 /// ProcessInstanceKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(ProcessInstanceKeyFilterPropertyJsonConverter))]
 public sealed class ProcessInstanceKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ProcessInstanceKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -18201,6 +21412,74 @@ public sealed class ProcessInstanceKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<ProcessInstanceKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ProcessInstanceKeyFilterProperty(ProcessInstanceKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ProcessInstanceKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ProcessInstanceKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ProcessInstanceKeyFilterProperty>
+{
+    public override ProcessInstanceKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ProcessInstanceKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ProcessInstanceKey?>(ref reader, options) };
+        var result = new ProcessInstanceKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ProcessInstanceKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ProcessInstanceKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ProcessInstanceKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<ProcessInstanceKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ProcessInstanceKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -18772,8 +22051,15 @@ public readonly record struct ProcessInstanceStateExactMatch : global::Camunda.O
 /// <summary>
 /// ProcessInstanceStateEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(ProcessInstanceStateFilterPropertyJsonConverter))]
 public sealed class ProcessInstanceStateFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ProcessInstanceStateEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -18812,6 +22098,74 @@ public sealed class ProcessInstanceStateFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ProcessInstanceStateFilterProperty(ProcessInstanceStateEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ProcessInstanceStateFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ProcessInstanceStateFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ProcessInstanceStateFilterProperty>
+{
+    public override ProcessInstanceStateFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ProcessInstanceStateFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ProcessInstanceStateEnum?>(ref reader, options) };
+        var result = new ProcessInstanceStateFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ProcessInstanceStateEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ProcessInstanceStateEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ProcessInstanceStateEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ProcessInstanceStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -18954,8 +22308,15 @@ public readonly record struct ResourceKeyExactMatch : global::Camunda.Orchestrat
 /// <summary>
 /// ResourceKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(ResourceKeyFilterPropertyJsonConverter))]
 public sealed class ResourceKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ResourceKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -18986,6 +22347,74 @@ public sealed class ResourceKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<ResourceKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ResourceKeyFilterProperty(ResourceKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ResourceKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ResourceKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ResourceKeyFilterProperty>
+{
+    public override ResourceKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ResourceKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ResourceKey?>(ref reader, options) };
+        var result = new ResourceKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ResourceKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ResourceKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ResourceKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<ResourceKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ResourceKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -19679,8 +23108,15 @@ public readonly record struct ScopeKeyExactMatch : global::Camunda.Orchestration
 /// element instance or process instance that defines the scope of a variable.
 /// 
 /// </summary>
+[JsonConverter(typeof(ScopeKeyFilterPropertyJsonConverter))]
 public sealed class ScopeKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ScopeKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -19711,6 +23147,74 @@ public sealed class ScopeKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<ScopeKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ScopeKeyFilterProperty(ScopeKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ScopeKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ScopeKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ScopeKeyFilterProperty>
+{
+    public override ScopeKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ScopeKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ScopeKey?>(ref reader, options) };
+        var result = new ScopeKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ScopeKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ScopeKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ScopeKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<ScopeKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ScopeKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -20034,8 +23538,15 @@ public sealed class StatusMetric
 /// <summary>
 /// String property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(StringFilterPropertyJsonConverter))]
 public sealed class StringFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public string? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -20080,6 +23591,80 @@ public sealed class StringFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator StringFilterProperty(string value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="StringFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class StringFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<StringFilterProperty>
+{
+    public override StringFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new StringFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<string?>(ref reader, options) };
+        var result = new StringFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<string?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<string?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<string>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<string>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, StringFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -21673,8 +25258,15 @@ public readonly record struct UserTaskStateExactMatch : global::Camunda.Orchestr
 /// <summary>
 /// UserTaskStateEnum property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(UserTaskStateFilterPropertyJsonConverter))]
 public sealed class UserTaskStateFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public UserTaskStateEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -21713,6 +25305,74 @@ public sealed class UserTaskStateFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator UserTaskStateFilterProperty(UserTaskStateEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="UserTaskStateFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class UserTaskStateFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<UserTaskStateFilterProperty>
+{
+    public override UserTaskStateFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new UserTaskStateFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<UserTaskStateEnum?>(ref reader, options) };
+        var result = new UserTaskStateFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<UserTaskStateEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<UserTaskStateEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<UserTaskStateEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, UserTaskStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -22002,8 +25662,15 @@ public readonly record struct VariableKeyExactMatch : global::Camunda.Orchestrat
 /// <summary>
 /// VariableKey property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(VariableKeyFilterPropertyJsonConverter))]
 public sealed class VariableKeyFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public VariableKey? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -22034,6 +25701,74 @@ public sealed class VariableKeyFilterProperty
     [JsonPropertyName("$notIn")]
     public List<VariableKey>? NotIn { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator VariableKeyFilterProperty(VariableKey value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="VariableKeyFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class VariableKeyFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<VariableKeyFilterProperty>
+{
+    public override VariableKeyFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new VariableKeyFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<VariableKey?>(ref reader, options) };
+        var result = new VariableKeyFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<VariableKey?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<VariableKey?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<VariableKey>?>(ref reader, options); break;
+                case "$notIn": result.NotIn = global::System.Text.Json.JsonSerializer.Deserialize<List<VariableKey>?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, VariableKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.NotIn is not null)
+        {
+            writer.WritePropertyName("$notIn");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.NotIn, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -22412,8 +26147,15 @@ public readonly record struct WaitStateElementTypeExactMatch : global::Camunda.O
 /// <summary>
 /// Element type property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(WaitStateElementTypeFilterPropertyJsonConverter))]
 public sealed class WaitStateElementTypeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public WaitStateElementTypeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -22452,6 +26194,74 @@ public sealed class WaitStateElementTypeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator WaitStateElementTypeFilterProperty(WaitStateElementTypeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="WaitStateElementTypeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class WaitStateElementTypeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<WaitStateElementTypeFilterProperty>
+{
+    public override WaitStateElementTypeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new WaitStateElementTypeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<WaitStateElementTypeEnum?>(ref reader, options) };
+        var result = new WaitStateElementTypeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<WaitStateElementTypeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<WaitStateElementTypeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<WaitStateElementTypeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, WaitStateElementTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>
@@ -22505,8 +26315,15 @@ public readonly record struct WaitStateTypeExactMatch : global::Camunda.Orchestr
 /// <summary>
 /// Wait state type property with full advanced search capabilities.
 /// </summary>
+[JsonConverter(typeof(WaitStateTypeFilterPropertyJsonConverter))]
 public sealed class WaitStateTypeFilterProperty
 {
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public WaitStateTypeEnum? ExactMatch { get; set; }
+
     /// <summary>
     /// Checks for equality with the provided value.
     /// </summary>
@@ -22545,6 +26362,74 @@ public sealed class WaitStateTypeFilterProperty
     [JsonPropertyName("$like")]
     public LikeFilter? Like { get; set; }
 
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator WaitStateTypeFilterProperty(WaitStateTypeEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="WaitStateTypeFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class WaitStateTypeFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<WaitStateTypeFilterProperty>
+{
+    public override WaitStateTypeFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new WaitStateTypeFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<WaitStateTypeEnum?>(ref reader, options) };
+        var result = new WaitStateTypeFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<WaitStateTypeEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<WaitStateTypeEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<WaitStateTypeEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, WaitStateTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && !hasAdvanced)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
 }
 
 /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -3523,7 +3523,9 @@ internal sealed class AgentHistoryItemKeyFilterPropertyJsonConverter : global::S
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AgentHistoryItemKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("AgentHistoryItemKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -3850,7 +3852,9 @@ internal sealed class AgentInstanceHistoryCommitStatusFilterPropertyJsonConverte
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AgentInstanceHistoryCommitStatusFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("AgentInstanceHistoryCommitStatusFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -4229,7 +4233,9 @@ internal sealed class AgentInstanceHistoryRoleFilterPropertyJsonConverter : glob
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AgentInstanceHistoryRoleFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("AgentInstanceHistoryRoleFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -4455,7 +4461,9 @@ internal sealed class AgentInstanceKeyFilterPropertyJsonConverter : global::Syst
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AgentInstanceKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("AgentInstanceKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -4942,7 +4950,9 @@ internal sealed class AgentInstanceStatusFilterPropertyJsonConverter : global::S
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AgentInstanceStatusFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("AgentInstanceStatusFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -5256,7 +5266,9 @@ internal sealed class AuditLogActorTypeFilterPropertyJsonConverter : global::Sys
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AuditLogActorTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("AuditLogActorTypeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -5438,7 +5450,9 @@ internal sealed class AuditLogEntityKeyFilterPropertyJsonConverter : global::Sys
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AuditLogEntityKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("AuditLogEntityKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -5837,7 +5851,9 @@ internal sealed class AuditLogKeyFilterPropertyJsonConverter : global::System.Te
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AuditLogKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("AuditLogKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -6247,7 +6263,9 @@ internal sealed class AuditLogResultFilterPropertyJsonConverter : global::System
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, AuditLogResultFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("AuditLogResultFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -6883,7 +6901,9 @@ internal sealed class BasicStringFilterPropertyJsonConverter : global::System.Te
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, BasicStringFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("BasicStringFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -7291,7 +7311,9 @@ internal sealed class BatchOperationItemStateFilterPropertyJsonConverter : globa
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, BatchOperationItemStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("BatchOperationItemStateFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -7632,7 +7654,9 @@ internal sealed class BatchOperationStateFilterPropertyJsonConverter : global::S
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, BatchOperationStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("BatchOperationStateFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -7808,7 +7832,9 @@ internal sealed class BatchOperationTypeFilterPropertyJsonConverter : global::Sy
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, BatchOperationTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("BatchOperationTypeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -8108,7 +8134,9 @@ internal sealed class CategoryFilterPropertyJsonConverter : global::System.Text.
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, CategoryFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("CategoryFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -8478,7 +8506,9 @@ internal sealed class ClusterVariableScopeFilterPropertyJsonConverter : global::
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ClusterVariableScopeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ClusterVariableScopeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -9256,7 +9286,9 @@ internal sealed class DateTimeFilterPropertyJsonConverter : global::System.Text.
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DateTimeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.Gt is not null || value.Gte is not null || value.Lt is not null || value.Lte is not null || value.In is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("DateTimeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -9537,7 +9569,9 @@ internal sealed class DecisionDefinitionKeyFilterPropertyJsonConverter : global:
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DecisionDefinitionKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("DecisionDefinitionKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -9908,7 +9942,9 @@ internal sealed class DecisionEvaluationInstanceKeyFilterPropertyJsonConverter :
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DecisionEvaluationInstanceKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("DecisionEvaluationInstanceKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -10092,7 +10128,9 @@ internal sealed class DecisionEvaluationKeyFilterPropertyJsonConverter : global:
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DecisionEvaluationKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("DecisionEvaluationKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -10725,7 +10763,9 @@ internal sealed class DecisionInstanceStateFilterPropertyJsonConverter : global:
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DecisionInstanceStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("DecisionInstanceStateFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -10941,7 +10981,9 @@ internal sealed class DecisionRequirementsKeyFilterPropertyJsonConverter : globa
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DecisionRequirementsKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("DecisionRequirementsKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -11453,7 +11495,9 @@ internal sealed class DeploymentKeyFilterPropertyJsonConverter : global::System.
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, DeploymentKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("DeploymentKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -12036,7 +12080,9 @@ internal sealed class ElementIdFilterPropertyJsonConverter : global::System.Text
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ElementIdFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ElementIdFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -12424,7 +12470,9 @@ internal sealed class ElementInstanceKeyFilterPropertyJsonConverter : global::Sy
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ElementInstanceKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ElementInstanceKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -12743,7 +12791,9 @@ internal sealed class ElementInstanceStateFilterPropertyJsonConverter : global::
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ElementInstanceStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ElementInstanceStateFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -13080,7 +13130,9 @@ internal sealed class EntityTypeFilterPropertyJsonConverter : global::System.Tex
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, EntityTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("EntityTypeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -13594,7 +13646,9 @@ internal sealed class FormKeyFilterPropertyJsonConverter : global::System.Text.J
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, FormKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("FormKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -13881,7 +13935,9 @@ internal sealed class GlobalListenerSourceFilterPropertyJsonConverter : global::
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, GlobalListenerSourceFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("GlobalListenerSourceFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -14086,7 +14142,9 @@ internal sealed class GlobalTaskListenerEventTypeFilterPropertyJsonConverter : g
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, GlobalTaskListenerEventTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("GlobalTaskListenerEventTypeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -14849,7 +14907,9 @@ internal sealed class IncidentErrorTypeFilterPropertyJsonConverter : global::Sys
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, IncidentErrorTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("IncidentErrorTypeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -15509,7 +15569,9 @@ internal sealed class IncidentStateFilterPropertyJsonConverter : global::System.
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, IncidentStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("IncidentStateFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -15655,7 +15717,9 @@ internal sealed class IntegerFilterPropertyJsonConverter : global::System.Text.J
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, IntegerFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.Gt is not null || value.Gte is not null || value.Lt is not null || value.Lte is not null || value.In is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("IntegerFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -16296,7 +16360,9 @@ internal sealed class JobKeyFilterPropertyJsonConverter : global::System.Text.Js
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, JobKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("JobKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -16460,7 +16526,9 @@ internal sealed class JobKindFilterPropertyJsonConverter : global::System.Text.J
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, JobKindFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("JobKindFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -16636,7 +16704,9 @@ internal sealed class JobListenerEventTypeFilterPropertyJsonConverter : global::
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, JobListenerEventTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("JobListenerEventTypeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -17238,7 +17308,9 @@ internal sealed class JobStateFilterPropertyJsonConverter : global::System.Text.
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, JobStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("JobStateFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -18513,7 +18585,9 @@ internal sealed class MessageSubscriptionKeyFilterPropertyJsonConverter : global
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, MessageSubscriptionKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("MessageSubscriptionKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -18884,7 +18958,9 @@ internal sealed class MessageSubscriptionStateFilterPropertyJsonConverter : glob
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, MessageSubscriptionStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("MessageSubscriptionStateFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -19049,7 +19125,9 @@ internal sealed class MessageSubscriptionTypeFilterPropertyJsonConverter : globa
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, MessageSubscriptionTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("MessageSubscriptionTypeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -19303,7 +19381,9 @@ internal sealed class OperationTypeFilterPropertyJsonConverter : global::System.
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, OperationTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("OperationTypeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -19752,7 +19832,9 @@ internal sealed class ProcessDefinitionIdFilterPropertyJsonConverter : global::S
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ProcessDefinitionIdFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ProcessDefinitionIdFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -20156,7 +20238,9 @@ internal sealed class ProcessDefinitionKeyFilterPropertyJsonConverter : global::
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ProcessDefinitionKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ProcessDefinitionKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -21447,7 +21531,9 @@ internal sealed class ProcessInstanceKeyFilterPropertyJsonConverter : global::Sy
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ProcessInstanceKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ProcessInstanceKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -22133,7 +22219,9 @@ internal sealed class ProcessInstanceStateFilterPropertyJsonConverter : global::
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ProcessInstanceStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ProcessInstanceStateFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -22382,7 +22470,9 @@ internal sealed class ResourceKeyFilterPropertyJsonConverter : global::System.Te
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ResourceKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ResourceKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -23182,7 +23272,9 @@ internal sealed class ScopeKeyFilterPropertyJsonConverter : global::System.Text.
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ScopeKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ScopeKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -23627,7 +23719,9 @@ internal sealed class StringFilterPropertyJsonConverter : global::System.Text.Js
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, StringFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("StringFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -25340,7 +25434,9 @@ internal sealed class UserTaskStateFilterPropertyJsonConverter : global::System.
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, UserTaskStateFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("UserTaskStateFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -25736,7 +25832,9 @@ internal sealed class VariableKeyFilterPropertyJsonConverter : global::System.Te
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, VariableKeyFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.NotIn is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("VariableKeyFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -26229,7 +26327,9 @@ internal sealed class WaitStateElementTypeFilterPropertyJsonConverter : global::
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, WaitStateElementTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("WaitStateElementTypeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;
@@ -26397,7 +26497,9 @@ internal sealed class WaitStateTypeFilterPropertyJsonConverter : global::System.
     public override void Write(global::System.Text.Json.Utf8JsonWriter writer, WaitStateTypeFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
     {
         var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
-        if (value.ExactMatch is not null && !hasAdvanced)
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("WaitStateTypeFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
         {
             global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
             return;

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:3109b2bbf804c57e74e0f4726bb7fa69d81a8b5f1fc331f5d2ceaf34b8cc6622";
+    public const string SpecHash = "sha256:58b138a72a997a92677d7303929b2ff3acd80d14726313fd87eb6e9625d38bd4";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/FilterPropertyExactMatchSerializationTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/FilterPropertyExactMatchSerializationTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using Camunda.Orchestration.Sdk;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Behavioural guard (against the generated SDK) for advanced-filter <c>oneOf</c>
+/// properties: the exact-match (bare scalar) branch and the advanced (operator
+/// object) branch must both be expressible and must round-trip to the correct wire
+/// shape. The bare form is what servers predating advanced filtering on a field
+/// accept, so this is what keeps a newer SDK working against an older server
+/// (see #267). Uses <c>ProcessInstanceKeyFilterProperty</c> as the representative.
+/// </summary>
+public class FilterPropertyExactMatchSerializationTests
+{
+    private const string Key = "2251799813685261";
+
+    // Same key converters the client registers on its serializer options; the
+    // generated filter converter delegates key (de)serialization to these.
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        Converters =
+        {
+            new CamundaKeyJsonConverterFactory(),
+            new CamundaLongKeyJsonConverterFactory(),
+        },
+    };
+
+    [Fact]
+    public void Exact_match_serializes_as_bare_scalar()
+    {
+        // Implicit conversion from the key — the original (pre-advanced-filter) call shape.
+        ProcessInstanceKeyFilterProperty filter = ProcessInstanceKey.AssumeExists(Key);
+        Assert.Equal($"\"{Key}\"", JsonSerializer.Serialize(filter, Options));
+    }
+
+    [Fact]
+    public void Advanced_operator_serializes_as_object()
+    {
+        var filter = new ProcessInstanceKeyFilterProperty { Eq = ProcessInstanceKey.AssumeExists(Key) };
+        Assert.Equal($"{{\"$eq\":\"{Key}\"}}", JsonSerializer.Serialize(filter, Options));
+    }
+
+    [Fact]
+    public void Bare_scalar_deserializes_to_exact_match()
+    {
+        var filter = JsonSerializer.Deserialize<ProcessInstanceKeyFilterProperty>($"\"{Key}\"", Options);
+        Assert.NotNull(filter);
+        Assert.Equal(Key, filter!.ExactMatch?.Value);
+        Assert.Null(filter.Eq);
+    }
+
+    [Fact]
+    public void Object_deserializes_to_advanced_operator()
+    {
+        var filter = JsonSerializer.Deserialize<ProcessInstanceKeyFilterProperty>($"{{\"$eq\":\"{Key}\"}}", Options);
+        Assert.NotNull(filter);
+        Assert.Equal(Key, filter!.Eq?.Value);
+        Assert.Null(filter.ExactMatch);
+    }
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/FilterPropertyExactMatchSerializationTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/FilterPropertyExactMatchSerializationTests.cs
@@ -58,4 +58,17 @@ public class FilterPropertyExactMatchSerializationTests
         Assert.Equal(Key, filter!.Eq?.Value);
         Assert.Null(filter.ExactMatch);
     }
+
+    [Fact]
+    public void Setting_both_branches_throws()
+    {
+        // oneOf semantics: exactly one branch. Populating both is ambiguous and must fail
+        // loudly rather than silently dropping ExactMatch.
+        var filter = new ProcessInstanceKeyFilterProperty
+        {
+            ExactMatch = ProcessInstanceKey.AssumeExists(Key),
+            Eq = ProcessInstanceKey.AssumeExists(Key),
+        };
+        Assert.Throws<JsonException>(() => JsonSerializer.Serialize(filter, Options));
+    }
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/GeneratorOneOfExactMatchTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/GeneratorOneOfExactMatchTests.cs
@@ -144,7 +144,8 @@ public class GeneratorOneOfExactMatchTests
 
         public void Dispose()
         {
-            try { Directory.Delete(Root, recursive: true); }
+            try
+            { Directory.Delete(Root, recursive: true); }
             catch { /* best-effort cleanup */ }
         }
     }

--- a/test/Camunda.Orchestration.Sdk.Tests/GeneratorOneOfExactMatchTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/GeneratorOneOfExactMatchTests.cs
@@ -1,0 +1,151 @@
+using Camunda.Orchestration.Sdk.Generator;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Defect-class regression guard for advanced-filter <c>oneOf</c> properties.
+///
+/// The Camunda search API models a filterable field as
+/// <c>XFilterProperty = oneOf[ XExactMatch (a bare scalar), AdvancedXFilter ({ $eq, $in, … }) ]</c>,
+/// so the wire accepts <em>either</em> a bare value (<c>"k": "123"</c>) or the
+/// operator object (<c>"k": { "$eq": "123" }</c>). The bare/exact-match form is
+/// also the shape older servers (that predate advanced filtering on that field)
+/// expect.
+///
+/// The defect: the generator collapsed the <c>oneOf</c> to the non-primitive
+/// (advanced) variant only, dropping the exact-match (scalar) branch entirely.
+/// The generated type therefore exposed just <c>Eq</c>/<c>In</c>/… and there was
+/// no way to send the bare form — which both hurts ergonomics and breaks
+/// newer-SDK → older-server compatibility for these fields (see #267).
+///
+/// The fix targets the defect <em>class</em>: any <c>oneOf[scalar | advanced]</c>
+/// filter property must also surface the exact-match branch — an
+/// <c>ExactMatch</c> member, an implicit conversion from the value type, and a
+/// converter that serialises the bare scalar when only the exact match is set.
+/// </summary>
+public class GeneratorOneOfExactMatchTests
+{
+    //   MyKey               : string  (semantic-key-like domain struct)
+    //   MyKeyExactMatch     : string + allOf[MyKey]   (the bare/scalar branch)
+    //   AdvancedMyKeyFilter : object { $eq: MyKey, $in: MyKey[] }
+    //   MyKeyFilterProperty : oneOf[ MyKeyExactMatch, AdvancedMyKeyFilter ]
+    private const string OneOfExactMatchSpec = """
+        {
+          "openapi": "3.0.3",
+          "info": { "title": "Test", "version": "1.0.0" },
+          "paths": {
+            "/thing": {
+              "get": {
+                "operationId": "getThing",
+                "responses": {
+                  "200": {
+                    "description": "ok",
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Thing" } } }
+                  }
+                }
+              }
+            }
+          },
+          "components": {
+            "schemas": {
+              "MyKey": { "type": "string" },
+              "MyKeyExactMatch": {
+                "type": "string",
+                "title": "Exact match",
+                "allOf": [ { "$ref": "#/components/schemas/MyKey" } ]
+              },
+              "AdvancedMyKeyFilter": {
+                "type": "object",
+                "properties": {
+                  "$eq":  { "allOf": [ { "$ref": "#/components/schemas/MyKey" } ] },
+                  "$in":  { "type": "array", "items": { "$ref": "#/components/schemas/MyKey" } }
+                }
+              },
+              "MyKeyFilterProperty": {
+                "description": "MyKey property with full advanced search capabilities.",
+                "oneOf": [
+                  { "$ref": "#/components/schemas/MyKeyExactMatch" },
+                  { "$ref": "#/components/schemas/AdvancedMyKeyFilter" }
+                ]
+              },
+              "Thing": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "allOf": [ { "$ref": "#/components/schemas/MyKeyFilterProperty" } ],
+                    "description": "the key"
+                  }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    [Fact]
+    public void Filter_property_oneOf_exposes_exact_match_scalar_branch()
+    {
+        using var tmp = TempSpecDir.Create();
+        File.WriteAllText(tmp.SpecPath, OneOfExactMatchSpec);
+        File.WriteAllText(tmp.MetadataPath, MinimalBundledSpec.MinimalMetadata);
+
+        CSharpClientGenerator.Generate(tmp.SpecPath, tmp.MetadataPath, tmp.OutputDir);
+        var models = File.ReadAllText(Path.Combine(tmp.OutputDir, "Models.Generated.cs"));
+        var root = CSharpSyntaxTree.ParseText(models).GetCompilationUnitRoot();
+
+        var filter = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .SingleOrDefault(c => c.Identifier.ValueText == "MyKeyFilterProperty");
+        Assert.True(filter != null, "Expected a generated MyKeyFilterProperty class.");
+
+        var props = filter!.Members.OfType<PropertyDeclarationSyntax>()
+            .ToDictionary(p => p.Identifier.ValueText, p => p.Type.ToString());
+
+        // The advanced operators must still be present (existing behaviour).
+        Assert.Contains("Eq", props.Keys);
+        Assert.Contains("In", props.Keys);
+
+        // The defect: the exact-match (scalar) branch was dropped. It must be
+        // surfaced as an ExactMatch member typed as the value type (MyKey), so a
+        // bare value can be expressed at all.
+        Assert.Contains("ExactMatch", props.Keys);
+        Assert.Equal("MyKey?", props["ExactMatch"]);
+
+        // Ergonomics + the original (pre-advanced-filter) call shape: assigning a
+        // bare key must compile, via an implicit conversion from the value type.
+        Assert.Contains("public static implicit operator MyKeyFilterProperty(MyKey", models);
+
+        // Faithful wire behaviour requires a custom converter (bare scalar when
+        // only ExactMatch is set; the { $eq, … } object otherwise).
+        Assert.Contains("[JsonConverter(typeof(MyKeyFilterPropertyJsonConverter))]", models);
+        Assert.Contains("class MyKeyFilterPropertyJsonConverter", models);
+    }
+
+    private sealed class TempSpecDir : IDisposable
+    {
+        public string Root { get; }
+        public string SpecPath => Path.Combine(Root, "spec.json");
+        public string MetadataPath => Path.Combine(Root, "metadata.json");
+        public string OutputDir => Path.Combine(Root, "out");
+
+        private TempSpecDir(string root)
+        {
+            Root = root;
+            Directory.CreateDirectory(OutputDir);
+        }
+
+        public static TempSpecDir Create()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "csharp-gen-oneof-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            return new TempSpecDir(dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Root, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -486,8 +486,10 @@ TYPE Camunda.Orchestration.Sdk.AgentHistoryItemKeyExactMatch : struct interfaces
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.AgentHistoryItemKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.AgentHistoryItemKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentHistoryItemKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -547,8 +549,10 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusExactMatch : stru
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum>? In { get; set; } [JsonPropertyName("$in")]
@@ -617,8 +621,10 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleExactMatch : struct inter
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum>? In { get; set; } [JsonPropertyName("$in")]
@@ -665,8 +671,10 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceKeyExactMatch : struct interfaces=[C
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.AgentInstanceKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AgentInstanceKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -781,8 +789,10 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusExactMatch : struct interfaces
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceStatusFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.AgentInstanceStatusFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AgentInstanceStatusEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -844,8 +854,10 @@ TYPE Camunda.Orchestration.Sdk.AuditLogActorTypeExactMatch : struct interfaces=[
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.AuditLogActorTypeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.AuditLogActorTypeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuditLogActorTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AuditLogActorTypeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AuditLogActorTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -877,8 +889,10 @@ TYPE Camunda.Orchestration.Sdk.AuditLogEntityKeyExactMatch : struct interfaces=[
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.AuditLogEntityKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.AuditLogEntityKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuditLogEntityKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AuditLogEntityKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AuditLogEntityKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogEntityKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -956,8 +970,10 @@ TYPE Camunda.Orchestration.Sdk.AuditLogKeyExactMatch : struct interfaces=[Camund
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.AuditLogKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.AuditLogKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuditLogKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AuditLogKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AuditLogKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -1033,8 +1049,10 @@ TYPE Camunda.Orchestration.Sdk.AuditLogResultExactMatch : struct interfaces=[Cam
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.AuditLogResultFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.AuditLogResultFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuditLogResultEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AuditLogResultEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AuditLogResultEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -1233,11 +1251,13 @@ TYPE Camunda.Orchestration.Sdk.BasicStringFilter : sealed class
   PROP System.String? Neq { get; set; } [JsonPropertyName("$neq")]
 
 TYPE Camunda.Orchestration.Sdk.BasicStringFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.BasicStringFilterPropertyJsonConverter
   CTOR ()
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<System.String>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Collections.Generic.List<System.String>? NotIn { get; set; } [JsonPropertyName("$notIn")]
   PROP System.String? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP System.String? ExactMatch { get; set; }
   PROP System.String? Neq { get; set; } [JsonPropertyName("$neq")]
 
 TYPE Camunda.Orchestration.Sdk.BatchOperationCreatedResult : sealed class
@@ -1336,8 +1356,10 @@ TYPE Camunda.Orchestration.Sdk.BatchOperationItemStateExactMatch : struct interf
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.BatchOperationItemStateFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.BatchOperationItemStateFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.BatchOperationItemStateEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.BatchOperationItemStateEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.BatchOperationItemStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -1414,8 +1436,10 @@ TYPE Camunda.Orchestration.Sdk.BatchOperationStateExactMatch : struct interfaces
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.BatchOperationStateFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.BatchOperationStateFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.BatchOperationStateEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.BatchOperationStateEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.BatchOperationStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -1445,8 +1469,10 @@ TYPE Camunda.Orchestration.Sdk.BatchOperationTypeExactMatch : struct interfaces=
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.BatchOperationTypeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.BatchOperationTypeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.BatchOperationTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.BatchOperationTypeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.BatchOperationTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -1782,8 +1808,10 @@ TYPE Camunda.Orchestration.Sdk.CategoryExactMatch : struct interfaces=[Camunda.O
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.CategoryFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.CategoryFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuditLogCategoryEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AuditLogCategoryEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AuditLogCategoryEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -1859,8 +1887,10 @@ TYPE Camunda.Orchestration.Sdk.ClusterVariableScopeExactMatch : struct interface
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableScopeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ClusterVariableScopeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -2057,10 +2087,12 @@ TYPE Camunda.Orchestration.Sdk.CursorForwardPagination : sealed class base=Camun
   PROP System.Int32? Limit { get; set; } [JsonPropertyName("limit")]
 
 TYPE Camunda.Orchestration.Sdk.DateTimeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.DateTimeFilterPropertyJsonConverter
   CTOR ()
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<System.DateTimeOffset>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.DateTimeOffset? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP System.DateTimeOffset? ExactMatch { get; set; }
   PROP System.DateTimeOffset? Gt { get; set; } [JsonPropertyName("$gt")]
   PROP System.DateTimeOffset? Gte { get; set; } [JsonPropertyName("$gte")]
   PROP System.DateTimeOffset? Lt { get; set; } [JsonPropertyName("$lt")]
@@ -2108,8 +2140,10 @@ TYPE Camunda.Orchestration.Sdk.DecisionDefinitionKeyExactMatch : struct interfac
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.DecisionDefinitionKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.DecisionDefinitionKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DecisionDefinitionKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.DecisionDefinitionKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.DecisionDefinitionKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.DecisionDefinitionKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -2197,8 +2231,10 @@ TYPE Camunda.Orchestration.Sdk.DecisionEvaluationInstanceKeyExactMatch : struct 
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.DecisionEvaluationInstanceKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.DecisionEvaluationInstanceKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DecisionEvaluationInstanceKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.DecisionEvaluationInstanceKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.DecisionEvaluationInstanceKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.DecisionEvaluationInstanceKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -2227,8 +2263,10 @@ TYPE Camunda.Orchestration.Sdk.DecisionEvaluationKeyExactMatch : struct interfac
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.DecisionEvaluationKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.DecisionEvaluationKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DecisionEvaluationKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.DecisionEvaluationKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.DecisionEvaluationKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.DecisionEvaluationKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -2362,8 +2400,10 @@ TYPE Camunda.Orchestration.Sdk.DecisionInstanceStateExactMatch : struct interfac
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.DecisionInstanceStateFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.DecisionInstanceStateFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DecisionInstanceStateEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.DecisionInstanceStateEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.DecisionInstanceStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -2398,8 +2438,10 @@ TYPE Camunda.Orchestration.Sdk.DecisionRequirementsKeyExactMatch : struct interf
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.DecisionRequirementsKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.DecisionRequirementsKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DecisionRequirementsKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.DecisionRequirementsKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.DecisionRequirementsKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.DecisionRequirementsKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -2508,8 +2550,10 @@ TYPE Camunda.Orchestration.Sdk.DeploymentKeyExactMatch : struct interfaces=[Camu
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.DeploymentKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.DeploymentKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DeploymentKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.DeploymentKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.DeploymentKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.DeploymentKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -2631,8 +2675,10 @@ TYPE Camunda.Orchestration.Sdk.ElementIdExactMatch : struct interfaces=[Camunda.
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.ElementIdFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ElementIdFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ElementId? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ElementId? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.ElementId? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -2755,8 +2801,10 @@ TYPE Camunda.Orchestration.Sdk.ElementInstanceKeyExactMatch : struct interfaces=
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ElementInstanceKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ElementInstanceKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -2859,8 +2907,10 @@ TYPE Camunda.Orchestration.Sdk.ElementInstanceStateExactMatch : struct interface
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.ElementInstanceStateFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ElementInstanceStateFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ElementInstanceStateEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ElementInstanceStateEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.ElementInstanceStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -2929,8 +2979,10 @@ TYPE Camunda.Orchestration.Sdk.EntityTypeExactMatch : struct interfaces=[Camunda
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.EntityTypeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.EntityTypeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuditLogEntityTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AuditLogEntityTypeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AuditLogEntityTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -3051,8 +3103,10 @@ TYPE Camunda.Orchestration.Sdk.FormKeyExactMatch : struct interfaces=[Camunda.Or
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.FormKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.FormKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.FormKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.FormKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.FormKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.FormKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -3105,8 +3159,10 @@ TYPE Camunda.Orchestration.Sdk.GlobalListenerSourceExactMatch : struct interface
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.GlobalListenerSourceFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.GlobalListenerSourceFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.GlobalListenerSourceEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.GlobalListenerSourceEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.GlobalListenerSourceEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -3140,8 +3196,10 @@ TYPE Camunda.Orchestration.Sdk.GlobalTaskListenerEventTypeExactMatch : struct in
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.GlobalTaskListenerEventTypeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.GlobalTaskListenerEventTypeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.GlobalTaskListenerEventTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.GlobalTaskListenerEventTypeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.GlobalTaskListenerEventTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -3371,8 +3429,10 @@ TYPE Camunda.Orchestration.Sdk.IncidentErrorTypeExactMatch : struct interfaces=[
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.IncidentErrorTypeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.IncidentErrorTypeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.IncidentErrorTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.IncidentErrorTypeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.IncidentErrorTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -3536,8 +3596,10 @@ TYPE Camunda.Orchestration.Sdk.IncidentStateExactMatch : struct interfaces=[Camu
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.IncidentStateFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.IncidentStateFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.IncidentStateEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.IncidentStateEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.IncidentStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -3548,10 +3610,12 @@ TYPE Camunda.Orchestration.Sdk.InferredAncestorKeyInstruction : sealed class bas
   CTOR ()
 
 TYPE Camunda.Orchestration.Sdk.IntegerFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.IntegerFilterPropertyJsonConverter
   CTOR ()
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<System.Int32>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Int32? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP System.Int32? ExactMatch { get; set; }
   PROP System.Int32? Gt { get; set; } [JsonPropertyName("$gt")]
   PROP System.Int32? Gte { get; set; } [JsonPropertyName("$gte")]
   PROP System.Int32? Lt { get; set; } [JsonPropertyName("$lt")]
@@ -3686,8 +3750,10 @@ TYPE Camunda.Orchestration.Sdk.JobKeyExactMatch : struct interfaces=[Camunda.Orc
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.JobKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.JobKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.JobKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.JobKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.JobKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.JobKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -3711,8 +3777,10 @@ TYPE Camunda.Orchestration.Sdk.JobKindExactMatch : struct interfaces=[Camunda.Or
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.JobKindFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.JobKindFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.JobKindEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.JobKindEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.JobKindEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -3742,8 +3810,10 @@ TYPE Camunda.Orchestration.Sdk.JobListenerEventTypeExactMatch : struct interface
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.JobListenerEventTypeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.JobListenerEventTypeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.JobListenerEventTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.JobListenerEventTypeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.JobListenerEventTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -3881,8 +3951,10 @@ TYPE Camunda.Orchestration.Sdk.JobStateExactMatch : struct interfaces=[Camunda.O
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.JobStateFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.JobStateFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.JobStateEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.JobStateEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.JobStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -4195,8 +4267,10 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionKeyExactMatch : struct interfa
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.MessageSubscriptionKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.MessageSubscriptionKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.MessageSubscriptionKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -4276,9 +4350,11 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionStateExactMatch : struct inter
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.MessageSubscriptionStateFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.MessageSubscriptionStateFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionStateEnum>? In { get; set; } [JsonPropertyName("$in")]
@@ -4299,9 +4375,11 @@ TYPE Camunda.Orchestration.Sdk.MessageSubscriptionTypeExactMatch : struct interf
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.MessageSubscriptionTypeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.MessageSubscriptionTypeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
@@ -4359,8 +4437,10 @@ TYPE Camunda.Orchestration.Sdk.OperationTypeExactMatch : struct interfaces=[Camu
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.OperationTypeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.OperationTypeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuditLogOperationTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.AuditLogOperationTypeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.AuditLogOperationTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
@@ -4489,9 +4569,11 @@ TYPE Camunda.Orchestration.Sdk.ProcessDefinitionIdExactMatch : struct interfaces
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.ProcessDefinitionIdFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ProcessDefinitionIdFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionId? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionId>? In { get; set; } [JsonPropertyName("$in")]
@@ -4588,8 +4670,10 @@ TYPE Camunda.Orchestration.Sdk.ProcessDefinitionKeyExactMatch : struct interface
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ProcessDefinitionKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -4829,8 +4913,10 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceKeyExactMatch : struct interfaces=
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ProcessInstanceKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessInstanceKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -4985,9 +5071,11 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceStateExactMatch : struct interface
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.ProcessInstanceStateFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ProcessInstanceStateFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceStateEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceStateEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.ProcessInstanceStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessInstanceStateEnum>? In { get; set; } [JsonPropertyName("$in")]
@@ -5021,8 +5109,10 @@ TYPE Camunda.Orchestration.Sdk.ResourceKeyExactMatch : struct interfaces=[Camund
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.ResourceKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ResourceKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ResourceKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ResourceKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.ResourceKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ResourceKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -5259,8 +5349,10 @@ TYPE Camunda.Orchestration.Sdk.ScopeKeyExactMatch : struct interfaces=[Camunda.O
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.ScopeKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ScopeKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ScopeKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ScopeKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.ScopeKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ScopeKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -5362,12 +5454,14 @@ TYPE Camunda.Orchestration.Sdk.StopResult : struct interfaces=[System.IEquatable
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.StringFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.StringFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<System.String>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Collections.Generic.List<System.String>? NotIn { get; set; } [JsonPropertyName("$notIn")]
   PROP System.String? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP System.String? ExactMatch { get; set; }
   PROP System.String? Neq { get; set; } [JsonPropertyName("$neq")]
 
 TYPE Camunda.Orchestration.Sdk.SystemConfigurationResponse : sealed class
@@ -5805,9 +5899,11 @@ TYPE Camunda.Orchestration.Sdk.UserTaskStateExactMatch : struct interfaces=[Camu
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.UserTaskStateFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.UserTaskStateFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP Camunda.Orchestration.Sdk.UserTaskStateEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.UserTaskStateEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.UserTaskStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.UserTaskStateEnum>? In { get; set; } [JsonPropertyName("$in")]
@@ -5914,8 +6010,10 @@ TYPE Camunda.Orchestration.Sdk.VariableKeyExactMatch : struct interfaces=[Camund
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.VariableKeyFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.VariableKeyFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.VariableKey? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.VariableKey? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.VariableKey? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableKey>? In { get; set; } [JsonPropertyName("$in")]
@@ -6049,9 +6147,11 @@ TYPE Camunda.Orchestration.Sdk.WaitStateElementTypeExactMatch : struct interface
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.WaitStateElementTypeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.WaitStateElementTypeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP Camunda.Orchestration.Sdk.WaitStateElementTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.WaitStateElementTypeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.WaitStateElementTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.WaitStateElementTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
@@ -6076,9 +6176,11 @@ TYPE Camunda.Orchestration.Sdk.WaitStateTypeExactMatch : struct interfaces=[Camu
   METHOD virtual System.String ToString()
 
 TYPE Camunda.Orchestration.Sdk.WaitStateTypeFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.WaitStateTypeFilterPropertyJsonConverter
   CTOR ()
   PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
   PROP Camunda.Orchestration.Sdk.WaitStateTypeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.WaitStateTypeEnum? ExactMatch { get; set; }
   PROP Camunda.Orchestration.Sdk.WaitStateTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.WaitStateTypeEnum>? In { get; set; } [JsonPropertyName("$in")]

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -2291,6 +2291,7 @@ TYPE Camunda.Orchestration.Sdk.DecisionInstanceFilter : sealed class
   PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.ProcessInstanceKey? ProcessInstanceKey { get; set; } [JsonPropertyName("processInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? BusinessId { get; set; } [JsonPropertyName("businessId")]
   PROP Camunda.Orchestration.Sdk.TenantId? TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Int32? DecisionDefinitionVersion { get; set; } [JsonPropertyName("decisionDefinitionVersion")]
   PROP System.String? DecisionDefinitionName { get; set; } [JsonPropertyName("decisionDefinitionName")]
@@ -2298,6 +2299,7 @@ TYPE Camunda.Orchestration.Sdk.DecisionInstanceFilter : sealed class
 
 TYPE Camunda.Orchestration.Sdk.DecisionInstanceGetQueryResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.BusinessId? BusinessId { get; set; } [JsonPropertyName("businessId")]
   PROP Camunda.Orchestration.Sdk.DecisionDefinitionId DecisionDefinitionId { get; set; } [JsonPropertyName("decisionDefinitionId")]
   PROP Camunda.Orchestration.Sdk.DecisionDefinitionKey DecisionDefinitionKey { get; set; } [JsonPropertyName("decisionDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.DecisionDefinitionKey RootDecisionDefinitionKey { get; set; } [JsonPropertyName("rootDecisionDefinitionKey")]
@@ -2329,6 +2331,7 @@ TYPE Camunda.Orchestration.Sdk.DecisionInstanceKey : struct interfaces=[Camunda.
 
 TYPE Camunda.Orchestration.Sdk.DecisionInstanceResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.BusinessId? BusinessId { get; set; } [JsonPropertyName("businessId")]
   PROP Camunda.Orchestration.Sdk.DecisionDefinitionId DecisionDefinitionId { get; set; } [JsonPropertyName("decisionDefinitionId")]
   PROP Camunda.Orchestration.Sdk.DecisionDefinitionKey DecisionDefinitionKey { get; set; } [JsonPropertyName("decisionDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.DecisionDefinitionKey RootDecisionDefinitionKey { get; set; } [JsonPropertyName("rootDecisionDefinitionKey")]
@@ -2366,21 +2369,22 @@ TYPE Camunda.Orchestration.Sdk.DecisionInstanceSearchQuerySortRequest : sealed c
 TYPE Camunda.Orchestration.Sdk.DecisionInstanceSearchQuerySortRequestField : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
   underlying=System.Int32
-  MEMBER DecisionDefinitionId = 0 json="decisionDefinitionId"
-  MEMBER DecisionDefinitionKey = 1 json="decisionDefinitionKey"
-  MEMBER DecisionDefinitionName = 2 json="decisionDefinitionName"
-  MEMBER DecisionDefinitionType = 3 json="decisionDefinitionType"
-  MEMBER DecisionDefinitionVersion = 4 json="decisionDefinitionVersion"
-  MEMBER DecisionEvaluationInstanceKey = 5 json="decisionEvaluationInstanceKey"
-  MEMBER DecisionEvaluationKey = 6 json="decisionEvaluationKey"
-  MEMBER ElementInstanceKey = 7 json="elementInstanceKey"
-  MEMBER EvaluationDate = 8 json="evaluationDate"
-  MEMBER EvaluationFailure = 9 json="evaluationFailure"
-  MEMBER ProcessDefinitionKey = 10 json="processDefinitionKey"
-  MEMBER ProcessInstanceKey = 11 json="processInstanceKey"
-  MEMBER RootDecisionDefinitionKey = 12 json="rootDecisionDefinitionKey"
-  MEMBER State = 13 json="state"
-  MEMBER TenantId = 14 json="tenantId"
+  MEMBER BusinessId = 0 json="businessId"
+  MEMBER DecisionDefinitionId = 1 json="decisionDefinitionId"
+  MEMBER DecisionDefinitionKey = 2 json="decisionDefinitionKey"
+  MEMBER DecisionDefinitionName = 3 json="decisionDefinitionName"
+  MEMBER DecisionDefinitionType = 4 json="decisionDefinitionType"
+  MEMBER DecisionDefinitionVersion = 5 json="decisionDefinitionVersion"
+  MEMBER DecisionEvaluationInstanceKey = 6 json="decisionEvaluationInstanceKey"
+  MEMBER DecisionEvaluationKey = 7 json="decisionEvaluationKey"
+  MEMBER ElementInstanceKey = 8 json="elementInstanceKey"
+  MEMBER EvaluationDate = 9 json="evaluationDate"
+  MEMBER EvaluationFailure = 10 json="evaluationFailure"
+  MEMBER ProcessDefinitionKey = 11 json="processDefinitionKey"
+  MEMBER ProcessInstanceKey = 12 json="processInstanceKey"
+  MEMBER RootDecisionDefinitionKey = 13 json="rootDecisionDefinitionKey"
+  MEMBER State = 14 json="state"
+  MEMBER TenantId = 15 json="tenantId"
 
 TYPE Camunda.Orchestration.Sdk.DecisionInstanceStateEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter


### PR DESCRIPTION
## Problem

Advanced-filter fields are modelled in the spec as a `oneOf`:

```
XFilterProperty = oneOf[ XExactMatch (a bare scalar), AdvancedXFilter ({ $eq, $neq, $in, … }) ]
```

so the wire accepts **either** a bare value (`"processInstanceKey": "123"`) or the operator object (`"processInstanceKey": { "$eq": "123" }`). The bare/exact-match form is also what servers that predate advanced filtering on a field still expect.

The generator collapsed this `oneOf` to the advanced variant only (`FindNonPrimitiveOneOfVariant`), emitting a class with just `Eq`/`In`/… and **dropping the exact-match (scalar) branch entirely**. Consequences:

- The bare form was unreachable from the typed SDK — you *had* to write `new …FilterProperty { Eq = … }`.
- A newer SDK could no longer talk to an older server for these fields: it can only emit `{ "$eq": … }`, which an older engine rejects with `400` (see #267).

History note: the collapse came from [`009b6dffb`](https://github.com/camunda/orchestration-cluster-api-csharp/commit/009b6dffb) ("generate FilterProperty classes with advanced filter properties"), whose goal was to fix **42 empty FilterProperty classes** by populating them with the advanced operators. Reaching past the scalar variant to grab the operators was deliberate; *omitting* the scalar branch was an incidental gap, not a reasoned exclusion. This PR completes that work rather than reverting it.

## Change

For the `oneOf[scalar | advanced]` pattern the generator now also emits:

- an **`ExactMatch`** member, typed as the `$eq` value type;
- an **implicit conversion** from that value type — so `ProcessInstanceKey = someKey` compiles again (the original, pre-advanced-filter call shape);
- a per-type **`JsonConverter`** that writes the bare scalar when only `ExactMatch` is set and the `{ $eq, … }` object otherwise, and reads scalar-or-object.

Driven by the schema's actual operator list, so it applies uniformly to **all 51 `*FilterProperty` types** and handles object-valued operators too (e.g. `$like` → `LikeFilter`, which correctly forces the object form and is never mistaken for the exact-match type).

This is **additive** (new members + operators); existing `{ Eq = … }` code is unaffected.

## Tests

- `GeneratorOneOfExactMatchTests` — defect-class generator guard: a `oneOf[scalar|advanced]` filter must surface `ExactMatch`, an implicit operator, and a converter (red before the fix).
- `FilterPropertyExactMatchSerializationTests` — behavioural round-trip against the generated SDK (with the client's key converters):
  - `ProcessInstanceKey = …AssumeExists("…")` → `"2251799813685261"` (the 8.9-compatible bare form)
  - `{ Eq = … }` → `{"$eq":"2251799813685261"}`
  - both deserialize back correctly

Full suite: **1084/1084** green; clean Release build (generated converters compile against the real types).

## Commits

1. `fix(gen):` generator change + tests
2. `chore(gen):` regenerated `Models.Generated.cs` + refreshed `PublicApi.shipped.txt`

Closes #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
