### PR TITLE
feat: add updateJobsBatchOperation endpoint and example coverage

### DIFF
--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -1953,6 +1953,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.UpdateJobsBatchOperationAsync(Camunda.Orchestration.Sdk.JobBatchUpdateRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/BatchOperation.cs#UpdateJobsBatchOperation)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.UpdateMappingRuleAsync(System.String,Camunda.Orchestration.Sdk.MappingRuleUpdateRequest,System.Threading.CancellationToken)
 example:
 - *content

--- a/examples/BatchOperation.cs
+++ b/examples/BatchOperation.cs
@@ -186,4 +186,26 @@ public static class BatchOperationExamples
     }
     // </DeleteDecisionInstancesBatchOperation>
     #endregion DeleteDecisionInstancesBatchOperation
+
+    #region UpdateJobsBatchOperation
+
+    // <UpdateJobsBatchOperation>
+    public static async Task UpdateJobsBatchOperationExample()
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.UpdateJobsBatchOperationAsync(
+            new JobBatchUpdateRequest
+            {
+                Filter = new JobFilter
+                {
+                    Type = new StringFilterProperty { Eq = "my-job-type" },
+                },
+                Changeset = new JobChangeset { Retries = 3 },
+            });
+
+        Console.WriteLine($"Batch operation key: {result.BatchOperationKey}");
+    }
+    // </UpdateJobsBatchOperation>
+    #endregion UpdateJobsBatchOperation
 }

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -1045,6 +1045,13 @@
       "label": "Delete decision instances in batch"
     }
   ],
+  "updateJobsBatchOperation": [
+    {
+      "file": "BatchOperation.cs",
+      "region": "UpdateJobsBatchOperation",
+      "label": "Update jobs in batch"
+    }
+  ],
   "getVariable": [
     {
       "file": "VariableElement.cs",

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -8935,6 +8935,95 @@
         "x-added-in-version": "8.6"
       }
     },
+    "/jobs/batch-update": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Job"
+        ],
+        "operationId": "updateJobsBatchOperation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Update jobs (batch)",
+        "description": "Creates a batch operation to update jobs matching the given filter. At least one changeset field must be non-null. This is done asynchronously; the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobBatchUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The batch operation was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperationCreatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The job batch update operation failed. More details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/jobs/statistics/global": {
       "get": {
         "x-eventually-consistent": true,
@@ -22455,6 +22544,7 @@
           "MIGRATE_PROCESS_INSTANCE",
           "MODIFY_PROCESS_INSTANCE",
           "RESOLVE_INCIDENT",
+          "UPDATE_JOB",
           "UPDATE_VARIABLE"
         ]
       },
@@ -30212,6 +30302,86 @@
         },
         "x-properties-added-in-version": [
           {
+            "propertyName": "deadline",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "deniedReason",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "elementId",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "elementInstanceKey",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "endTime",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "errorCode",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "errorMessage",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "hasFailedWithRetriesLeft",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "isDenied",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "jobKey",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "kind",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "listenerEventType",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "processDefinitionId",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "processDefinitionKey",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "processInstanceKey",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "retries",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "state",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "tenantId",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "type",
+            "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "worker",
+            "addedInVersion": "8.8"
+          },
+          {
             "propertyName": "creationTime",
             "addedInVersion": "8.9"
           },
@@ -30699,10 +30869,49 @@
         },
         "x-properties-added-in-version": [
           {
+            "propertyName": "retries",
+            "addedInVersion": "8.6"
+          },
+          {
+            "propertyName": "timeout",
+            "addedInVersion": "8.6"
+          },
+          {
             "propertyName": "priority",
             "addedInVersion": "8.10"
           }
         ]
+      },
+      "JobBatchUpdateRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "The filter and changeset for a batch job update operation. The filter defines which jobs are updated; the changeset defines what to update. At least one changeset field must be non-null.\n",
+        "properties": {
+          "filter": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobFilter"
+              }
+            ],
+            "description": "The job filter. At least one dimension must be set."
+          },
+          "changeset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobChangeset"
+              }
+            ],
+            "description": "The fields to update. At least one field must be non-null."
+          },
+          "operationReference": {
+            "$ref": "#/components/schemas/OperationReference"
+          }
+        },
+        "required": [
+          "changeset",
+          "filter"
+        ],
+        "x-added-in-version": "8.10"
       },
       "TenantFilterEnum": {
         "description": "The tenant filtering strategy for job activation. Determines whether to use tenant IDs provided in the request or tenant IDs assigned to the authenticated principal.\n",

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:58b138a72a997a92677d7303929b2ff3acd80d14726313fd87eb6e9625d38bd4",
+  "specHash": "sha256:9d03097114dc146e0d6358fa42ec4032548cf62b4b4af3e8bebc558c9188894e",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -5902,6 +5902,35 @@
       }
     },
     {
+      "operationId": "updateJobsBatchOperation",
+      "path": "/jobs/batch-update",
+      "method": "post",
+      "tags": [
+        "Job"
+      ],
+      "summary": "Update jobs (batch)",
+      "description": "Creates a batch operation to update jobs matching the given filter. At least one changeset field must be non-null. This is done asynchronously; the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": true,
+      "pathParams": [],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "jobs.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "JobBatchUpdateRequest",
+      "successResponseSchemaRef": "BatchOperationCreatedResult",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "getGlobalJobStatistics",
       "path": "/jobs/statistics/global",
       "method": "get",
@@ -9648,7 +9677,7 @@
   "integrity": {
     "totalSemanticKeys": 41,
     "totalUnions": 64,
-    "totalOperations": 193,
+    "totalOperations": 194,
     "totalEventuallyConsistent": 90,
     "totalDeprecatedEnumSchemas": 2,
     "totalSemanticProviders": 23

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -8754,6 +8754,18 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Update jobs (batch)
+    /// Creates a batch operation to update jobs matching the given filter. At least one changeset field must be non-null. This is done asynchronously; the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
+    /// 
+    /// </summary>
+    /// <remarks>Operation: updateJobsBatchOperation</remarks>
+    public async Task<BatchOperationCreatedResult> UpdateJobsBatchOperationAsync(JobBatchUpdateRequest body, CancellationToken ct = default)
+    {
+        var path = $"/jobs/batch-update";
+        return await InvokeWithRetryAsync(() => SendAsync<BatchOperationCreatedResult>(HttpMethod.Post, path, body, ct), "updateJobsBatchOperation", false, ct);
+    }
+
+    /// <summary>
     /// Update mapping rule
     /// Update a mapping rule.
     /// 

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -7717,6 +7717,8 @@ public enum BatchOperationTypeEnum
     MODIFYPROCESSINSTANCE,
     [JsonPropertyName("RESOLVE_INCIDENT")]
     RESOLVEINCIDENT,
+    [JsonPropertyName("UPDATE_JOB")]
+    UPDATEJOB,
     [JsonPropertyName("UPDATE_VARIABLE")]
     UPDATEVARIABLE,
 }
@@ -15900,6 +15902,34 @@ public sealed class JobActivationResult
     /// </summary>
     [JsonPropertyName("jobs")]
     public List<ActivatedJobResult> Jobs { get; set; } = null!;
+
+}
+
+/// <summary>
+/// The filter and changeset for a batch job update operation. The filter defines which jobs are updated; the changeset defines what to update. At least one changeset field must be non-null.
+/// 
+/// </summary>
+public sealed class JobBatchUpdateRequest
+{
+    /// <summary>
+    /// The job filter. At least one dimension must be set.
+    /// </summary>
+    [JsonPropertyName("filter")]
+    public JobFilter Filter { get; set; } = null!;
+
+    /// <summary>
+    /// The fields to update. At least one field must be non-null.
+    /// </summary>
+    [JsonPropertyName("changeset")]
+    public JobChangeset Changeset { get; set; } = null!;
+
+    /// <summary>
+    /// A reference key chosen by the user that will be part of all records resulting from this operation.
+    /// Must be &gt; 0 if provided.
+    /// 
+    /// </summary>
+    [JsonPropertyName("operationReference")]
+    public OperationReference? OperationReference { get; set; }
 
 }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:58b138a72a997a92677d7303929b2ff3acd80d14726313fd87eb6e9625d38bd4";
+    public const string SpecHash = "sha256:9d03097114dc146e0d6358fa42ec4032548cf62b4b4af3e8bebc558c9188894e";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -1457,7 +1457,8 @@ TYPE Camunda.Orchestration.Sdk.BatchOperationTypeEnum : enum interfaces=[System.
   MEMBER MIGRATEPROCESSINSTANCE = 6 json="MIGRATE_PROCESS_INSTANCE"
   MEMBER MODIFYPROCESSINSTANCE = 7 json="MODIFY_PROCESS_INSTANCE"
   MEMBER RESOLVEINCIDENT = 8 json="RESOLVE_INCIDENT"
-  MEMBER UPDATEVARIABLE = 9 json="UPDATE_VARIABLE"
+  MEMBER UPDATEJOB = 9 json="UPDATE_JOB"
+  MEMBER UPDATEVARIABLE = 10 json="UPDATE_VARIABLE"
 
 TYPE Camunda.Orchestration.Sdk.BatchOperationTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.BatchOperationTypeExactMatch>]
   PROP System.String Value { get; }
@@ -1603,6 +1604,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationCreatedResult> ModifyProcessInstancesBatchOperationAsync(Camunda.Orchestration.Sdk.ProcessInstanceModificationBatchOperationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationCreatedResult> ResolveIncidentsBatchOperationAsync(Camunda.Orchestration.Sdk.ProcessInstanceIncidentResolutionBatchOperationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationCreatedResult> ResolveProcessInstanceIncidentsAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationCreatedResult> UpdateJobsBatchOperationAsync(Camunda.Orchestration.Sdk.JobBatchUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationItemSearchQueryResult> SearchBatchOperationItemsAsync(Camunda.Orchestration.Sdk.BatchOperationItemSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationItemSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationResponse> GetBatchOperationAsync(Camunda.Orchestration.Sdk.BatchOperationKey batchOperationKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationResponse>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult> SearchBatchOperationsAsync(Camunda.Orchestration.Sdk.BatchOperationSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -3649,6 +3651,12 @@ TYPE Camunda.Orchestration.Sdk.JobActivationRequest : sealed class interfaces=[C
 TYPE Camunda.Orchestration.Sdk.JobActivationResult : sealed class
   CTOR ()
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ActivatedJobResult> Jobs { get; set; } [JsonPropertyName("jobs")]
+
+TYPE Camunda.Orchestration.Sdk.JobBatchUpdateRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.JobChangeset Changeset { get; set; } [JsonPropertyName("changeset")]
+  PROP Camunda.Orchestration.Sdk.JobFilter Filter { get; set; } [JsonPropertyName("filter")]
+  PROP Camunda.Orchestration.Sdk.OperationReference? OperationReference { get; set; } [JsonPropertyName("operationReference")]
 
 TYPE Camunda.Orchestration.Sdk.JobChangeset : sealed class
   CTOR ()


### PR DESCRIPTION
## What

Adds the new Camunda 8.10 `updateJobsBatchOperation` operation (`POST /jobs/batch-update`) and its example coverage.

Closes #278.

## Changes

Two commits, split per [AGENTS.md](AGENTS.md):

1. **`feat: add updateJobsBatchOperation endpoint`** — regenerate the SDK against the upstream spec.
   - `UpdateJobsBatchOperationAsync(JobBatchUpdateRequest)` → `BatchOperationCreatedResult` in `Generated/CamundaClient.Generated.cs`
   - `JobBatchUpdateRequest` + `JobChangeset.Priority` / job `priority` filter in `Generated/Models.Generated.cs`
   - bundled spec + `SpecHash.Generated.cs` + refreshed `PublicApi.shipped.txt` baseline
2. **`docs: add example coverage for updateJobsBatchOperation`** — the actual ask in #278.
   - `examples/BatchOperation.cs` — new `UpdateJobsBatchOperation` region
   - `examples/operation-map.json` — `updateJobsBatchOperation` → "Update jobs in batch"
   - `docs/overwrite/CamundaClient.md` — overwrite-doc entry

## Verification

- `dotnet build` (Release): 0 errors
- `dotnet build docs/examples/Examples.csproj`: 0 errors (example type-checks against the SDK)
- README snippet sync: in sync
- Unit tests: 1080/1080 (net8.0 + net10.0)

## Note

Pre-existing CRLF lint warnings in `test/.../ReporterTests.cs` are untouched by this PR (Windows-checkout artifact; passes on Linux CI).