### PR TITLE
feat(gen): stable enum numeric values via persisted manifest

### DIFF
--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -36,6 +36,10 @@ internal static class CSharpClientGenerator
 
         Directory.CreateDirectory(outputDir);
 
+        // Load the stable enum-value manifest so adding spec members never shifts
+        // the numeric value of existing enum members (see EnumValueRegistry).
+        EnumValueRegistry.LoadFrom(Path.Combine(outputDir, "EnumValues.json"));
+
         // Load operation → example map (optional — generation succeeds without it)
         var examplesDir = Path.GetFullPath(Path.Combine(outputDir, "..", "..", "..", "examples"));
         var operationExamples = LoadOperationExamples(examplesDir);
@@ -76,6 +80,9 @@ internal static class CSharpClientGenerator
         SafeEmit.ScanGeneratedSource(specHashPath, specHashCode);
         File.WriteAllText(specHashPath, specHashCode);
         Console.WriteLine($"[generator] Generated SpecHash.Generated.cs (specHash: {metadata.SpecHash})");
+
+        // Persist any newly-assigned enum values for stability on the next run.
+        EnumValueRegistry.Save();
     }
 
     private static List<OperationMeta> CollectOperations(OpenApiDocument doc, SpecMetadata metadata, Dictionary<string, IOpenApiSchema> inlineSchemas)
@@ -801,13 +808,14 @@ internal static class CSharpClientGenerator
                 foreach (var e in EnumStringValues(schema))
                 {
                     var enumName = ToPascalCase(e);
+                    var enumValue = EnumValueRegistry.Assign(typeName, e);
                     var deprecatedVersion = metadata.GetDeprecatedEnumMemberVersion(name, e);
                     if (deprecatedVersion != null)
                     {
                         sb.AppendLine($"    [Obsolete(\"Deprecated since {SafeEmit.SafeCSharpStringLiteral(deprecatedVersion)}\")]");
                     }
                     sb.AppendLine($"    [JsonPropertyName(\"{SafeEmit.SafeCSharpStringLiteral(e)}\")]");
-                    sb.AppendLine($"    {enumName},");
+                    sb.AppendLine($"    {enumName} = {enumValue},");
                 }
                 sb.AppendLine("}");
                 sb.AppendLine();
@@ -2338,8 +2346,9 @@ internal static class CSharpClientGenerator
         foreach (var e in EnumStringValues(propSchema))
         {
             var enumName = ToPascalCase(e);
+            var enumValue = EnumValueRegistry.Assign(enumTypeName, e);
             sb.AppendLine($"    [JsonPropertyName(\"{SafeEmit.SafeCSharpStringLiteral(e)}\")]");
-            sb.AppendLine($"    {enumName},");
+            sb.AppendLine($"    {enumName} = {enumValue},");
         }
         sb.AppendLine("}");
         sb.AppendLine();

--- a/src/Camunda.Orchestration.Sdk.Generator/EnumValueRegistry.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/EnumValueRegistry.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+
+namespace Camunda.Orchestration.Sdk.Generator;
+
+/// <summary>
+/// Assigns <b>stable</b> integer values to generated enum members.
+///
+/// Generated enums serialize by name (<c>JsonStringEnumConverter</c> +
+/// <c>JsonPropertyName</c>), but their implicit numeric values are baked into
+/// consumer IL. When the upstream spec inserts a new member mid-list, every
+/// later member's implicit value shifts, silently breaking any consumer that
+/// cast/persisted the numeric value. To prevent that, member→int assignments
+/// are persisted to a JSON manifest next to the generated output and reloaded
+/// on each run:
+/// <list type="bullet">
+///   <item>existing members keep their assigned value (order-independent),</item>
+///   <item>new members get the next free int (max + 1),</item>
+///   <item>removed members are retained as tombstones so their int is never reused.</item>
+/// </list>
+/// The registry is process-global but reset per <see cref="LoadFrom"/> call so
+/// that independent generation runs (e.g. unit tests against temp dirs) stay
+/// isolated.
+/// </summary>
+internal static class EnumValueRegistry
+{
+    private static readonly Dictionary<string, Dictionary<string, int>> _map =
+        new(StringComparer.Ordinal);
+    private static string? _path;
+
+    private static readonly JsonSerializerOptions _writeOptions = new() { WriteIndented = true };
+
+    /// <summary>Reset in-memory state and load the manifest at <paramref name="path"/> if present.</summary>
+    public static void LoadFrom(string path)
+    {
+        _map.Clear();
+        _path = path;
+
+        if (!File.Exists(path))
+            return;
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, int>>>(
+                File.ReadAllText(path));
+            if (parsed != null)
+            {
+                foreach (var (enumType, members) in parsed)
+                    _map[enumType] = new Dictionary<string, int>(members, StringComparer.Ordinal);
+            }
+        }
+        catch (JsonException)
+        {
+            // Corrupt manifest → reseed from scratch (deterministic by call order).
+            _map.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Return the stable integer for <paramref name="wireValue"/> in
+    /// <paramref name="enumType"/>, assigning the next free value if unseen.
+    /// </summary>
+    public static int Assign(string enumType, string wireValue)
+    {
+        if (!_map.TryGetValue(enumType, out var members))
+        {
+            members = new Dictionary<string, int>(StringComparer.Ordinal);
+            _map[enumType] = members;
+        }
+
+        if (members.TryGetValue(wireValue, out var existing))
+            return existing;
+
+        var next = members.Count == 0 ? 0 : members.Values.Max() + 1;
+        members[wireValue] = next;
+        return next;
+    }
+
+    /// <summary>Persist the manifest (stable key order) to the path given to <see cref="LoadFrom"/>.</summary>
+    public static void Save()
+    {
+        if (_path == null)
+            return;
+
+        var ordered = _map
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .ToDictionary(
+                kv => kv.Key,
+                kv => kv.Value
+                    .OrderBy(m => m.Value)
+                    .ToDictionary(m => m.Key, m => m.Value, StringComparer.Ordinal),
+                StringComparer.Ordinal);
+
+        var json = JsonSerializer.Serialize(ordered, _writeOptions);
+        File.WriteAllText(_path, json + "\n");
+    }
+}

--- a/src/Camunda.Orchestration.Sdk/Generated/EnumValues.json
+++ b/src/Camunda.Orchestration.Sdk/Generated/EnumValues.json
@@ -1,0 +1,794 @@
+{
+  "AgentInstanceHistoryCommitStatusEnum": {
+    "COMMITTED": 0,
+    "PENDING": 1,
+    "DISCARDED": 2
+  },
+  "AgentInstanceHistoryRoleEnum": {
+    "USER": 0,
+    "ASSISTANT": 1,
+    "TOOL_RESULT": 2
+  },
+  "AgentInstanceHistorySearchQuerySortRequestField": {
+    "producedAt": 0,
+    "historyItemKey": 1,
+    "iteration": 2
+  },
+  "AgentInstanceMessageContentTypeEnum": {
+    "TEXT": 0,
+    "DOCUMENT": 1,
+    "OBJECT": 2
+  },
+  "AgentInstanceSearchQuerySortRequestField": {
+    "agentInstanceKey": 0,
+    "status": 1,
+    "elementId": 2,
+    "processInstanceKey": 3,
+    "rootProcessInstanceKey": 4,
+    "processDefinitionKey": 5,
+    "tenantId": 6,
+    "creationDate": 7,
+    "lastUpdatedDate": 8,
+    "completionDate": 9
+  },
+  "AgentInstanceStatusEnum": {
+    "UNKNOWN": 0,
+    "COMPLETED": 1,
+    "IDLE": 2,
+    "INITIALIZING": 3,
+    "THINKING": 4,
+    "TOOL_CALLING": 5,
+    "TOOL_DISCOVERY": 6
+  },
+  "AgentInstanceUpdateStatusEnum": {
+    "IDLE": 0,
+    "THINKING": 1,
+    "TOOL_CALLING": 2,
+    "TOOL_DISCOVERY": 3
+  },
+  "AuditLogActorTypeEnum": {
+    "ANONYMOUS": 0,
+    "CLIENT": 1,
+    "UNKNOWN": 2,
+    "USER": 3
+  },
+  "AuditLogCategoryEnum": {
+    "ADMIN": 0,
+    "DEPLOYED_RESOURCES": 1,
+    "USER_TASKS": 2
+  },
+  "AuditLogEntityTypeEnum": {
+    "AUTHORIZATION": 0,
+    "BATCH": 1,
+    "DECISION": 2,
+    "GROUP": 3,
+    "INCIDENT": 4,
+    "JOB": 5,
+    "MAPPING_RULE": 6,
+    "PROCESS_INSTANCE": 7,
+    "RESOURCE": 8,
+    "ROLE": 9,
+    "TENANT": 10,
+    "USER": 11,
+    "USER_TASK": 12,
+    "VARIABLE": 13,
+    "CLIENT": 14
+  },
+  "AuditLogOperationTypeEnum": {
+    "ASSIGN": 0,
+    "CANCEL": 1,
+    "COMPLETE": 2,
+    "CREATE": 3,
+    "DELETE": 4,
+    "EVALUATE": 5,
+    "MIGRATE": 6,
+    "MODIFY": 7,
+    "RESOLVE": 8,
+    "RESUME": 9,
+    "SUSPEND": 10,
+    "UNASSIGN": 11,
+    "UNKNOWN": 12,
+    "UPDATE": 13
+  },
+  "AuditLogResultEnum": {
+    "FAIL": 0,
+    "SUCCESS": 1
+  },
+  "AuditLogSearchQuerySortRequestField": {
+    "actorId": 0,
+    "actorType": 1,
+    "auditLogKey": 2,
+    "batchOperationKey": 3,
+    "batchOperationType": 4,
+    "category": 5,
+    "decisionDefinitionId": 6,
+    "decisionDefinitionKey": 7,
+    "decisionEvaluationKey": 8,
+    "decisionRequirementsId": 9,
+    "decisionRequirementsKey": 10,
+    "elementInstanceKey": 11,
+    "entityKey": 12,
+    "entityType": 13,
+    "jobKey": 14,
+    "operationType": 15,
+    "processDefinitionId": 16,
+    "processDefinitionKey": 17,
+    "processInstanceKey": 18,
+    "inboundChannelType": 19,
+    "inboundChannelToolName": 20,
+    "result": 21,
+    "tenantId": 22,
+    "timestamp": 23,
+    "userTaskKey": 24
+  },
+  "AuthorizationSearchQuerySortRequestField": {
+    "ownerId": 0,
+    "ownerType": 1,
+    "resourceId": 2,
+    "resourcePropertyName": 3,
+    "resourceType": 4
+  },
+  "BatchOperationErrorType": {
+    "QUERY_FAILED": 0,
+    "RESULT_BUFFER_SIZE_EXCEEDED": 1
+  },
+  "BatchOperationItemResponseState": {
+    "ACTIVE": 0,
+    "COMPLETED": 1,
+    "SKIPPED": 2,
+    "CANCELED": 3,
+    "FAILED": 4
+  },
+  "BatchOperationItemSearchQuerySortRequestField": {
+    "batchOperationKey": 0,
+    "itemKey": 1,
+    "processInstanceKey": 2,
+    "processedDate": 3,
+    "state": 4
+  },
+  "BatchOperationItemStateEnum": {
+    "ACTIVE": 0,
+    "COMPLETED": 1,
+    "CANCELED": 2,
+    "FAILED": 3
+  },
+  "BatchOperationSearchQuerySortRequestField": {
+    "batchOperationKey": 0,
+    "operationType": 1,
+    "state": 2,
+    "startDate": 3,
+    "endDate": 4,
+    "actorType": 5,
+    "actorId": 6
+  },
+  "BatchOperationStateEnum": {
+    "ACTIVE": 0,
+    "CANCELED": 1,
+    "COMPLETED": 2,
+    "CREATED": 3,
+    "FAILED": 4,
+    "PARTIALLY_COMPLETED": 5,
+    "SUSPENDED": 6
+  },
+  "BatchOperationTypeEnum": {
+    "ADD_VARIABLE": 0,
+    "CANCEL_PROCESS_INSTANCE": 1,
+    "DELETE_DECISION_DEFINITION": 2,
+    "DELETE_DECISION_INSTANCE": 3,
+    "DELETE_PROCESS_DEFINITION": 4,
+    "DELETE_PROCESS_INSTANCE": 5,
+    "MIGRATE_PROCESS_INSTANCE": 6,
+    "MODIFY_PROCESS_INSTANCE": 7,
+    "RESOLVE_INCIDENT": 8,
+    "UPDATE_JOB": 9,
+    "UPDATE_VARIABLE": 10
+  },
+  "CloudStage": {
+    "dev": 0,
+    "int": 1,
+    "prod": 2
+  },
+  "ClusterVariableScopeEnum": {
+    "GLOBAL": 0,
+    "TENANT": 1
+  },
+  "ClusterVariableSearchQuerySortRequestField": {
+    "name": 0,
+    "value": 1,
+    "tenantId": 2,
+    "scope": 3
+  },
+  "CorrelatedMessageSubscriptionSearchQuerySortRequestField": {
+    "businessId": 0,
+    "correlationKey": 1,
+    "correlationTime": 2,
+    "elementId": 3,
+    "elementInstanceKey": 4,
+    "messageKey": 5,
+    "messageName": 6,
+    "partitionId": 7,
+    "processDefinitionId": 8,
+    "processDefinitionKey": 9,
+    "processInstanceKey": 10,
+    "subscriptionKey": 11,
+    "tenantId": 12
+  },
+  "DecisionDefinitionSearchQuerySortRequestField": {
+    "decisionDefinitionKey": 0,
+    "decisionDefinitionId": 1,
+    "name": 2,
+    "version": 3,
+    "decisionRequirementsId": 4,
+    "decisionRequirementsKey": 5,
+    "decisionRequirementsName": 6,
+    "decisionRequirementsVersion": 7,
+    "tenantId": 8
+  },
+  "DecisionDefinitionTypeEnum": {
+    "DECISION_TABLE": 0,
+    "LITERAL_EXPRESSION": 1,
+    "UNSPECIFIED": 2,
+    "UNKNOWN": 3
+  },
+  "DecisionInstanceSearchQuerySortRequestField": {
+    "businessId": 0,
+    "decisionDefinitionId": 1,
+    "decisionDefinitionKey": 2,
+    "decisionDefinitionName": 3,
+    "decisionDefinitionType": 4,
+    "decisionDefinitionVersion": 5,
+    "decisionEvaluationInstanceKey": 6,
+    "decisionEvaluationKey": 7,
+    "elementInstanceKey": 8,
+    "evaluationDate": 9,
+    "evaluationFailure": 10,
+    "processDefinitionKey": 11,
+    "processInstanceKey": 12,
+    "rootDecisionDefinitionKey": 13,
+    "state": 14,
+    "tenantId": 15
+  },
+  "DecisionInstanceStateEnum": {
+    "EVALUATED": 0,
+    "FAILED": 1,
+    "UNSPECIFIED": 2,
+    "UNKNOWN": 3
+  },
+  "DecisionRequirementsSearchQuerySortRequestField": {
+    "decisionRequirementsKey": 0,
+    "decisionRequirementsName": 1,
+    "version": 2,
+    "decisionRequirementsId": 3,
+    "tenantId": 4
+  },
+  "DocumentReferenceCamundaDocumentType": {
+    "camunda": 0
+  },
+  "ElementInstanceFilterFieldsType": {
+    "UNSPECIFIED": 0,
+    "PROCESS": 1,
+    "SUB_PROCESS": 2,
+    "EVENT_SUB_PROCESS": 3,
+    "AD_HOC_SUB_PROCESS": 4,
+    "AD_HOC_SUB_PROCESS_INNER_INSTANCE": 5,
+    "START_EVENT": 6,
+    "INTERMEDIATE_CATCH_EVENT": 7,
+    "INTERMEDIATE_THROW_EVENT": 8,
+    "BOUNDARY_EVENT": 9,
+    "END_EVENT": 10,
+    "SERVICE_TASK": 11,
+    "RECEIVE_TASK": 12,
+    "USER_TASK": 13,
+    "MANUAL_TASK": 14,
+    "TASK": 15,
+    "EXCLUSIVE_GATEWAY": 16,
+    "INCLUSIVE_GATEWAY": 17,
+    "PARALLEL_GATEWAY": 18,
+    "EVENT_BASED_GATEWAY": 19,
+    "SEQUENCE_FLOW": 20,
+    "MULTI_INSTANCE_BODY": 21,
+    "CALL_ACTIVITY": 22,
+    "BUSINESS_RULE_TASK": 23,
+    "SCRIPT_TASK": 24,
+    "SEND_TASK": 25,
+    "UNKNOWN": 26
+  },
+  "ElementInstanceFilterType": {
+    "UNSPECIFIED": 0,
+    "PROCESS": 1,
+    "SUB_PROCESS": 2,
+    "EVENT_SUB_PROCESS": 3,
+    "AD_HOC_SUB_PROCESS": 4,
+    "AD_HOC_SUB_PROCESS_INNER_INSTANCE": 5,
+    "START_EVENT": 6,
+    "INTERMEDIATE_CATCH_EVENT": 7,
+    "INTERMEDIATE_THROW_EVENT": 8,
+    "BOUNDARY_EVENT": 9,
+    "END_EVENT": 10,
+    "SERVICE_TASK": 11,
+    "RECEIVE_TASK": 12,
+    "USER_TASK": 13,
+    "MANUAL_TASK": 14,
+    "TASK": 15,
+    "EXCLUSIVE_GATEWAY": 16,
+    "INCLUSIVE_GATEWAY": 17,
+    "PARALLEL_GATEWAY": 18,
+    "EVENT_BASED_GATEWAY": 19,
+    "SEQUENCE_FLOW": 20,
+    "MULTI_INSTANCE_BODY": 21,
+    "CALL_ACTIVITY": 22,
+    "BUSINESS_RULE_TASK": 23,
+    "SCRIPT_TASK": 24,
+    "SEND_TASK": 25,
+    "UNKNOWN": 26
+  },
+  "ElementInstanceResultType": {
+    "UNSPECIFIED": 0,
+    "PROCESS": 1,
+    "SUB_PROCESS": 2,
+    "EVENT_SUB_PROCESS": 3,
+    "AD_HOC_SUB_PROCESS": 4,
+    "AD_HOC_SUB_PROCESS_INNER_INSTANCE": 5,
+    "START_EVENT": 6,
+    "INTERMEDIATE_CATCH_EVENT": 7,
+    "INTERMEDIATE_THROW_EVENT": 8,
+    "BOUNDARY_EVENT": 9,
+    "END_EVENT": 10,
+    "SERVICE_TASK": 11,
+    "RECEIVE_TASK": 12,
+    "USER_TASK": 13,
+    "MANUAL_TASK": 14,
+    "TASK": 15,
+    "EXCLUSIVE_GATEWAY": 16,
+    "INCLUSIVE_GATEWAY": 17,
+    "PARALLEL_GATEWAY": 18,
+    "EVENT_BASED_GATEWAY": 19,
+    "SEQUENCE_FLOW": 20,
+    "MULTI_INSTANCE_BODY": 21,
+    "CALL_ACTIVITY": 22,
+    "BUSINESS_RULE_TASK": 23,
+    "SCRIPT_TASK": 24,
+    "SEND_TASK": 25,
+    "UNKNOWN": 26
+  },
+  "ElementInstanceSearchQuerySortRequestField": {
+    "elementInstanceKey": 0,
+    "processInstanceKey": 1,
+    "processDefinitionKey": 2,
+    "processDefinitionId": 3,
+    "startDate": 4,
+    "endDate": 5,
+    "elementId": 6,
+    "elementName": 7,
+    "type": 8,
+    "state": 9,
+    "incidentKey": 10,
+    "tenantId": 11
+  },
+  "ElementInstanceStateEnum": {
+    "ACTIVE": 0,
+    "COMPLETED": 1,
+    "TERMINATED": 2
+  },
+  "ElementInstanceWaitStateQuerySortRequestField": {
+    "elementInstanceKey": 0,
+    "processInstanceKey": 1,
+    "rootProcessInstanceKey": 2,
+    "elementId": 3
+  },
+  "GlobalListenerSourceEnum": {
+    "CONFIGURATION": 0,
+    "API": 1
+  },
+  "GlobalTaskListenerEventTypeEnum": {
+    "all": 0,
+    "creating": 1,
+    "assigning": 2,
+    "updating": 3,
+    "completing": 4,
+    "canceling": 5
+  },
+  "GlobalTaskListenerSearchQuerySortRequestField": {
+    "id": 0,
+    "type": 1,
+    "afterNonGlobal": 2,
+    "priority": 3,
+    "source": 4
+  },
+  "GroupClientSearchQuerySortRequestField": {
+    "clientId": 0
+  },
+  "GroupSearchQuerySortRequestField": {
+    "name": 0,
+    "groupId": 1
+  },
+  "GroupUserSearchQuerySortRequestField": {
+    "username": 0
+  },
+  "IncidentErrorTypeEnum": {
+    "AD_HOC_SUB_PROCESS_NO_RETRIES": 0,
+    "CALLED_DECISION_ERROR": 1,
+    "CALLED_ELEMENT_ERROR": 2,
+    "CONDITION_ERROR": 3,
+    "DECISION_EVALUATION_ERROR": 4,
+    "EXECUTION_LISTENER_NO_RETRIES": 5,
+    "EXTRACT_VALUE_ERROR": 6,
+    "FORM_NOT_FOUND": 7,
+    "IO_MAPPING_ERROR": 8,
+    "JOB_NO_RETRIES": 9,
+    "MESSAGE_SIZE_EXCEEDED": 10,
+    "RESOURCE_NOT_FOUND": 11,
+    "TASK_LISTENER_NO_RETRIES": 12,
+    "UNHANDLED_ERROR_EVENT": 13,
+    "UNKNOWN": 14,
+    "UNSPECIFIED": 15
+  },
+  "IncidentProcessInstanceStatisticsByDefinitionQuerySortRequestField": {
+    "activeInstancesWithErrorCount": 0,
+    "processDefinitionKey": 1,
+    "tenantId": 2
+  },
+  "IncidentProcessInstanceStatisticsByErrorQuerySortRequestField": {
+    "errorMessage": 0,
+    "activeInstancesWithErrorCount": 1
+  },
+  "IncidentSearchQuerySortRequestField": {
+    "incidentKey": 0,
+    "processDefinitionKey": 1,
+    "processDefinitionId": 2,
+    "processInstanceKey": 3,
+    "errorType": 4,
+    "elementId": 5,
+    "elementInstanceKey": 6,
+    "creationTime": 7,
+    "state": 8,
+    "jobKey": 9,
+    "tenantId": 10
+  },
+  "IncidentStateEnum": {
+    "ACTIVE": 0,
+    "MIGRATED": 1,
+    "PENDING": 2,
+    "RESOLVED": 3,
+    "UNKNOWN": 4
+  },
+  "JobKindEnum": {
+    "BPMN_ELEMENT": 0,
+    "EXECUTION_LISTENER": 1,
+    "TASK_LISTENER": 2,
+    "AD_HOC_SUB_PROCESS": 3
+  },
+  "JobListenerEventTypeEnum": {
+    "ASSIGNING": 0,
+    "BEFORE_ALL": 1,
+    "CANCEL": 2,
+    "CANCELING": 3,
+    "COMPLETING": 4,
+    "CREATING": 5,
+    "END": 6,
+    "START": 7,
+    "UNSPECIFIED": 8,
+    "UPDATING": 9
+  },
+  "JobSearchQuerySortRequestField": {
+    "deadline": 0,
+    "deniedReason": 1,
+    "elementId": 2,
+    "elementInstanceKey": 3,
+    "endTime": 4,
+    "errorCode": 5,
+    "errorMessage": 6,
+    "hasFailedWithRetriesLeft": 7,
+    "isDenied": 8,
+    "jobKey": 9,
+    "kind": 10,
+    "listenerEventType": 11,
+    "priority": 12,
+    "processDefinitionId": 13,
+    "processDefinitionKey": 14,
+    "processInstanceKey": 15,
+    "retries": 16,
+    "state": 17,
+    "tenantId": 18,
+    "type": 19,
+    "worker": 20
+  },
+  "JobStateEnum": {
+    "CANCELED": 0,
+    "COMPLETED": 1,
+    "CREATED": 2,
+    "ERROR_THROWN": 3,
+    "FAILED": 4,
+    "MIGRATED": 5,
+    "PRIORITY_UPDATED": 6,
+    "RETRIES_UPDATED": 7,
+    "TIMED_OUT": 8
+  },
+  "MappingRuleSearchQuerySortRequestField": {
+    "mappingRuleId": 0,
+    "claimName": 1,
+    "claimValue": 2,
+    "name": 3
+  },
+  "MessageSubscriptionSearchQuerySortRequestField": {
+    "messageSubscriptionKey": 0,
+    "processDefinitionId": 1,
+    "processDefinitionName": 2,
+    "processDefinitionVersion": 3,
+    "processInstanceKey": 4,
+    "elementId": 5,
+    "elementInstanceKey": 6,
+    "messageSubscriptionState": 7,
+    "messageSubscriptionType": 8,
+    "lastUpdatedDate": 9,
+    "messageName": 10,
+    "correlationKey": 11,
+    "tenantId": 12,
+    "toolName": 13,
+    "inboundConnectorType": 14
+  },
+  "MessageSubscriptionStateEnum": {
+    "CORRELATED": 0,
+    "CREATED": 1,
+    "DELETED": 2,
+    "MIGRATED": 3
+  },
+  "MessageSubscriptionTypeEnum": {
+    "START_EVENT": 0,
+    "PROCESS_EVENT": 1
+  },
+  "OwnerTypeEnum": {
+    "USER": 0,
+    "CLIENT": 1,
+    "ROLE": 2,
+    "GROUP": 3,
+    "MAPPING_RULE": 4,
+    "UNSPECIFIED": 5
+  },
+  "PartitionHealth": {
+    "healthy": 0,
+    "unhealthy": 1,
+    "dead": 2
+  },
+  "PartitionRole": {
+    "leader": 0,
+    "follower": 1,
+    "inactive": 2
+  },
+  "PermissionTypeEnum": {
+    "ACCESS": 0,
+    "CANCEL_PROCESS_INSTANCE": 1,
+    "CLAIM": 2,
+    "CLAIM_USER_TASK": 3,
+    "COMPLETE": 4,
+    "COMPLETE_USER_TASK": 5,
+    "CREATE": 6,
+    "CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE": 7,
+    "CREATE_BATCH_OPERATION_DELETE_DECISION_DEFINITION": 8,
+    "CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE": 9,
+    "CREATE_BATCH_OPERATION_DELETE_PROCESS_DEFINITION": 10,
+    "CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE": 11,
+    "CREATE_BATCH_OPERATION_MIGRATE_PROCESS_INSTANCE": 12,
+    "CREATE_BATCH_OPERATION_MODIFY_PROCESS_INSTANCE": 13,
+    "CREATE_BATCH_OPERATION_RESOLVE_INCIDENT": 14,
+    "CREATE_BATCH_OPERATION_UPDATE_JOB": 15,
+    "CREATE_DECISION_INSTANCE": 16,
+    "CREATE_PROCESS_INSTANCE": 17,
+    "CREATE_TASK_LISTENER": 18,
+    "DELETE": 19,
+    "DELETE_DECISION_INSTANCE": 20,
+    "DELETE_DRD": 21,
+    "DELETE_FORM": 22,
+    "DELETE_PROCESS": 23,
+    "DELETE_PROCESS_INSTANCE": 24,
+    "DELETE_RESOURCE": 25,
+    "DELETE_TASK_LISTENER": 26,
+    "EVALUATE": 27,
+    "MODIFY_PROCESS_INSTANCE": 28,
+    "READ": 29,
+    "READ_DECISION_DEFINITION": 30,
+    "READ_DECISION_INSTANCE": 31,
+    "READ_JOB_METRIC": 32,
+    "READ_PROCESS_DEFINITION": 33,
+    "READ_PROCESS_INSTANCE": 34,
+    "READ_USAGE_METRIC": 35,
+    "READ_USER_TASK": 36,
+    "READ_TASK_LISTENER": 37,
+    "UPDATE": 38,
+    "UPDATE_PROCESS_INSTANCE": 39,
+    "UPDATE_USER_TASK": 40,
+    "UPDATE_TASK_LISTENER": 41
+  },
+  "ProcessDefinitionInstanceStatisticsQuerySortRequestField": {
+    "processDefinitionId": 0,
+    "activeInstancesWithIncidentCount": 1,
+    "activeInstancesWithoutIncidentCount": 2
+  },
+  "ProcessDefinitionInstanceVersionStatisticsQuerySortRequestField": {
+    "processDefinitionId": 0,
+    "processDefinitionKey": 1,
+    "processDefinitionName": 2,
+    "processDefinitionVersion": 3,
+    "activeInstancesWithIncidentCount": 4,
+    "activeInstancesWithoutIncidentCount": 5
+  },
+  "ProcessDefinitionSearchQuerySortRequestField": {
+    "processDefinitionKey": 0,
+    "name": 1,
+    "resourceName": 2,
+    "version": 3,
+    "versionTag": 4,
+    "processDefinitionId": 5,
+    "tenantId": 6
+  },
+  "ProcessInstanceSearchQuerySortRequestField": {
+    "processInstanceKey": 0,
+    "processDefinitionId": 1,
+    "processDefinitionName": 2,
+    "processDefinitionVersion": 3,
+    "processDefinitionVersionTag": 4,
+    "processDefinitionKey": 5,
+    "parentProcessInstanceKey": 6,
+    "parentElementInstanceKey": 7,
+    "startDate": 8,
+    "endDate": 9,
+    "state": 10,
+    "hasIncident": 11,
+    "tenantId": 12,
+    "businessId": 13
+  },
+  "ProcessInstanceStateEnum": {
+    "ACTIVE": 0,
+    "COMPLETED": 1,
+    "TERMINATED": 2
+  },
+  "ResourceSearchQuerySortRequestField": {
+    "resourceKey": 0,
+    "resourceName": 1,
+    "resourceId": 2,
+    "version": 3,
+    "versionTag": 4,
+    "deploymentKey": 5,
+    "tenantId": 6
+  },
+  "ResourceTypeEnum": {
+    "AUDIT_LOG": 0,
+    "AUTHORIZATION": 1,
+    "BATCH": 2,
+    "CLUSTER_VARIABLE": 3,
+    "COMPONENT": 4,
+    "DECISION_DEFINITION": 5,
+    "DECISION_REQUIREMENTS_DEFINITION": 6,
+    "DOCUMENT": 7,
+    "EXPRESSION": 8,
+    "GLOBAL_LISTENER": 9,
+    "GROUP": 10,
+    "MAPPING_RULE": 11,
+    "MESSAGE": 12,
+    "PROCESS_DEFINITION": 13,
+    "RESOURCE": 14,
+    "ROLE": 15,
+    "SYSTEM": 16,
+    "TENANT": 17,
+    "USER": 18,
+    "USER_TASK": 19
+  },
+  "RoleClientSearchQuerySortRequestField": {
+    "clientId": 0
+  },
+  "RoleGroupSearchQuerySortRequestField": {
+    "groupId": 0
+  },
+  "RoleSearchQuerySortRequestField": {
+    "name": 0,
+    "roleId": 1
+  },
+  "RoleUserSearchQuerySortRequestField": {
+    "username": 0
+  },
+  "SortOrderEnum": {
+    "ASC": 0,
+    "DESC": 1
+  },
+  "TenantClientSearchQuerySortRequestField": {
+    "clientId": 0
+  },
+  "TenantFilterEnum": {
+    "PROVIDED": 0,
+    "ASSIGNED": 1
+  },
+  "TenantGroupSearchQuerySortRequestField": {
+    "groupId": 0
+  },
+  "TenantSearchQuerySortRequestField": {
+    "key": 0,
+    "name": 1,
+    "tenantId": 2
+  },
+  "TenantUserSearchQuerySortRequestField": {
+    "username": 0
+  },
+  "UserSearchQuerySortRequestField": {
+    "username": 0,
+    "name": 1,
+    "email": 2
+  },
+  "UserTaskSearchQuerySortRequestField": {
+    "creationDate": 0,
+    "completionDate": 1,
+    "followUpDate": 2,
+    "dueDate": 3,
+    "priority": 4,
+    "name": 5,
+    "businessId": 6
+  },
+  "UserTaskStateEnum": {
+    "CREATING": 0,
+    "CREATED": 1,
+    "ASSIGNING": 2,
+    "UPDATING": 3,
+    "COMPLETING": 4,
+    "COMPLETED": 5,
+    "CANCELING": 6,
+    "CANCELED": 7,
+    "FAILED": 8
+  },
+  "UserTaskVariableSearchQuerySortRequestField": {
+    "value": 0,
+    "name": 1,
+    "tenantId": 2,
+    "variableKey": 3,
+    "scopeKey": 4,
+    "processInstanceKey": 5
+  },
+  "VariableSearchQuerySortRequestField": {
+    "value": 0,
+    "name": 1,
+    "tenantId": 2,
+    "variableKey": 3,
+    "scopeKey": 4,
+    "processInstanceKey": 5
+  },
+  "WaitStateElementTypeEnum": {
+    "AD_HOC_SUB_PROCESS": 0,
+    "AD_HOC_SUB_PROCESS_INNER_INSTANCE": 1,
+    "BOUNDARY_EVENT": 2,
+    "BUSINESS_RULE_TASK": 3,
+    "CALL_ACTIVITY": 4,
+    "END_EVENT": 5,
+    "EVENT_BASED_GATEWAY": 6,
+    "EVENT_SUB_PROCESS": 7,
+    "EXCLUSIVE_GATEWAY": 8,
+    "INCLUSIVE_GATEWAY": 9,
+    "INTERMEDIATE_CATCH_EVENT": 10,
+    "INTERMEDIATE_THROW_EVENT": 11,
+    "MANUAL_TASK": 12,
+    "MULTI_INSTANCE_BODY": 13,
+    "PARALLEL_GATEWAY": 14,
+    "PROCESS": 15,
+    "RECEIVE_TASK": 16,
+    "SCRIPT_TASK": 17,
+    "SEND_TASK": 18,
+    "SEQUENCE_FLOW": 19,
+    "SERVICE_TASK": 20,
+    "START_EVENT": 21,
+    "SUB_PROCESS": 22,
+    "TASK": 23,
+    "UNKNOWN": 24,
+    "UNSPECIFIED": 25,
+    "USER_TASK": 26
+  },
+  "WaitStateTypeEnum": {
+    "JOB": 0,
+    "MESSAGE": 1,
+    "USER_TASK": 2,
+    "TIMER": 3,
+    "SIGNAL": 4,
+    "CONDITION": 5
+  },
+  "WebappComponent": {
+    "operate": 0,
+    "tasklist": 1,
+    "admin": 2
+  }
+}

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -14,11 +14,11 @@ namespace Camunda.Orchestration.Sdk;
 public enum AgentInstanceHistorySearchQuerySortRequestField
 {
     [JsonPropertyName("producedAt")]
-    ProducedAt,
+    ProducedAt = 0,
     [JsonPropertyName("historyItemKey")]
-    HistoryItemKey,
+    HistoryItemKey = 1,
     [JsonPropertyName("iteration")]
-    Iteration,
+    Iteration = 2,
 }
 
 /// <summary>
@@ -28,25 +28,25 @@ public enum AgentInstanceHistorySearchQuerySortRequestField
 public enum AgentInstanceSearchQuerySortRequestField
 {
     [JsonPropertyName("agentInstanceKey")]
-    AgentInstanceKey,
+    AgentInstanceKey = 0,
     [JsonPropertyName("status")]
-    Status,
+    Status = 1,
     [JsonPropertyName("elementId")]
-    ElementId,
+    ElementId = 2,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 3,
     [JsonPropertyName("rootProcessInstanceKey")]
-    RootProcessInstanceKey,
+    RootProcessInstanceKey = 4,
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 5,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 6,
     [JsonPropertyName("creationDate")]
-    CreationDate,
+    CreationDate = 7,
     [JsonPropertyName("lastUpdatedDate")]
-    LastUpdatedDate,
+    LastUpdatedDate = 8,
     [JsonPropertyName("completionDate")]
-    CompletionDate,
+    CompletionDate = 9,
 }
 
 /// <summary>
@@ -56,55 +56,55 @@ public enum AgentInstanceSearchQuerySortRequestField
 public enum AuditLogSearchQuerySortRequestField
 {
     [JsonPropertyName("actorId")]
-    ActorId,
+    ActorId = 0,
     [JsonPropertyName("actorType")]
-    ActorType,
+    ActorType = 1,
     [JsonPropertyName("auditLogKey")]
-    AuditLogKey,
+    AuditLogKey = 2,
     [JsonPropertyName("batchOperationKey")]
-    BatchOperationKey,
+    BatchOperationKey = 3,
     [JsonPropertyName("batchOperationType")]
-    BatchOperationType,
+    BatchOperationType = 4,
     [JsonPropertyName("category")]
-    Category,
+    Category = 5,
     [JsonPropertyName("decisionDefinitionId")]
-    DecisionDefinitionId,
+    DecisionDefinitionId = 6,
     [JsonPropertyName("decisionDefinitionKey")]
-    DecisionDefinitionKey,
+    DecisionDefinitionKey = 7,
     [JsonPropertyName("decisionEvaluationKey")]
-    DecisionEvaluationKey,
+    DecisionEvaluationKey = 8,
     [JsonPropertyName("decisionRequirementsId")]
-    DecisionRequirementsId,
+    DecisionRequirementsId = 9,
     [JsonPropertyName("decisionRequirementsKey")]
-    DecisionRequirementsKey,
+    DecisionRequirementsKey = 10,
     [JsonPropertyName("elementInstanceKey")]
-    ElementInstanceKey,
+    ElementInstanceKey = 11,
     [JsonPropertyName("entityKey")]
-    EntityKey,
+    EntityKey = 12,
     [JsonPropertyName("entityType")]
-    EntityType,
+    EntityType = 13,
     [JsonPropertyName("jobKey")]
-    JobKey,
+    JobKey = 14,
     [JsonPropertyName("operationType")]
-    OperationType,
+    OperationType = 15,
     [JsonPropertyName("processDefinitionId")]
-    ProcessDefinitionId,
+    ProcessDefinitionId = 16,
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 17,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 18,
     [JsonPropertyName("inboundChannelType")]
-    InboundChannelType,
+    InboundChannelType = 19,
     [JsonPropertyName("inboundChannelToolName")]
-    InboundChannelToolName,
+    InboundChannelToolName = 20,
     [JsonPropertyName("result")]
-    Result,
+    Result = 21,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 22,
     [JsonPropertyName("timestamp")]
-    Timestamp,
+    Timestamp = 23,
     [JsonPropertyName("userTaskKey")]
-    UserTaskKey,
+    UserTaskKey = 24,
 }
 
 /// <summary>
@@ -114,15 +114,15 @@ public enum AuditLogSearchQuerySortRequestField
 public enum AuthorizationSearchQuerySortRequestField
 {
     [JsonPropertyName("ownerId")]
-    OwnerId,
+    OwnerId = 0,
     [JsonPropertyName("ownerType")]
-    OwnerType,
+    OwnerType = 1,
     [JsonPropertyName("resourceId")]
-    ResourceId,
+    ResourceId = 2,
     [JsonPropertyName("resourcePropertyName")]
-    ResourcePropertyName,
+    ResourcePropertyName = 3,
     [JsonPropertyName("resourceType")]
-    ResourceType,
+    ResourceType = 4,
 }
 
 /// <summary>
@@ -132,9 +132,9 @@ public enum AuthorizationSearchQuerySortRequestField
 public enum BatchOperationErrorType
 {
     [JsonPropertyName("QUERY_FAILED")]
-    QUERYFAILED,
+    QUERYFAILED = 0,
     [JsonPropertyName("RESULT_BUFFER_SIZE_EXCEEDED")]
-    RESULTBUFFERSIZEEXCEEDED,
+    RESULTBUFFERSIZEEXCEEDED = 1,
 }
 
 /// <summary>
@@ -144,15 +144,15 @@ public enum BatchOperationErrorType
 public enum BatchOperationItemResponseState
 {
     [JsonPropertyName("ACTIVE")]
-    ACTIVE,
+    ACTIVE = 0,
     [JsonPropertyName("COMPLETED")]
-    COMPLETED,
+    COMPLETED = 1,
     [JsonPropertyName("SKIPPED")]
-    SKIPPED,
+    SKIPPED = 2,
     [JsonPropertyName("CANCELED")]
-    CANCELED,
+    CANCELED = 3,
     [JsonPropertyName("FAILED")]
-    FAILED,
+    FAILED = 4,
 }
 
 /// <summary>
@@ -162,15 +162,15 @@ public enum BatchOperationItemResponseState
 public enum BatchOperationItemSearchQuerySortRequestField
 {
     [JsonPropertyName("batchOperationKey")]
-    BatchOperationKey,
+    BatchOperationKey = 0,
     [JsonPropertyName("itemKey")]
-    ItemKey,
+    ItemKey = 1,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 2,
     [JsonPropertyName("processedDate")]
-    ProcessedDate,
+    ProcessedDate = 3,
     [JsonPropertyName("state")]
-    State,
+    State = 4,
 }
 
 /// <summary>
@@ -180,19 +180,19 @@ public enum BatchOperationItemSearchQuerySortRequestField
 public enum BatchOperationSearchQuerySortRequestField
 {
     [JsonPropertyName("batchOperationKey")]
-    BatchOperationKey,
+    BatchOperationKey = 0,
     [JsonPropertyName("operationType")]
-    OperationType,
+    OperationType = 1,
     [JsonPropertyName("state")]
-    State,
+    State = 2,
     [JsonPropertyName("startDate")]
-    StartDate,
+    StartDate = 3,
     [JsonPropertyName("endDate")]
-    EndDate,
+    EndDate = 4,
     [JsonPropertyName("actorType")]
-    ActorType,
+    ActorType = 5,
     [JsonPropertyName("actorId")]
-    ActorId,
+    ActorId = 6,
 }
 
 /// <summary>
@@ -202,13 +202,13 @@ public enum BatchOperationSearchQuerySortRequestField
 public enum ClusterVariableSearchQuerySortRequestField
 {
     [JsonPropertyName("name")]
-    Name,
+    Name = 0,
     [JsonPropertyName("value")]
-    Value,
+    Value = 1,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 2,
     [JsonPropertyName("scope")]
-    Scope,
+    Scope = 3,
 }
 
 /// <summary>
@@ -218,31 +218,31 @@ public enum ClusterVariableSearchQuerySortRequestField
 public enum CorrelatedMessageSubscriptionSearchQuerySortRequestField
 {
     [JsonPropertyName("businessId")]
-    BusinessId,
+    BusinessId = 0,
     [JsonPropertyName("correlationKey")]
-    CorrelationKey,
+    CorrelationKey = 1,
     [JsonPropertyName("correlationTime")]
-    CorrelationTime,
+    CorrelationTime = 2,
     [JsonPropertyName("elementId")]
-    ElementId,
+    ElementId = 3,
     [JsonPropertyName("elementInstanceKey")]
-    ElementInstanceKey,
+    ElementInstanceKey = 4,
     [JsonPropertyName("messageKey")]
-    MessageKey,
+    MessageKey = 5,
     [JsonPropertyName("messageName")]
-    MessageName,
+    MessageName = 6,
     [JsonPropertyName("partitionId")]
-    PartitionId,
+    PartitionId = 7,
     [JsonPropertyName("processDefinitionId")]
-    ProcessDefinitionId,
+    ProcessDefinitionId = 8,
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 9,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 10,
     [JsonPropertyName("subscriptionKey")]
-    SubscriptionKey,
+    SubscriptionKey = 11,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 12,
 }
 
 /// <summary>
@@ -252,23 +252,23 @@ public enum CorrelatedMessageSubscriptionSearchQuerySortRequestField
 public enum DecisionDefinitionSearchQuerySortRequestField
 {
     [JsonPropertyName("decisionDefinitionKey")]
-    DecisionDefinitionKey,
+    DecisionDefinitionKey = 0,
     [JsonPropertyName("decisionDefinitionId")]
-    DecisionDefinitionId,
+    DecisionDefinitionId = 1,
     [JsonPropertyName("name")]
-    Name,
+    Name = 2,
     [JsonPropertyName("version")]
-    Version,
+    Version = 3,
     [JsonPropertyName("decisionRequirementsId")]
-    DecisionRequirementsId,
+    DecisionRequirementsId = 4,
     [JsonPropertyName("decisionRequirementsKey")]
-    DecisionRequirementsKey,
+    DecisionRequirementsKey = 5,
     [JsonPropertyName("decisionRequirementsName")]
-    DecisionRequirementsName,
+    DecisionRequirementsName = 6,
     [JsonPropertyName("decisionRequirementsVersion")]
-    DecisionRequirementsVersion,
+    DecisionRequirementsVersion = 7,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 8,
 }
 
 /// <summary>
@@ -278,37 +278,37 @@ public enum DecisionDefinitionSearchQuerySortRequestField
 public enum DecisionInstanceSearchQuerySortRequestField
 {
     [JsonPropertyName("businessId")]
-    BusinessId,
+    BusinessId = 0,
     [JsonPropertyName("decisionDefinitionId")]
-    DecisionDefinitionId,
+    DecisionDefinitionId = 1,
     [JsonPropertyName("decisionDefinitionKey")]
-    DecisionDefinitionKey,
+    DecisionDefinitionKey = 2,
     [JsonPropertyName("decisionDefinitionName")]
-    DecisionDefinitionName,
+    DecisionDefinitionName = 3,
     [JsonPropertyName("decisionDefinitionType")]
-    DecisionDefinitionType,
+    DecisionDefinitionType = 4,
     [JsonPropertyName("decisionDefinitionVersion")]
-    DecisionDefinitionVersion,
+    DecisionDefinitionVersion = 5,
     [JsonPropertyName("decisionEvaluationInstanceKey")]
-    DecisionEvaluationInstanceKey,
+    DecisionEvaluationInstanceKey = 6,
     [JsonPropertyName("decisionEvaluationKey")]
-    DecisionEvaluationKey,
+    DecisionEvaluationKey = 7,
     [JsonPropertyName("elementInstanceKey")]
-    ElementInstanceKey,
+    ElementInstanceKey = 8,
     [JsonPropertyName("evaluationDate")]
-    EvaluationDate,
+    EvaluationDate = 9,
     [JsonPropertyName("evaluationFailure")]
-    EvaluationFailure,
+    EvaluationFailure = 10,
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 11,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 12,
     [JsonPropertyName("rootDecisionDefinitionKey")]
-    RootDecisionDefinitionKey,
+    RootDecisionDefinitionKey = 13,
     [JsonPropertyName("state")]
-    State,
+    State = 14,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 15,
 }
 
 /// <summary>
@@ -318,15 +318,15 @@ public enum DecisionInstanceSearchQuerySortRequestField
 public enum DecisionRequirementsSearchQuerySortRequestField
 {
     [JsonPropertyName("decisionRequirementsKey")]
-    DecisionRequirementsKey,
+    DecisionRequirementsKey = 0,
     [JsonPropertyName("decisionRequirementsName")]
-    DecisionRequirementsName,
+    DecisionRequirementsName = 1,
     [JsonPropertyName("version")]
-    Version,
+    Version = 2,
     [JsonPropertyName("decisionRequirementsId")]
-    DecisionRequirementsId,
+    DecisionRequirementsId = 3,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 4,
 }
 
 /// <summary>
@@ -336,7 +336,7 @@ public enum DecisionRequirementsSearchQuerySortRequestField
 public enum DocumentReferenceCamundaDocumentType
 {
     [JsonPropertyName("camunda")]
-    Camunda,
+    Camunda = 0,
 }
 
 /// <summary>
@@ -346,59 +346,59 @@ public enum DocumentReferenceCamundaDocumentType
 public enum ElementInstanceFilterFieldsType
 {
     [JsonPropertyName("UNSPECIFIED")]
-    UNSPECIFIED,
+    UNSPECIFIED = 0,
     [JsonPropertyName("PROCESS")]
-    PROCESS,
+    PROCESS = 1,
     [JsonPropertyName("SUB_PROCESS")]
-    SUBPROCESS,
+    SUBPROCESS = 2,
     [JsonPropertyName("EVENT_SUB_PROCESS")]
-    EVENTSUBPROCESS,
+    EVENTSUBPROCESS = 3,
     [JsonPropertyName("AD_HOC_SUB_PROCESS")]
-    ADHOCSUBPROCESS,
+    ADHOCSUBPROCESS = 4,
     [JsonPropertyName("AD_HOC_SUB_PROCESS_INNER_INSTANCE")]
-    ADHOCSUBPROCESSINNERINSTANCE,
+    ADHOCSUBPROCESSINNERINSTANCE = 5,
     [JsonPropertyName("START_EVENT")]
-    STARTEVENT,
+    STARTEVENT = 6,
     [JsonPropertyName("INTERMEDIATE_CATCH_EVENT")]
-    INTERMEDIATECATCHEVENT,
+    INTERMEDIATECATCHEVENT = 7,
     [JsonPropertyName("INTERMEDIATE_THROW_EVENT")]
-    INTERMEDIATETHROWEVENT,
+    INTERMEDIATETHROWEVENT = 8,
     [JsonPropertyName("BOUNDARY_EVENT")]
-    BOUNDARYEVENT,
+    BOUNDARYEVENT = 9,
     [JsonPropertyName("END_EVENT")]
-    ENDEVENT,
+    ENDEVENT = 10,
     [JsonPropertyName("SERVICE_TASK")]
-    SERVICETASK,
+    SERVICETASK = 11,
     [JsonPropertyName("RECEIVE_TASK")]
-    RECEIVETASK,
+    RECEIVETASK = 12,
     [JsonPropertyName("USER_TASK")]
-    USERTASK,
+    USERTASK = 13,
     [JsonPropertyName("MANUAL_TASK")]
-    MANUALTASK,
+    MANUALTASK = 14,
     [JsonPropertyName("TASK")]
-    TASK,
+    TASK = 15,
     [JsonPropertyName("EXCLUSIVE_GATEWAY")]
-    EXCLUSIVEGATEWAY,
+    EXCLUSIVEGATEWAY = 16,
     [JsonPropertyName("INCLUSIVE_GATEWAY")]
-    INCLUSIVEGATEWAY,
+    INCLUSIVEGATEWAY = 17,
     [JsonPropertyName("PARALLEL_GATEWAY")]
-    PARALLELGATEWAY,
+    PARALLELGATEWAY = 18,
     [JsonPropertyName("EVENT_BASED_GATEWAY")]
-    EVENTBASEDGATEWAY,
+    EVENTBASEDGATEWAY = 19,
     [JsonPropertyName("SEQUENCE_FLOW")]
-    SEQUENCEFLOW,
+    SEQUENCEFLOW = 20,
     [JsonPropertyName("MULTI_INSTANCE_BODY")]
-    MULTIINSTANCEBODY,
+    MULTIINSTANCEBODY = 21,
     [JsonPropertyName("CALL_ACTIVITY")]
-    CALLACTIVITY,
+    CALLACTIVITY = 22,
     [JsonPropertyName("BUSINESS_RULE_TASK")]
-    BUSINESSRULETASK,
+    BUSINESSRULETASK = 23,
     [JsonPropertyName("SCRIPT_TASK")]
-    SCRIPTTASK,
+    SCRIPTTASK = 24,
     [JsonPropertyName("SEND_TASK")]
-    SENDTASK,
+    SENDTASK = 25,
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 26,
 }
 
 /// <summary>
@@ -408,59 +408,59 @@ public enum ElementInstanceFilterFieldsType
 public enum ElementInstanceFilterType
 {
     [JsonPropertyName("UNSPECIFIED")]
-    UNSPECIFIED,
+    UNSPECIFIED = 0,
     [JsonPropertyName("PROCESS")]
-    PROCESS,
+    PROCESS = 1,
     [JsonPropertyName("SUB_PROCESS")]
-    SUBPROCESS,
+    SUBPROCESS = 2,
     [JsonPropertyName("EVENT_SUB_PROCESS")]
-    EVENTSUBPROCESS,
+    EVENTSUBPROCESS = 3,
     [JsonPropertyName("AD_HOC_SUB_PROCESS")]
-    ADHOCSUBPROCESS,
+    ADHOCSUBPROCESS = 4,
     [JsonPropertyName("AD_HOC_SUB_PROCESS_INNER_INSTANCE")]
-    ADHOCSUBPROCESSINNERINSTANCE,
+    ADHOCSUBPROCESSINNERINSTANCE = 5,
     [JsonPropertyName("START_EVENT")]
-    STARTEVENT,
+    STARTEVENT = 6,
     [JsonPropertyName("INTERMEDIATE_CATCH_EVENT")]
-    INTERMEDIATECATCHEVENT,
+    INTERMEDIATECATCHEVENT = 7,
     [JsonPropertyName("INTERMEDIATE_THROW_EVENT")]
-    INTERMEDIATETHROWEVENT,
+    INTERMEDIATETHROWEVENT = 8,
     [JsonPropertyName("BOUNDARY_EVENT")]
-    BOUNDARYEVENT,
+    BOUNDARYEVENT = 9,
     [JsonPropertyName("END_EVENT")]
-    ENDEVENT,
+    ENDEVENT = 10,
     [JsonPropertyName("SERVICE_TASK")]
-    SERVICETASK,
+    SERVICETASK = 11,
     [JsonPropertyName("RECEIVE_TASK")]
-    RECEIVETASK,
+    RECEIVETASK = 12,
     [JsonPropertyName("USER_TASK")]
-    USERTASK,
+    USERTASK = 13,
     [JsonPropertyName("MANUAL_TASK")]
-    MANUALTASK,
+    MANUALTASK = 14,
     [JsonPropertyName("TASK")]
-    TASK,
+    TASK = 15,
     [JsonPropertyName("EXCLUSIVE_GATEWAY")]
-    EXCLUSIVEGATEWAY,
+    EXCLUSIVEGATEWAY = 16,
     [JsonPropertyName("INCLUSIVE_GATEWAY")]
-    INCLUSIVEGATEWAY,
+    INCLUSIVEGATEWAY = 17,
     [JsonPropertyName("PARALLEL_GATEWAY")]
-    PARALLELGATEWAY,
+    PARALLELGATEWAY = 18,
     [JsonPropertyName("EVENT_BASED_GATEWAY")]
-    EVENTBASEDGATEWAY,
+    EVENTBASEDGATEWAY = 19,
     [JsonPropertyName("SEQUENCE_FLOW")]
-    SEQUENCEFLOW,
+    SEQUENCEFLOW = 20,
     [JsonPropertyName("MULTI_INSTANCE_BODY")]
-    MULTIINSTANCEBODY,
+    MULTIINSTANCEBODY = 21,
     [JsonPropertyName("CALL_ACTIVITY")]
-    CALLACTIVITY,
+    CALLACTIVITY = 22,
     [JsonPropertyName("BUSINESS_RULE_TASK")]
-    BUSINESSRULETASK,
+    BUSINESSRULETASK = 23,
     [JsonPropertyName("SCRIPT_TASK")]
-    SCRIPTTASK,
+    SCRIPTTASK = 24,
     [JsonPropertyName("SEND_TASK")]
-    SENDTASK,
+    SENDTASK = 25,
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 26,
 }
 
 /// <summary>
@@ -470,59 +470,59 @@ public enum ElementInstanceFilterType
 public enum ElementInstanceResultType
 {
     [JsonPropertyName("UNSPECIFIED")]
-    UNSPECIFIED,
+    UNSPECIFIED = 0,
     [JsonPropertyName("PROCESS")]
-    PROCESS,
+    PROCESS = 1,
     [JsonPropertyName("SUB_PROCESS")]
-    SUBPROCESS,
+    SUBPROCESS = 2,
     [JsonPropertyName("EVENT_SUB_PROCESS")]
-    EVENTSUBPROCESS,
+    EVENTSUBPROCESS = 3,
     [JsonPropertyName("AD_HOC_SUB_PROCESS")]
-    ADHOCSUBPROCESS,
+    ADHOCSUBPROCESS = 4,
     [JsonPropertyName("AD_HOC_SUB_PROCESS_INNER_INSTANCE")]
-    ADHOCSUBPROCESSINNERINSTANCE,
+    ADHOCSUBPROCESSINNERINSTANCE = 5,
     [JsonPropertyName("START_EVENT")]
-    STARTEVENT,
+    STARTEVENT = 6,
     [JsonPropertyName("INTERMEDIATE_CATCH_EVENT")]
-    INTERMEDIATECATCHEVENT,
+    INTERMEDIATECATCHEVENT = 7,
     [JsonPropertyName("INTERMEDIATE_THROW_EVENT")]
-    INTERMEDIATETHROWEVENT,
+    INTERMEDIATETHROWEVENT = 8,
     [JsonPropertyName("BOUNDARY_EVENT")]
-    BOUNDARYEVENT,
+    BOUNDARYEVENT = 9,
     [JsonPropertyName("END_EVENT")]
-    ENDEVENT,
+    ENDEVENT = 10,
     [JsonPropertyName("SERVICE_TASK")]
-    SERVICETASK,
+    SERVICETASK = 11,
     [JsonPropertyName("RECEIVE_TASK")]
-    RECEIVETASK,
+    RECEIVETASK = 12,
     [JsonPropertyName("USER_TASK")]
-    USERTASK,
+    USERTASK = 13,
     [JsonPropertyName("MANUAL_TASK")]
-    MANUALTASK,
+    MANUALTASK = 14,
     [JsonPropertyName("TASK")]
-    TASK,
+    TASK = 15,
     [JsonPropertyName("EXCLUSIVE_GATEWAY")]
-    EXCLUSIVEGATEWAY,
+    EXCLUSIVEGATEWAY = 16,
     [JsonPropertyName("INCLUSIVE_GATEWAY")]
-    INCLUSIVEGATEWAY,
+    INCLUSIVEGATEWAY = 17,
     [JsonPropertyName("PARALLEL_GATEWAY")]
-    PARALLELGATEWAY,
+    PARALLELGATEWAY = 18,
     [JsonPropertyName("EVENT_BASED_GATEWAY")]
-    EVENTBASEDGATEWAY,
+    EVENTBASEDGATEWAY = 19,
     [JsonPropertyName("SEQUENCE_FLOW")]
-    SEQUENCEFLOW,
+    SEQUENCEFLOW = 20,
     [JsonPropertyName("MULTI_INSTANCE_BODY")]
-    MULTIINSTANCEBODY,
+    MULTIINSTANCEBODY = 21,
     [JsonPropertyName("CALL_ACTIVITY")]
-    CALLACTIVITY,
+    CALLACTIVITY = 22,
     [JsonPropertyName("BUSINESS_RULE_TASK")]
-    BUSINESSRULETASK,
+    BUSINESSRULETASK = 23,
     [JsonPropertyName("SCRIPT_TASK")]
-    SCRIPTTASK,
+    SCRIPTTASK = 24,
     [JsonPropertyName("SEND_TASK")]
-    SENDTASK,
+    SENDTASK = 25,
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 26,
 }
 
 /// <summary>
@@ -532,29 +532,29 @@ public enum ElementInstanceResultType
 public enum ElementInstanceSearchQuerySortRequestField
 {
     [JsonPropertyName("elementInstanceKey")]
-    ElementInstanceKey,
+    ElementInstanceKey = 0,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 1,
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 2,
     [JsonPropertyName("processDefinitionId")]
-    ProcessDefinitionId,
+    ProcessDefinitionId = 3,
     [JsonPropertyName("startDate")]
-    StartDate,
+    StartDate = 4,
     [JsonPropertyName("endDate")]
-    EndDate,
+    EndDate = 5,
     [JsonPropertyName("elementId")]
-    ElementId,
+    ElementId = 6,
     [JsonPropertyName("elementName")]
-    ElementName,
+    ElementName = 7,
     [JsonPropertyName("type")]
-    Type,
+    Type = 8,
     [JsonPropertyName("state")]
-    State,
+    State = 9,
     [JsonPropertyName("incidentKey")]
-    IncidentKey,
+    IncidentKey = 10,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 11,
 }
 
 /// <summary>
@@ -564,13 +564,13 @@ public enum ElementInstanceSearchQuerySortRequestField
 public enum ElementInstanceWaitStateQuerySortRequestField
 {
     [JsonPropertyName("elementInstanceKey")]
-    ElementInstanceKey,
+    ElementInstanceKey = 0,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 1,
     [JsonPropertyName("rootProcessInstanceKey")]
-    RootProcessInstanceKey,
+    RootProcessInstanceKey = 2,
     [JsonPropertyName("elementId")]
-    ElementId,
+    ElementId = 3,
 }
 
 /// <summary>
@@ -580,15 +580,15 @@ public enum ElementInstanceWaitStateQuerySortRequestField
 public enum GlobalTaskListenerSearchQuerySortRequestField
 {
     [JsonPropertyName("id")]
-    Id,
+    Id = 0,
     [JsonPropertyName("type")]
-    Type,
+    Type = 1,
     [JsonPropertyName("afterNonGlobal")]
-    AfterNonGlobal,
+    AfterNonGlobal = 2,
     [JsonPropertyName("priority")]
-    Priority,
+    Priority = 3,
     [JsonPropertyName("source")]
-    Source,
+    Source = 4,
 }
 
 /// <summary>
@@ -598,7 +598,7 @@ public enum GlobalTaskListenerSearchQuerySortRequestField
 public enum GroupClientSearchQuerySortRequestField
 {
     [JsonPropertyName("clientId")]
-    ClientId,
+    ClientId = 0,
 }
 
 /// <summary>
@@ -608,9 +608,9 @@ public enum GroupClientSearchQuerySortRequestField
 public enum GroupSearchQuerySortRequestField
 {
     [JsonPropertyName("name")]
-    Name,
+    Name = 0,
     [JsonPropertyName("groupId")]
-    GroupId,
+    GroupId = 1,
 }
 
 /// <summary>
@@ -620,7 +620,7 @@ public enum GroupSearchQuerySortRequestField
 public enum GroupUserSearchQuerySortRequestField
 {
     [JsonPropertyName("username")]
-    Username,
+    Username = 0,
 }
 
 /// <summary>
@@ -630,11 +630,11 @@ public enum GroupUserSearchQuerySortRequestField
 public enum IncidentProcessInstanceStatisticsByDefinitionQuerySortRequestField
 {
     [JsonPropertyName("activeInstancesWithErrorCount")]
-    ActiveInstancesWithErrorCount,
+    ActiveInstancesWithErrorCount = 0,
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 1,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 2,
 }
 
 /// <summary>
@@ -644,9 +644,9 @@ public enum IncidentProcessInstanceStatisticsByDefinitionQuerySortRequestField
 public enum IncidentProcessInstanceStatisticsByErrorQuerySortRequestField
 {
     [JsonPropertyName("errorMessage")]
-    ErrorMessage,
+    ErrorMessage = 0,
     [JsonPropertyName("activeInstancesWithErrorCount")]
-    ActiveInstancesWithErrorCount,
+    ActiveInstancesWithErrorCount = 1,
 }
 
 /// <summary>
@@ -656,27 +656,27 @@ public enum IncidentProcessInstanceStatisticsByErrorQuerySortRequestField
 public enum IncidentSearchQuerySortRequestField
 {
     [JsonPropertyName("incidentKey")]
-    IncidentKey,
+    IncidentKey = 0,
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 1,
     [JsonPropertyName("processDefinitionId")]
-    ProcessDefinitionId,
+    ProcessDefinitionId = 2,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 3,
     [JsonPropertyName("errorType")]
-    ErrorType,
+    ErrorType = 4,
     [JsonPropertyName("elementId")]
-    ElementId,
+    ElementId = 5,
     [JsonPropertyName("elementInstanceKey")]
-    ElementInstanceKey,
+    ElementInstanceKey = 6,
     [JsonPropertyName("creationTime")]
-    CreationTime,
+    CreationTime = 7,
     [JsonPropertyName("state")]
-    State,
+    State = 8,
     [JsonPropertyName("jobKey")]
-    JobKey,
+    JobKey = 9,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 10,
 }
 
 /// <summary>
@@ -686,47 +686,47 @@ public enum IncidentSearchQuerySortRequestField
 public enum JobSearchQuerySortRequestField
 {
     [JsonPropertyName("deadline")]
-    Deadline,
+    Deadline = 0,
     [JsonPropertyName("deniedReason")]
-    DeniedReason,
+    DeniedReason = 1,
     [JsonPropertyName("elementId")]
-    ElementId,
+    ElementId = 2,
     [JsonPropertyName("elementInstanceKey")]
-    ElementInstanceKey,
+    ElementInstanceKey = 3,
     [JsonPropertyName("endTime")]
-    EndTime,
+    EndTime = 4,
     [JsonPropertyName("errorCode")]
-    ErrorCode,
+    ErrorCode = 5,
     [JsonPropertyName("errorMessage")]
-    ErrorMessage,
+    ErrorMessage = 6,
     [JsonPropertyName("hasFailedWithRetriesLeft")]
-    HasFailedWithRetriesLeft,
+    HasFailedWithRetriesLeft = 7,
     [JsonPropertyName("isDenied")]
-    IsDenied,
+    IsDenied = 8,
     [JsonPropertyName("jobKey")]
-    JobKey,
+    JobKey = 9,
     [JsonPropertyName("kind")]
-    Kind,
+    Kind = 10,
     [JsonPropertyName("listenerEventType")]
-    ListenerEventType,
+    ListenerEventType = 11,
     [JsonPropertyName("priority")]
-    Priority,
+    Priority = 12,
     [JsonPropertyName("processDefinitionId")]
-    ProcessDefinitionId,
+    ProcessDefinitionId = 13,
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 14,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 15,
     [JsonPropertyName("retries")]
-    Retries,
+    Retries = 16,
     [JsonPropertyName("state")]
-    State,
+    State = 17,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 18,
     [JsonPropertyName("type")]
-    Type,
+    Type = 19,
     [JsonPropertyName("worker")]
-    Worker,
+    Worker = 20,
 }
 
 /// <summary>
@@ -736,13 +736,13 @@ public enum JobSearchQuerySortRequestField
 public enum MappingRuleSearchQuerySortRequestField
 {
     [JsonPropertyName("mappingRuleId")]
-    MappingRuleId,
+    MappingRuleId = 0,
     [JsonPropertyName("claimName")]
-    ClaimName,
+    ClaimName = 1,
     [JsonPropertyName("claimValue")]
-    ClaimValue,
+    ClaimValue = 2,
     [JsonPropertyName("name")]
-    Name,
+    Name = 3,
 }
 
 /// <summary>
@@ -752,35 +752,35 @@ public enum MappingRuleSearchQuerySortRequestField
 public enum MessageSubscriptionSearchQuerySortRequestField
 {
     [JsonPropertyName("messageSubscriptionKey")]
-    MessageSubscriptionKey,
+    MessageSubscriptionKey = 0,
     [JsonPropertyName("processDefinitionId")]
-    ProcessDefinitionId,
+    ProcessDefinitionId = 1,
     [JsonPropertyName("processDefinitionName")]
-    ProcessDefinitionName,
+    ProcessDefinitionName = 2,
     [JsonPropertyName("processDefinitionVersion")]
-    ProcessDefinitionVersion,
+    ProcessDefinitionVersion = 3,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 4,
     [JsonPropertyName("elementId")]
-    ElementId,
+    ElementId = 5,
     [JsonPropertyName("elementInstanceKey")]
-    ElementInstanceKey,
+    ElementInstanceKey = 6,
     [JsonPropertyName("messageSubscriptionState")]
-    MessageSubscriptionState,
+    MessageSubscriptionState = 7,
     [JsonPropertyName("messageSubscriptionType")]
-    MessageSubscriptionType,
+    MessageSubscriptionType = 8,
     [JsonPropertyName("lastUpdatedDate")]
-    LastUpdatedDate,
+    LastUpdatedDate = 9,
     [JsonPropertyName("messageName")]
-    MessageName,
+    MessageName = 10,
     [JsonPropertyName("correlationKey")]
-    CorrelationKey,
+    CorrelationKey = 11,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 12,
     [JsonPropertyName("toolName")]
-    ToolName,
+    ToolName = 13,
     [JsonPropertyName("inboundConnectorType")]
-    InboundConnectorType,
+    InboundConnectorType = 14,
 }
 
 /// <summary>
@@ -790,11 +790,11 @@ public enum MessageSubscriptionSearchQuerySortRequestField
 public enum PartitionHealth
 {
     [JsonPropertyName("healthy")]
-    Healthy,
+    Healthy = 0,
     [JsonPropertyName("unhealthy")]
-    Unhealthy,
+    Unhealthy = 1,
     [JsonPropertyName("dead")]
-    Dead,
+    Dead = 2,
 }
 
 /// <summary>
@@ -804,11 +804,11 @@ public enum PartitionHealth
 public enum PartitionRole
 {
     [JsonPropertyName("leader")]
-    Leader,
+    Leader = 0,
     [JsonPropertyName("follower")]
-    Follower,
+    Follower = 1,
     [JsonPropertyName("inactive")]
-    Inactive,
+    Inactive = 2,
 }
 
 /// <summary>
@@ -818,11 +818,11 @@ public enum PartitionRole
 public enum ProcessDefinitionInstanceStatisticsQuerySortRequestField
 {
     [JsonPropertyName("processDefinitionId")]
-    ProcessDefinitionId,
+    ProcessDefinitionId = 0,
     [JsonPropertyName("activeInstancesWithIncidentCount")]
-    ActiveInstancesWithIncidentCount,
+    ActiveInstancesWithIncidentCount = 1,
     [JsonPropertyName("activeInstancesWithoutIncidentCount")]
-    ActiveInstancesWithoutIncidentCount,
+    ActiveInstancesWithoutIncidentCount = 2,
 }
 
 /// <summary>
@@ -832,17 +832,17 @@ public enum ProcessDefinitionInstanceStatisticsQuerySortRequestField
 public enum ProcessDefinitionInstanceVersionStatisticsQuerySortRequestField
 {
     [JsonPropertyName("processDefinitionId")]
-    ProcessDefinitionId,
+    ProcessDefinitionId = 0,
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 1,
     [JsonPropertyName("processDefinitionName")]
-    ProcessDefinitionName,
+    ProcessDefinitionName = 2,
     [JsonPropertyName("processDefinitionVersion")]
-    ProcessDefinitionVersion,
+    ProcessDefinitionVersion = 3,
     [JsonPropertyName("activeInstancesWithIncidentCount")]
-    ActiveInstancesWithIncidentCount,
+    ActiveInstancesWithIncidentCount = 4,
     [JsonPropertyName("activeInstancesWithoutIncidentCount")]
-    ActiveInstancesWithoutIncidentCount,
+    ActiveInstancesWithoutIncidentCount = 5,
 }
 
 /// <summary>
@@ -852,19 +852,19 @@ public enum ProcessDefinitionInstanceVersionStatisticsQuerySortRequestField
 public enum ProcessDefinitionSearchQuerySortRequestField
 {
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 0,
     [JsonPropertyName("name")]
-    Name,
+    Name = 1,
     [JsonPropertyName("resourceName")]
-    ResourceName,
+    ResourceName = 2,
     [JsonPropertyName("version")]
-    Version,
+    Version = 3,
     [JsonPropertyName("versionTag")]
-    VersionTag,
+    VersionTag = 4,
     [JsonPropertyName("processDefinitionId")]
-    ProcessDefinitionId,
+    ProcessDefinitionId = 5,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 6,
 }
 
 /// <summary>
@@ -874,33 +874,33 @@ public enum ProcessDefinitionSearchQuerySortRequestField
 public enum ProcessInstanceSearchQuerySortRequestField
 {
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 0,
     [JsonPropertyName("processDefinitionId")]
-    ProcessDefinitionId,
+    ProcessDefinitionId = 1,
     [JsonPropertyName("processDefinitionName")]
-    ProcessDefinitionName,
+    ProcessDefinitionName = 2,
     [JsonPropertyName("processDefinitionVersion")]
-    ProcessDefinitionVersion,
+    ProcessDefinitionVersion = 3,
     [JsonPropertyName("processDefinitionVersionTag")]
-    ProcessDefinitionVersionTag,
+    ProcessDefinitionVersionTag = 4,
     [JsonPropertyName("processDefinitionKey")]
-    ProcessDefinitionKey,
+    ProcessDefinitionKey = 5,
     [JsonPropertyName("parentProcessInstanceKey")]
-    ParentProcessInstanceKey,
+    ParentProcessInstanceKey = 6,
     [JsonPropertyName("parentElementInstanceKey")]
-    ParentElementInstanceKey,
+    ParentElementInstanceKey = 7,
     [JsonPropertyName("startDate")]
-    StartDate,
+    StartDate = 8,
     [JsonPropertyName("endDate")]
-    EndDate,
+    EndDate = 9,
     [JsonPropertyName("state")]
-    State,
+    State = 10,
     [JsonPropertyName("hasIncident")]
-    HasIncident,
+    HasIncident = 11,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 12,
     [JsonPropertyName("businessId")]
-    BusinessId,
+    BusinessId = 13,
 }
 
 /// <summary>
@@ -910,19 +910,19 @@ public enum ProcessInstanceSearchQuerySortRequestField
 public enum ResourceSearchQuerySortRequestField
 {
     [JsonPropertyName("resourceKey")]
-    ResourceKey,
+    ResourceKey = 0,
     [JsonPropertyName("resourceName")]
-    ResourceName,
+    ResourceName = 1,
     [JsonPropertyName("resourceId")]
-    ResourceId,
+    ResourceId = 2,
     [JsonPropertyName("version")]
-    Version,
+    Version = 3,
     [JsonPropertyName("versionTag")]
-    VersionTag,
+    VersionTag = 4,
     [JsonPropertyName("deploymentKey")]
-    DeploymentKey,
+    DeploymentKey = 5,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 6,
 }
 
 /// <summary>
@@ -932,7 +932,7 @@ public enum ResourceSearchQuerySortRequestField
 public enum RoleClientSearchQuerySortRequestField
 {
     [JsonPropertyName("clientId")]
-    ClientId,
+    ClientId = 0,
 }
 
 /// <summary>
@@ -942,7 +942,7 @@ public enum RoleClientSearchQuerySortRequestField
 public enum RoleGroupSearchQuerySortRequestField
 {
     [JsonPropertyName("groupId")]
-    GroupId,
+    GroupId = 0,
 }
 
 /// <summary>
@@ -952,9 +952,9 @@ public enum RoleGroupSearchQuerySortRequestField
 public enum RoleSearchQuerySortRequestField
 {
     [JsonPropertyName("name")]
-    Name,
+    Name = 0,
     [JsonPropertyName("roleId")]
-    RoleId,
+    RoleId = 1,
 }
 
 /// <summary>
@@ -964,7 +964,7 @@ public enum RoleSearchQuerySortRequestField
 public enum RoleUserSearchQuerySortRequestField
 {
     [JsonPropertyName("username")]
-    Username,
+    Username = 0,
 }
 
 /// <summary>
@@ -974,7 +974,7 @@ public enum RoleUserSearchQuerySortRequestField
 public enum TenantClientSearchQuerySortRequestField
 {
     [JsonPropertyName("clientId")]
-    ClientId,
+    ClientId = 0,
 }
 
 /// <summary>
@@ -984,7 +984,7 @@ public enum TenantClientSearchQuerySortRequestField
 public enum TenantGroupSearchQuerySortRequestField
 {
     [JsonPropertyName("groupId")]
-    GroupId,
+    GroupId = 0,
 }
 
 /// <summary>
@@ -994,11 +994,11 @@ public enum TenantGroupSearchQuerySortRequestField
 public enum TenantSearchQuerySortRequestField
 {
     [JsonPropertyName("key")]
-    Key,
+    Key = 0,
     [JsonPropertyName("name")]
-    Name,
+    Name = 1,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 2,
 }
 
 /// <summary>
@@ -1008,7 +1008,7 @@ public enum TenantSearchQuerySortRequestField
 public enum TenantUserSearchQuerySortRequestField
 {
     [JsonPropertyName("username")]
-    Username,
+    Username = 0,
 }
 
 /// <summary>
@@ -1018,11 +1018,11 @@ public enum TenantUserSearchQuerySortRequestField
 public enum UserSearchQuerySortRequestField
 {
     [JsonPropertyName("username")]
-    Username,
+    Username = 0,
     [JsonPropertyName("name")]
-    Name,
+    Name = 1,
     [JsonPropertyName("email")]
-    Email,
+    Email = 2,
 }
 
 /// <summary>
@@ -1032,19 +1032,19 @@ public enum UserSearchQuerySortRequestField
 public enum UserTaskSearchQuerySortRequestField
 {
     [JsonPropertyName("creationDate")]
-    CreationDate,
+    CreationDate = 0,
     [JsonPropertyName("completionDate")]
-    CompletionDate,
+    CompletionDate = 1,
     [JsonPropertyName("followUpDate")]
-    FollowUpDate,
+    FollowUpDate = 2,
     [JsonPropertyName("dueDate")]
-    DueDate,
+    DueDate = 3,
     [JsonPropertyName("priority")]
-    Priority,
+    Priority = 4,
     [JsonPropertyName("name")]
-    Name,
+    Name = 5,
     [JsonPropertyName("businessId")]
-    BusinessId,
+    BusinessId = 6,
 }
 
 /// <summary>
@@ -1054,17 +1054,17 @@ public enum UserTaskSearchQuerySortRequestField
 public enum UserTaskVariableSearchQuerySortRequestField
 {
     [JsonPropertyName("value")]
-    Value,
+    Value = 0,
     [JsonPropertyName("name")]
-    Name,
+    Name = 1,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 2,
     [JsonPropertyName("variableKey")]
-    VariableKey,
+    VariableKey = 3,
     [JsonPropertyName("scopeKey")]
-    ScopeKey,
+    ScopeKey = 4,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 5,
 }
 
 /// <summary>
@@ -1074,17 +1074,17 @@ public enum UserTaskVariableSearchQuerySortRequestField
 public enum VariableSearchQuerySortRequestField
 {
     [JsonPropertyName("value")]
-    Value,
+    Value = 0,
     [JsonPropertyName("name")]
-    Name,
+    Name = 1,
     [JsonPropertyName("tenantId")]
-    TenantId,
+    TenantId = 2,
     [JsonPropertyName("variableKey")]
-    VariableKey,
+    VariableKey = 3,
     [JsonPropertyName("scopeKey")]
-    ScopeKey,
+    ScopeKey = 4,
     [JsonPropertyName("processInstanceKey")]
-    ProcessInstanceKey,
+    ProcessInstanceKey = 5,
 }
 
 /// <summary>
@@ -3749,11 +3749,11 @@ public sealed class AgentInstanceFilter
 public enum AgentInstanceHistoryCommitStatusEnum
 {
     [JsonPropertyName("COMMITTED")]
-    COMMITTED,
+    COMMITTED = 0,
     [JsonPropertyName("PENDING")]
-    PENDING,
+    PENDING = 1,
     [JsonPropertyName("DISCARDED")]
-    DISCARDED,
+    DISCARDED = 2,
 }
 
 /// <summary>
@@ -4130,11 +4130,11 @@ public sealed class AgentInstanceHistoryItemResult
 public enum AgentInstanceHistoryRoleEnum
 {
     [JsonPropertyName("USER")]
-    USER,
+    USER = 0,
     [JsonPropertyName("ASSISTANT")]
-    ASSISTANT,
+    ASSISTANT = 1,
     [JsonPropertyName("TOOL_RESULT")]
-    TOOLRESULT,
+    TOOLRESULT = 2,
 }
 
 /// <summary>
@@ -4552,11 +4552,11 @@ public abstract class AgentInstanceMessageContent { }
 public enum AgentInstanceMessageContentTypeEnum
 {
     [JsonPropertyName("TEXT")]
-    TEXT,
+    TEXT = 0,
     [JsonPropertyName("DOCUMENT")]
-    DOCUMENT,
+    DOCUMENT = 1,
     [JsonPropertyName("OBJECT")]
-    OBJECT,
+    OBJECT = 2,
 }
 
 /// <summary>
@@ -4824,19 +4824,19 @@ public sealed class AgentInstanceSearchQuerySortRequest
 public enum AgentInstanceStatusEnum
 {
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 0,
     [JsonPropertyName("COMPLETED")]
-    COMPLETED,
+    COMPLETED = 1,
     [JsonPropertyName("IDLE")]
-    IDLE,
+    IDLE = 2,
     [JsonPropertyName("INITIALIZING")]
-    INITIALIZING,
+    INITIALIZING = 3,
     [JsonPropertyName("THINKING")]
-    THINKING,
+    THINKING = 4,
     [JsonPropertyName("TOOL_CALLING")]
-    TOOLCALLING,
+    TOOLCALLING = 5,
     [JsonPropertyName("TOOL_DISCOVERY")]
-    TOOLDISCOVERY,
+    TOOLDISCOVERY = 6,
 }
 
 /// <summary>
@@ -5083,13 +5083,13 @@ public sealed class AgentInstanceUpdateRequest
 public enum AgentInstanceUpdateStatusEnum
 {
     [JsonPropertyName("IDLE")]
-    IDLE,
+    IDLE = 0,
     [JsonPropertyName("THINKING")]
-    THINKING,
+    THINKING = 1,
     [JsonPropertyName("TOOL_CALLING")]
-    TOOLCALLING,
+    TOOLCALLING = 2,
     [JsonPropertyName("TOOL_DISCOVERY")]
-    TOOLDISCOVERY,
+    TOOLDISCOVERY = 3,
 }
 
 /// <summary>
@@ -5146,13 +5146,13 @@ public abstract class AncestorScopeInstruction { }
 public enum AuditLogActorTypeEnum
 {
     [JsonPropertyName("ANONYMOUS")]
-    ANONYMOUS,
+    ANONYMOUS = 0,
     [JsonPropertyName("CLIENT")]
-    CLIENT,
+    CLIENT = 1,
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 2,
     [JsonPropertyName("USER")]
-    USER,
+    USER = 3,
 }
 
 /// <summary>
@@ -5312,11 +5312,11 @@ internal sealed class AuditLogActorTypeFilterPropertyJsonConverter : global::Sys
 public enum AuditLogCategoryEnum
 {
     [JsonPropertyName("ADMIN")]
-    ADMIN,
+    ADMIN = 0,
     [JsonPropertyName("DEPLOYED_RESOURCES")]
-    DEPLOYEDRESOURCES,
+    DEPLOYEDRESOURCES = 1,
     [JsonPropertyName("USER_TASKS")]
-    USERTASKS,
+    USERTASKS = 2,
 }
 
 /// <summary>
@@ -5496,35 +5496,35 @@ internal sealed class AuditLogEntityKeyFilterPropertyJsonConverter : global::Sys
 public enum AuditLogEntityTypeEnum
 {
     [JsonPropertyName("AUTHORIZATION")]
-    AUTHORIZATION,
+    AUTHORIZATION = 0,
     [JsonPropertyName("BATCH")]
-    BATCH,
+    BATCH = 1,
     [JsonPropertyName("DECISION")]
-    DECISION,
+    DECISION = 2,
     [JsonPropertyName("GROUP")]
-    GROUP,
+    GROUP = 3,
     [JsonPropertyName("INCIDENT")]
-    INCIDENT,
+    INCIDENT = 4,
     [JsonPropertyName("JOB")]
-    JOB,
+    JOB = 5,
     [JsonPropertyName("MAPPING_RULE")]
-    MAPPINGRULE,
+    MAPPINGRULE = 6,
     [JsonPropertyName("PROCESS_INSTANCE")]
-    PROCESSINSTANCE,
+    PROCESSINSTANCE = 7,
     [JsonPropertyName("RESOURCE")]
-    RESOURCE,
+    RESOURCE = 8,
     [JsonPropertyName("ROLE")]
-    ROLE,
+    ROLE = 9,
     [JsonPropertyName("TENANT")]
-    TENANT,
+    TENANT = 10,
     [JsonPropertyName("USER")]
-    USER,
+    USER = 11,
     [JsonPropertyName("USER_TASK")]
-    USERTASK,
+    USERTASK = 12,
     [JsonPropertyName("VARIABLE")]
-    VARIABLE,
+    VARIABLE = 13,
     [JsonPropertyName("CLIENT")]
-    CLIENT,
+    CLIENT = 14,
 }
 
 /// <summary>
@@ -5897,33 +5897,33 @@ internal sealed class AuditLogKeyFilterPropertyJsonConverter : global::System.Te
 public enum AuditLogOperationTypeEnum
 {
     [JsonPropertyName("ASSIGN")]
-    ASSIGN,
+    ASSIGN = 0,
     [JsonPropertyName("CANCEL")]
-    CANCEL,
+    CANCEL = 1,
     [JsonPropertyName("COMPLETE")]
-    COMPLETE,
+    COMPLETE = 2,
     [JsonPropertyName("CREATE")]
-    CREATE,
+    CREATE = 3,
     [JsonPropertyName("DELETE")]
-    DELETE,
+    DELETE = 4,
     [JsonPropertyName("EVALUATE")]
-    EVALUATE,
+    EVALUATE = 5,
     [JsonPropertyName("MIGRATE")]
-    MIGRATE,
+    MIGRATE = 6,
     [JsonPropertyName("MODIFY")]
-    MODIFY,
+    MODIFY = 7,
     [JsonPropertyName("RESOLVE")]
-    RESOLVE,
+    RESOLVE = 8,
     [JsonPropertyName("RESUME")]
-    RESUME,
+    RESUME = 9,
     [JsonPropertyName("SUSPEND")]
-    SUSPEND,
+    SUSPEND = 10,
     [JsonPropertyName("UNASSIGN")]
-    UNASSIGN,
+    UNASSIGN = 11,
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 12,
     [JsonPropertyName("UPDATE")]
-    UPDATE,
+    UPDATE = 13,
 }
 
 /// <summary>
@@ -6147,9 +6147,9 @@ public sealed class AuditLogResult
 public enum AuditLogResultEnum
 {
     [JsonPropertyName("FAIL")]
-    FAIL,
+    FAIL = 0,
     [JsonPropertyName("SUCCESS")]
-    SUCCESS,
+    SUCCESS = 1,
 }
 
 /// <summary>
@@ -7191,13 +7191,13 @@ public sealed class BatchOperationItemSearchQuerySortRequest
 public enum BatchOperationItemStateEnum
 {
     [JsonPropertyName("ACTIVE")]
-    ACTIVE,
+    ACTIVE = 0,
     [JsonPropertyName("COMPLETED")]
-    COMPLETED,
+    COMPLETED = 1,
     [JsonPropertyName("CANCELED")]
-    CANCELED,
+    CANCELED = 2,
     [JsonPropertyName("FAILED")]
-    FAILED,
+    FAILED = 3,
 }
 
 /// <summary>
@@ -7528,19 +7528,19 @@ public sealed class BatchOperationSearchQuerySortRequest
 public enum BatchOperationStateEnum
 {
     [JsonPropertyName("ACTIVE")]
-    ACTIVE,
+    ACTIVE = 0,
     [JsonPropertyName("CANCELED")]
-    CANCELED,
+    CANCELED = 1,
     [JsonPropertyName("COMPLETED")]
-    COMPLETED,
+    COMPLETED = 2,
     [JsonPropertyName("CREATED")]
-    CREATED,
+    CREATED = 3,
     [JsonPropertyName("FAILED")]
-    FAILED,
+    FAILED = 4,
     [JsonPropertyName("PARTIALLY_COMPLETED")]
-    PARTIALLYCOMPLETED,
+    PARTIALLYCOMPLETED = 5,
     [JsonPropertyName("SUSPENDED")]
-    SUSPENDED,
+    SUSPENDED = 6,
 }
 
 /// <summary>
@@ -7700,27 +7700,27 @@ internal sealed class BatchOperationStateFilterPropertyJsonConverter : global::S
 public enum BatchOperationTypeEnum
 {
     [JsonPropertyName("ADD_VARIABLE")]
-    ADDVARIABLE,
+    ADDVARIABLE = 0,
     [JsonPropertyName("CANCEL_PROCESS_INSTANCE")]
-    CANCELPROCESSINSTANCE,
+    CANCELPROCESSINSTANCE = 1,
     [JsonPropertyName("DELETE_DECISION_DEFINITION")]
-    DELETEDECISIONDEFINITION,
+    DELETEDECISIONDEFINITION = 2,
     [JsonPropertyName("DELETE_DECISION_INSTANCE")]
-    DELETEDECISIONINSTANCE,
+    DELETEDECISIONINSTANCE = 3,
     [JsonPropertyName("DELETE_PROCESS_DEFINITION")]
-    DELETEPROCESSDEFINITION,
+    DELETEPROCESSDEFINITION = 4,
     [JsonPropertyName("DELETE_PROCESS_INSTANCE")]
-    DELETEPROCESSINSTANCE,
+    DELETEPROCESSINSTANCE = 5,
     [JsonPropertyName("MIGRATE_PROCESS_INSTANCE")]
-    MIGRATEPROCESSINSTANCE,
+    MIGRATEPROCESSINSTANCE = 6,
     [JsonPropertyName("MODIFY_PROCESS_INSTANCE")]
-    MODIFYPROCESSINSTANCE,
+    MODIFYPROCESSINSTANCE = 7,
     [JsonPropertyName("RESOLVE_INCIDENT")]
-    RESOLVEINCIDENT,
+    RESOLVEINCIDENT = 8,
     [JsonPropertyName("UPDATE_JOB")]
-    UPDATEJOB,
+    UPDATEJOB = 9,
     [JsonPropertyName("UPDATE_VARIABLE")]
-    UPDATEVARIABLE,
+    UPDATEVARIABLE = 10,
 }
 
 /// <summary>
@@ -8294,11 +8294,11 @@ public sealed class CloudConfigurationResponse
 public enum CloudStage
 {
     [JsonPropertyName("dev")]
-    Dev,
+    Dev = 0,
     [JsonPropertyName("int")]
-    Int,
+    Int = 1,
     [JsonPropertyName("prod")]
-    Prod,
+    Prod = 2,
 }
 
 /// <summary>
@@ -8392,9 +8392,9 @@ public sealed class ClusterVariableResultBase
 public enum ClusterVariableScopeEnum
 {
     [JsonPropertyName("GLOBAL")]
-    GLOBAL,
+    GLOBAL = 0,
     [JsonPropertyName("TENANT")]
-    TENANT,
+    TENANT = 1,
 }
 
 /// <summary>
@@ -9741,14 +9741,14 @@ public sealed class DecisionDefinitionSearchQuerySortRequest
 public enum DecisionDefinitionTypeEnum
 {
     [JsonPropertyName("DECISION_TABLE")]
-    DECISIONTABLE,
+    DECISIONTABLE = 0,
     [JsonPropertyName("LITERAL_EXPRESSION")]
-    LITERALEXPRESSION,
+    LITERALEXPRESSION = 1,
     [Obsolete("Deprecated since 8.9.0")]
     [JsonPropertyName("UNSPECIFIED")]
-    UNSPECIFIED,
+    UNSPECIFIED = 2,
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 3,
 }
 
 /// <summary>
@@ -10663,15 +10663,15 @@ public sealed class DecisionInstanceSearchQuerySortRequest
 public enum DecisionInstanceStateEnum
 {
     [JsonPropertyName("EVALUATED")]
-    EVALUATED,
+    EVALUATED = 0,
     [JsonPropertyName("FAILED")]
-    FAILED,
+    FAILED = 1,
     [Obsolete("Deprecated since 8.9.0")]
     [JsonPropertyName("UNSPECIFIED")]
-    UNSPECIFIED,
+    UNSPECIFIED = 2,
     [Obsolete("Deprecated since 8.9.0")]
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 3,
 }
 
 /// <summary>
@@ -12702,11 +12702,11 @@ public sealed class ElementInstanceSearchQuerySortRequest
 public enum ElementInstanceStateEnum
 {
     [JsonPropertyName("ACTIVE")]
-    ACTIVE,
+    ACTIVE = 0,
     [JsonPropertyName("COMPLETED")]
-    COMPLETED,
+    COMPLETED = 1,
     [JsonPropertyName("TERMINATED")]
-    TERMINATED,
+    TERMINATED = 2,
 }
 
 /// <summary>
@@ -13848,9 +13848,9 @@ public readonly record struct GlobalListenerId : global::Camunda.Orchestration.S
 public enum GlobalListenerSourceEnum
 {
     [JsonPropertyName("CONFIGURATION")]
-    CONFIGURATION,
+    CONFIGURATION = 0,
     [JsonPropertyName("API")]
-    API,
+    API = 1,
 }
 
 /// <summary>
@@ -14047,17 +14047,17 @@ public sealed class GlobalTaskListenerBase
 public enum GlobalTaskListenerEventTypeEnum
 {
     [JsonPropertyName("all")]
-    All,
+    All = 0,
     [JsonPropertyName("creating")]
-    Creating,
+    Creating = 1,
     [JsonPropertyName("assigning")]
-    Assigning,
+    Assigning = 2,
     [JsonPropertyName("updating")]
-    Updating,
+    Updating = 3,
     [JsonPropertyName("completing")]
-    Completing,
+    Completing = 4,
     [JsonPropertyName("canceling")]
-    Canceling,
+    Canceling = 5,
 }
 
 /// <summary>
@@ -14785,37 +14785,37 @@ public sealed class GroupUserSearchResult
 public enum IncidentErrorTypeEnum
 {
     [JsonPropertyName("AD_HOC_SUB_PROCESS_NO_RETRIES")]
-    ADHOCSUBPROCESSNORETRIES,
+    ADHOCSUBPROCESSNORETRIES = 0,
     [JsonPropertyName("CALLED_DECISION_ERROR")]
-    CALLEDDECISIONERROR,
+    CALLEDDECISIONERROR = 1,
     [JsonPropertyName("CALLED_ELEMENT_ERROR")]
-    CALLEDELEMENTERROR,
+    CALLEDELEMENTERROR = 2,
     [JsonPropertyName("CONDITION_ERROR")]
-    CONDITIONERROR,
+    CONDITIONERROR = 3,
     [JsonPropertyName("DECISION_EVALUATION_ERROR")]
-    DECISIONEVALUATIONERROR,
+    DECISIONEVALUATIONERROR = 4,
     [JsonPropertyName("EXECUTION_LISTENER_NO_RETRIES")]
-    EXECUTIONLISTENERNORETRIES,
+    EXECUTIONLISTENERNORETRIES = 5,
     [JsonPropertyName("EXTRACT_VALUE_ERROR")]
-    EXTRACTVALUEERROR,
+    EXTRACTVALUEERROR = 6,
     [JsonPropertyName("FORM_NOT_FOUND")]
-    FORMNOTFOUND,
+    FORMNOTFOUND = 7,
     [JsonPropertyName("IO_MAPPING_ERROR")]
-    IOMAPPINGERROR,
+    IOMAPPINGERROR = 8,
     [JsonPropertyName("JOB_NO_RETRIES")]
-    JOBNORETRIES,
+    JOBNORETRIES = 9,
     [JsonPropertyName("MESSAGE_SIZE_EXCEEDED")]
-    MESSAGESIZEEXCEEDED,
+    MESSAGESIZEEXCEEDED = 10,
     [JsonPropertyName("RESOURCE_NOT_FOUND")]
-    RESOURCENOTFOUND,
+    RESOURCENOTFOUND = 11,
     [JsonPropertyName("TASK_LISTENER_NO_RETRIES")]
-    TASKLISTENERNORETRIES,
+    TASKLISTENERNORETRIES = 12,
     [JsonPropertyName("UNHANDLED_ERROR_EVENT")]
-    UNHANDLEDERROREVENT,
+    UNHANDLEDERROREVENT = 13,
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 14,
     [JsonPropertyName("UNSPECIFIED")]
-    UNSPECIFIED,
+    UNSPECIFIED = 15,
 }
 
 /// <summary>
@@ -15469,15 +15469,15 @@ public sealed class IncidentSearchQuerySortRequest
 public enum IncidentStateEnum
 {
     [JsonPropertyName("ACTIVE")]
-    ACTIVE,
+    ACTIVE = 0,
     [JsonPropertyName("MIGRATED")]
-    MIGRATED,
+    MIGRATED = 1,
     [JsonPropertyName("PENDING")]
-    PENDING,
+    PENDING = 2,
     [JsonPropertyName("RESOLVED")]
-    RESOLVED,
+    RESOLVED = 3,
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 4,
 }
 
 /// <summary>
@@ -16463,13 +16463,13 @@ internal sealed class JobKeyFilterPropertyJsonConverter : global::System.Text.Js
 public enum JobKindEnum
 {
     [JsonPropertyName("BPMN_ELEMENT")]
-    BPMNELEMENT,
+    BPMNELEMENT = 0,
     [JsonPropertyName("EXECUTION_LISTENER")]
-    EXECUTIONLISTENER,
+    EXECUTIONLISTENER = 1,
     [JsonPropertyName("TASK_LISTENER")]
-    TASKLISTENER,
+    TASKLISTENER = 2,
     [JsonPropertyName("AD_HOC_SUB_PROCESS")]
-    ADHOCSUBPROCESS,
+    ADHOCSUBPROCESS = 3,
 }
 
 /// <summary>
@@ -16629,25 +16629,25 @@ internal sealed class JobKindFilterPropertyJsonConverter : global::System.Text.J
 public enum JobListenerEventTypeEnum
 {
     [JsonPropertyName("ASSIGNING")]
-    ASSIGNING,
+    ASSIGNING = 0,
     [JsonPropertyName("BEFORE_ALL")]
-    BEFOREALL,
+    BEFOREALL = 1,
     [JsonPropertyName("CANCEL")]
-    CANCEL,
+    CANCEL = 2,
     [JsonPropertyName("CANCELING")]
-    CANCELING,
+    CANCELING = 3,
     [JsonPropertyName("COMPLETING")]
-    COMPLETING,
+    COMPLETING = 4,
     [JsonPropertyName("CREATING")]
-    CREATING,
+    CREATING = 5,
     [JsonPropertyName("END")]
-    END,
+    END = 6,
     [JsonPropertyName("START")]
-    START,
+    START = 7,
     [JsonPropertyName("UNSPECIFIED")]
-    UNSPECIFIED,
+    UNSPECIFIED = 8,
     [JsonPropertyName("UPDATING")]
-    UPDATING,
+    UPDATING = 9,
 }
 
 /// <summary>
@@ -17235,23 +17235,23 @@ public sealed class JobSearchResult
 public enum JobStateEnum
 {
     [JsonPropertyName("CANCELED")]
-    CANCELED,
+    CANCELED = 0,
     [JsonPropertyName("COMPLETED")]
-    COMPLETED,
+    COMPLETED = 1,
     [JsonPropertyName("CREATED")]
-    CREATED,
+    CREATED = 2,
     [JsonPropertyName("ERROR_THROWN")]
-    ERRORTHROWN,
+    ERRORTHROWN = 3,
     [JsonPropertyName("FAILED")]
-    FAILED,
+    FAILED = 4,
     [JsonPropertyName("MIGRATED")]
-    MIGRATED,
+    MIGRATED = 5,
     [JsonPropertyName("PRIORITY_UPDATED")]
-    PRIORITYUPDATED,
+    PRIORITYUPDATED = 6,
     [JsonPropertyName("RETRIES_UPDATED")]
-    RETRIESUPDATED,
+    RETRIESUPDATED = 7,
     [JsonPropertyName("TIMED_OUT")]
-    TIMEDOUT,
+    TIMEDOUT = 8,
 }
 
 /// <summary>
@@ -18895,13 +18895,13 @@ public sealed class MessageSubscriptionSearchQuerySortRequest
 public enum MessageSubscriptionStateEnum
 {
     [JsonPropertyName("CORRELATED")]
-    CORRELATED,
+    CORRELATED = 0,
     [JsonPropertyName("CREATED")]
-    CREATED,
+    CREATED = 1,
     [JsonPropertyName("DELETED")]
-    DELETED,
+    DELETED = 2,
     [JsonPropertyName("MIGRATED")]
-    MIGRATED,
+    MIGRATED = 3,
 }
 
 /// <summary>
@@ -19066,9 +19066,9 @@ internal sealed class MessageSubscriptionStateFilterPropertyJsonConverter : glob
 public enum MessageSubscriptionTypeEnum
 {
     [JsonPropertyName("START_EVENT")]
-    STARTEVENT,
+    STARTEVENT = 0,
     [JsonPropertyName("PROCESS_EVENT")]
-    PROCESSEVENT,
+    PROCESSEVENT = 1,
 }
 
 /// <summary>
@@ -19484,17 +19484,17 @@ internal sealed class OperationTypeFilterPropertyJsonConverter : global::System.
 public enum OwnerTypeEnum
 {
     [JsonPropertyName("USER")]
-    USER,
+    USER = 0,
     [JsonPropertyName("CLIENT")]
-    CLIENT,
+    CLIENT = 1,
     [JsonPropertyName("ROLE")]
-    ROLE,
+    ROLE = 2,
     [JsonPropertyName("GROUP")]
-    GROUP,
+    GROUP = 3,
     [JsonPropertyName("MAPPING_RULE")]
-    MAPPINGRULE,
+    MAPPINGRULE = 4,
     [JsonPropertyName("UNSPECIFIED")]
-    UNSPECIFIED,
+    UNSPECIFIED = 5,
 }
 
 /// <summary>
@@ -19529,89 +19529,89 @@ public sealed class Partition
 public enum PermissionTypeEnum
 {
     [JsonPropertyName("ACCESS")]
-    ACCESS,
+    ACCESS = 0,
     [JsonPropertyName("CANCEL_PROCESS_INSTANCE")]
-    CANCELPROCESSINSTANCE,
+    CANCELPROCESSINSTANCE = 1,
     [JsonPropertyName("CLAIM")]
-    CLAIM,
+    CLAIM = 2,
     [JsonPropertyName("CLAIM_USER_TASK")]
-    CLAIMUSERTASK,
+    CLAIMUSERTASK = 3,
     [JsonPropertyName("COMPLETE")]
-    COMPLETE,
+    COMPLETE = 4,
     [JsonPropertyName("COMPLETE_USER_TASK")]
-    COMPLETEUSERTASK,
+    COMPLETEUSERTASK = 5,
     [JsonPropertyName("CREATE")]
-    CREATE,
+    CREATE = 6,
     [JsonPropertyName("CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE")]
-    CREATEBATCHOPERATIONCANCELPROCESSINSTANCE,
+    CREATEBATCHOPERATIONCANCELPROCESSINSTANCE = 7,
     [JsonPropertyName("CREATE_BATCH_OPERATION_DELETE_DECISION_DEFINITION")]
-    CREATEBATCHOPERATIONDELETEDECISIONDEFINITION,
+    CREATEBATCHOPERATIONDELETEDECISIONDEFINITION = 8,
     [JsonPropertyName("CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE")]
-    CREATEBATCHOPERATIONDELETEDECISIONINSTANCE,
+    CREATEBATCHOPERATIONDELETEDECISIONINSTANCE = 9,
     [JsonPropertyName("CREATE_BATCH_OPERATION_DELETE_PROCESS_DEFINITION")]
-    CREATEBATCHOPERATIONDELETEPROCESSDEFINITION,
+    CREATEBATCHOPERATIONDELETEPROCESSDEFINITION = 10,
     [JsonPropertyName("CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE")]
-    CREATEBATCHOPERATIONDELETEPROCESSINSTANCE,
+    CREATEBATCHOPERATIONDELETEPROCESSINSTANCE = 11,
     [JsonPropertyName("CREATE_BATCH_OPERATION_MIGRATE_PROCESS_INSTANCE")]
-    CREATEBATCHOPERATIONMIGRATEPROCESSINSTANCE,
+    CREATEBATCHOPERATIONMIGRATEPROCESSINSTANCE = 12,
     [JsonPropertyName("CREATE_BATCH_OPERATION_MODIFY_PROCESS_INSTANCE")]
-    CREATEBATCHOPERATIONMODIFYPROCESSINSTANCE,
+    CREATEBATCHOPERATIONMODIFYPROCESSINSTANCE = 13,
     [JsonPropertyName("CREATE_BATCH_OPERATION_RESOLVE_INCIDENT")]
-    CREATEBATCHOPERATIONRESOLVEINCIDENT,
+    CREATEBATCHOPERATIONRESOLVEINCIDENT = 14,
     [JsonPropertyName("CREATE_BATCH_OPERATION_UPDATE_JOB")]
-    CREATEBATCHOPERATIONUPDATEJOB,
+    CREATEBATCHOPERATIONUPDATEJOB = 15,
     [JsonPropertyName("CREATE_DECISION_INSTANCE")]
-    CREATEDECISIONINSTANCE,
+    CREATEDECISIONINSTANCE = 16,
     [JsonPropertyName("CREATE_PROCESS_INSTANCE")]
-    CREATEPROCESSINSTANCE,
+    CREATEPROCESSINSTANCE = 17,
     [JsonPropertyName("CREATE_TASK_LISTENER")]
-    CREATETASKLISTENER,
+    CREATETASKLISTENER = 18,
     [JsonPropertyName("DELETE")]
-    DELETE,
+    DELETE = 19,
     [JsonPropertyName("DELETE_DECISION_INSTANCE")]
-    DELETEDECISIONINSTANCE,
+    DELETEDECISIONINSTANCE = 20,
     [JsonPropertyName("DELETE_DRD")]
-    DELETEDRD,
+    DELETEDRD = 21,
     [JsonPropertyName("DELETE_FORM")]
-    DELETEFORM,
+    DELETEFORM = 22,
     [JsonPropertyName("DELETE_PROCESS")]
-    DELETEPROCESS,
+    DELETEPROCESS = 23,
     [JsonPropertyName("DELETE_PROCESS_INSTANCE")]
-    DELETEPROCESSINSTANCE,
+    DELETEPROCESSINSTANCE = 24,
     [JsonPropertyName("DELETE_RESOURCE")]
-    DELETERESOURCE,
+    DELETERESOURCE = 25,
     [JsonPropertyName("DELETE_TASK_LISTENER")]
-    DELETETASKLISTENER,
+    DELETETASKLISTENER = 26,
     [JsonPropertyName("EVALUATE")]
-    EVALUATE,
+    EVALUATE = 27,
     [JsonPropertyName("MODIFY_PROCESS_INSTANCE")]
-    MODIFYPROCESSINSTANCE,
+    MODIFYPROCESSINSTANCE = 28,
     [JsonPropertyName("READ")]
-    READ,
+    READ = 29,
     [JsonPropertyName("READ_DECISION_DEFINITION")]
-    READDECISIONDEFINITION,
+    READDECISIONDEFINITION = 30,
     [JsonPropertyName("READ_DECISION_INSTANCE")]
-    READDECISIONINSTANCE,
+    READDECISIONINSTANCE = 31,
     [JsonPropertyName("READ_JOB_METRIC")]
-    READJOBMETRIC,
+    READJOBMETRIC = 32,
     [JsonPropertyName("READ_PROCESS_DEFINITION")]
-    READPROCESSDEFINITION,
+    READPROCESSDEFINITION = 33,
     [JsonPropertyName("READ_PROCESS_INSTANCE")]
-    READPROCESSINSTANCE,
+    READPROCESSINSTANCE = 34,
     [JsonPropertyName("READ_USAGE_METRIC")]
-    READUSAGEMETRIC,
+    READUSAGEMETRIC = 35,
     [JsonPropertyName("READ_USER_TASK")]
-    READUSERTASK,
+    READUSERTASK = 36,
     [JsonPropertyName("READ_TASK_LISTENER")]
-    READTASKLISTENER,
+    READTASKLISTENER = 37,
     [JsonPropertyName("UPDATE")]
-    UPDATE,
+    UPDATE = 38,
     [JsonPropertyName("UPDATE_PROCESS_INSTANCE")]
-    UPDATEPROCESSINSTANCE,
+    UPDATEPROCESSINSTANCE = 39,
     [JsonPropertyName("UPDATE_USER_TASK")]
-    UPDATEUSERTASK,
+    UPDATEUSERTASK = 40,
     [JsonPropertyName("UPDATE_TASK_LISTENER")]
-    UPDATETASKLISTENER,
+    UPDATETASKLISTENER = 41,
 }
 
 /// <summary>
@@ -22158,11 +22158,11 @@ public sealed class ProcessInstanceSequenceFlowsQueryResult
 public enum ProcessInstanceStateEnum
 {
     [JsonPropertyName("ACTIVE")]
-    ACTIVE,
+    ACTIVE = 0,
     [JsonPropertyName("COMPLETED")]
-    COMPLETED,
+    COMPLETED = 1,
     [JsonPropertyName("TERMINATED")]
-    TERMINATED,
+    TERMINATED = 2,
 }
 
 /// <summary>
@@ -22679,45 +22679,45 @@ public sealed class ResourceSearchQuerySortRequest
 public enum ResourceTypeEnum
 {
     [JsonPropertyName("AUDIT_LOG")]
-    AUDITLOG,
+    AUDITLOG = 0,
     [JsonPropertyName("AUTHORIZATION")]
-    AUTHORIZATION,
+    AUTHORIZATION = 1,
     [JsonPropertyName("BATCH")]
-    BATCH,
+    BATCH = 2,
     [JsonPropertyName("CLUSTER_VARIABLE")]
-    CLUSTERVARIABLE,
+    CLUSTERVARIABLE = 3,
     [JsonPropertyName("COMPONENT")]
-    COMPONENT,
+    COMPONENT = 4,
     [JsonPropertyName("DECISION_DEFINITION")]
-    DECISIONDEFINITION,
+    DECISIONDEFINITION = 5,
     [JsonPropertyName("DECISION_REQUIREMENTS_DEFINITION")]
-    DECISIONREQUIREMENTSDEFINITION,
+    DECISIONREQUIREMENTSDEFINITION = 6,
     [JsonPropertyName("DOCUMENT")]
-    DOCUMENT,
+    DOCUMENT = 7,
     [JsonPropertyName("EXPRESSION")]
-    EXPRESSION,
+    EXPRESSION = 8,
     [JsonPropertyName("GLOBAL_LISTENER")]
-    GLOBALLISTENER,
+    GLOBALLISTENER = 9,
     [JsonPropertyName("GROUP")]
-    GROUP,
+    GROUP = 10,
     [JsonPropertyName("MAPPING_RULE")]
-    MAPPINGRULE,
+    MAPPINGRULE = 11,
     [JsonPropertyName("MESSAGE")]
-    MESSAGE,
+    MESSAGE = 12,
     [JsonPropertyName("PROCESS_DEFINITION")]
-    PROCESSDEFINITION,
+    PROCESSDEFINITION = 13,
     [JsonPropertyName("RESOURCE")]
-    RESOURCE,
+    RESOURCE = 14,
     [JsonPropertyName("ROLE")]
-    ROLE,
+    ROLE = 15,
     [JsonPropertyName("SYSTEM")]
-    SYSTEM,
+    SYSTEM = 16,
     [JsonPropertyName("TENANT")]
-    TENANT,
+    TENANT = 17,
     [JsonPropertyName("USER")]
-    USER,
+    USER = 18,
     [JsonPropertyName("USER_TASK")]
-    USERTASK,
+    USERTASK = 19,
 }
 
 /// <summary>
@@ -23583,9 +23583,9 @@ public sealed class SignalWaitStateDetails : WaitStateDetails
 public enum SortOrderEnum
 {
     [JsonPropertyName("ASC")]
-    ASC,
+    ASC = 0,
     [JsonPropertyName("DESC")]
-    DESC,
+    DESC = 1,
 }
 
 /// <summary>
@@ -24037,9 +24037,9 @@ public sealed class TenantFilter
 public enum TenantFilterEnum
 {
     [JsonPropertyName("PROVIDED")]
-    PROVIDED,
+    PROVIDED = 0,
     [JsonPropertyName("ASSIGNED")]
-    ASSIGNED,
+    ASSIGNED = 1,
 }
 
 /// <summary>
@@ -25361,23 +25361,23 @@ public sealed class UserTaskSearchQuerySortRequest
 public enum UserTaskStateEnum
 {
     [JsonPropertyName("CREATING")]
-    CREATING,
+    CREATING = 0,
     [JsonPropertyName("CREATED")]
-    CREATED,
+    CREATED = 1,
     [JsonPropertyName("ASSIGNING")]
-    ASSIGNING,
+    ASSIGNING = 2,
     [JsonPropertyName("UPDATING")]
-    UPDATING,
+    UPDATING = 3,
     [JsonPropertyName("COMPLETING")]
-    COMPLETING,
+    COMPLETING = 4,
     [JsonPropertyName("COMPLETED")]
-    COMPLETED,
+    COMPLETED = 5,
     [JsonPropertyName("CANCELING")]
-    CANCELING,
+    CANCELING = 6,
     [JsonPropertyName("CANCELED")]
-    CANCELED,
+    CANCELED = 7,
     [JsonPropertyName("FAILED")]
-    FAILED,
+    FAILED = 8,
 }
 
 /// <summary>
@@ -26218,59 +26218,59 @@ public abstract class WaitStateDetails { }
 public enum WaitStateElementTypeEnum
 {
     [JsonPropertyName("AD_HOC_SUB_PROCESS")]
-    ADHOCSUBPROCESS,
+    ADHOCSUBPROCESS = 0,
     [JsonPropertyName("AD_HOC_SUB_PROCESS_INNER_INSTANCE")]
-    ADHOCSUBPROCESSINNERINSTANCE,
+    ADHOCSUBPROCESSINNERINSTANCE = 1,
     [JsonPropertyName("BOUNDARY_EVENT")]
-    BOUNDARYEVENT,
+    BOUNDARYEVENT = 2,
     [JsonPropertyName("BUSINESS_RULE_TASK")]
-    BUSINESSRULETASK,
+    BUSINESSRULETASK = 3,
     [JsonPropertyName("CALL_ACTIVITY")]
-    CALLACTIVITY,
+    CALLACTIVITY = 4,
     [JsonPropertyName("END_EVENT")]
-    ENDEVENT,
+    ENDEVENT = 5,
     [JsonPropertyName("EVENT_BASED_GATEWAY")]
-    EVENTBASEDGATEWAY,
+    EVENTBASEDGATEWAY = 6,
     [JsonPropertyName("EVENT_SUB_PROCESS")]
-    EVENTSUBPROCESS,
+    EVENTSUBPROCESS = 7,
     [JsonPropertyName("EXCLUSIVE_GATEWAY")]
-    EXCLUSIVEGATEWAY,
+    EXCLUSIVEGATEWAY = 8,
     [JsonPropertyName("INCLUSIVE_GATEWAY")]
-    INCLUSIVEGATEWAY,
+    INCLUSIVEGATEWAY = 9,
     [JsonPropertyName("INTERMEDIATE_CATCH_EVENT")]
-    INTERMEDIATECATCHEVENT,
+    INTERMEDIATECATCHEVENT = 10,
     [JsonPropertyName("INTERMEDIATE_THROW_EVENT")]
-    INTERMEDIATETHROWEVENT,
+    INTERMEDIATETHROWEVENT = 11,
     [JsonPropertyName("MANUAL_TASK")]
-    MANUALTASK,
+    MANUALTASK = 12,
     [JsonPropertyName("MULTI_INSTANCE_BODY")]
-    MULTIINSTANCEBODY,
+    MULTIINSTANCEBODY = 13,
     [JsonPropertyName("PARALLEL_GATEWAY")]
-    PARALLELGATEWAY,
+    PARALLELGATEWAY = 14,
     [JsonPropertyName("PROCESS")]
-    PROCESS,
+    PROCESS = 15,
     [JsonPropertyName("RECEIVE_TASK")]
-    RECEIVETASK,
+    RECEIVETASK = 16,
     [JsonPropertyName("SCRIPT_TASK")]
-    SCRIPTTASK,
+    SCRIPTTASK = 17,
     [JsonPropertyName("SEND_TASK")]
-    SENDTASK,
+    SENDTASK = 18,
     [JsonPropertyName("SEQUENCE_FLOW")]
-    SEQUENCEFLOW,
+    SEQUENCEFLOW = 19,
     [JsonPropertyName("SERVICE_TASK")]
-    SERVICETASK,
+    SERVICETASK = 20,
     [JsonPropertyName("START_EVENT")]
-    STARTEVENT,
+    STARTEVENT = 21,
     [JsonPropertyName("SUB_PROCESS")]
-    SUBPROCESS,
+    SUBPROCESS = 22,
     [JsonPropertyName("TASK")]
-    TASK,
+    TASK = 23,
     [JsonPropertyName("UNKNOWN")]
-    UNKNOWN,
+    UNKNOWN = 24,
     [JsonPropertyName("UNSPECIFIED")]
-    UNSPECIFIED,
+    UNSPECIFIED = 25,
     [JsonPropertyName("USER_TASK")]
-    USERTASK,
+    USERTASK = 26,
 }
 
 /// <summary>
@@ -26430,17 +26430,17 @@ internal sealed class WaitStateElementTypeFilterPropertyJsonConverter : global::
 public enum WaitStateTypeEnum
 {
     [JsonPropertyName("JOB")]
-    JOB,
+    JOB = 0,
     [JsonPropertyName("MESSAGE")]
-    MESSAGE,
+    MESSAGE = 1,
     [JsonPropertyName("USER_TASK")]
-    USERTASK,
+    USERTASK = 2,
     [JsonPropertyName("TIMER")]
-    TIMER,
+    TIMER = 3,
     [JsonPropertyName("SIGNAL")]
-    SIGNAL,
+    SIGNAL = 4,
     [JsonPropertyName("CONDITION")]
-    CONDITION,
+    CONDITION = 5,
 }
 
 /// <summary>
@@ -26600,10 +26600,10 @@ internal sealed class WaitStateTypeFilterPropertyJsonConverter : global::System.
 public enum WebappComponent
 {
     [JsonPropertyName("operate")]
-    Operate,
+    Operate = 0,
     [JsonPropertyName("tasklist")]
-    Tasklist,
+    Tasklist = 1,
     [JsonPropertyName("admin")]
-    Admin,
+    Admin = 2,
 }
 

--- a/test/Camunda.Orchestration.Sdk.Tests/EnumValueStabilityTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/EnumValueStabilityTests.cs
@@ -1,0 +1,102 @@
+using Camunda.Orchestration.Sdk.Generator;
+
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Defect-class regression guard for enum numeric-value stability (see #280).
+///
+/// Generated enums serialize by name, but their numeric values are baked into
+/// consumer IL. The defect class: when the upstream spec inserts a member
+/// mid-list, the generator (which assigned values by position) shifted every
+/// later member's value, silently changing behaviour for any consumer that cast
+/// or persisted the numeric value.
+///
+/// The fix is <see cref="EnumValueRegistry"/>: a persisted member→int manifest
+/// that keeps existing assignments stable and only ever appends. These tests
+/// assert the invariant directly — inserting/removing members must never change
+/// the value of a member that was already assigned.
+/// </summary>
+public class EnumValueStabilityTests
+{
+    private static string NewManifestPath() =>
+        Path.Combine(Path.GetTempPath(), $"enumvalues-{Guid.NewGuid():N}.json");
+
+    [Fact]
+    public void Assign_SeedsByCallOrder_FromEmpty()
+    {
+        var path = NewManifestPath();
+        try
+        {
+            EnumValueRegistry.LoadFrom(path);
+
+            Assert.Equal(0, EnumValueRegistry.Assign("MyEnum", "ALPHA"));
+            Assert.Equal(1, EnumValueRegistry.Assign("MyEnum", "BRAVO"));
+            Assert.Equal(2, EnumValueRegistry.Assign("MyEnum", "CHARLIE"));
+            // Re-asking is idempotent.
+            Assert.Equal(1, EnumValueRegistry.Assign("MyEnum", "BRAVO"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Assign_IsStable_WhenMemberInsertedMidList_AcrossRuns()
+    {
+        var path = NewManifestPath();
+        try
+        {
+            // First generation run: members ALPHA, BRAVO.
+            EnumValueRegistry.LoadFrom(path);
+            var alpha1 = EnumValueRegistry.Assign("MyEnum", "ALPHA");
+            var bravo1 = EnumValueRegistry.Assign("MyEnum", "BRAVO");
+            EnumValueRegistry.Save();
+
+            // Second run after upstream inserts CHARLIE *between* ALPHA and BRAVO.
+            EnumValueRegistry.LoadFrom(path);
+            var alpha2 = EnumValueRegistry.Assign("MyEnum", "ALPHA");
+            var charlie = EnumValueRegistry.Assign("MyEnum", "CHARLIE");
+            var bravo2 = EnumValueRegistry.Assign("MyEnum", "BRAVO");
+
+            // Existing members keep their values; the new one is appended.
+            Assert.Equal(alpha1, alpha2);
+            Assert.Equal(bravo1, bravo2);
+            Assert.Equal(2, charlie);
+            // Critically, BRAVO did NOT shift to make room for CHARLIE.
+            Assert.NotEqual(charlie, bravo2);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Assign_DoesNotReuse_RemovedMemberValue()
+    {
+        var path = NewManifestPath();
+        try
+        {
+            // Run 1: ALPHA=0, BRAVO=1, CHARLIE=2.
+            EnumValueRegistry.LoadFrom(path);
+            EnumValueRegistry.Assign("MyEnum", "ALPHA");
+            EnumValueRegistry.Assign("MyEnum", "BRAVO");
+            EnumValueRegistry.Assign("MyEnum", "CHARLIE");
+            EnumValueRegistry.Save();
+
+            // Run 2: BRAVO removed upstream, DELTA added. DELTA must not reuse
+            // BRAVO's retired value (1) — tombstones keep retired ints reserved.
+            EnumValueRegistry.LoadFrom(path);
+            EnumValueRegistry.Assign("MyEnum", "ALPHA");
+            EnumValueRegistry.Assign("MyEnum", "CHARLIE");
+            var delta = EnumValueRegistry.Assign("MyEnum", "DELTA");
+
+            Assert.Equal(3, delta);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
**Draft / prototype** for #280 — feedback wanted on the approach before polishing.

## Problem

Generated enums serialize by name (`JsonStringEnumConverter` + `JsonPropertyName`), but their numeric values are baked into consumer IL. The generator numbered members by position, so when the upstream spec inserts a member mid-list, every later member's value shifts — silently changing behaviour for any consumer that cast or persisted the numeric value. (Raised by Copilot on #279 re: `BatchOperationTypeEnum`.)

## Approach

`EnumValueRegistry` — a `member → int` manifest persisted to `Generated/EnumValues.json`, reloaded on each run:
- existing members keep their assigned value (order-independent),
- new members append (`max + 1`),
- removed members are retained as tombstones so their int is never reused.

Both enum emission sites now emit explicit `= <value>`. The manifest path is derived from `outputDir`, so `Generate()`'s signature is unchanged (the ~10 existing test callers and their temp-dir runs stay isolated).

## Blast radius (validated locally)

| | |
|---|---|
| `Models.Generated.cs` | **622 insertions / 622 deletions** — purely `Name,` → `Name = N,` |
| `PublicApi.shipped.txt` | **unchanged** — values preserved, so zero baseline churn |
| New files | `EnumValueRegistry.cs`, `Generated/EnumValues.json` (85 enums), `EnumValueStabilityTests.cs` |
| Tests | **1089 passed** (net8.0 + net10.0), incl. 3 new defect-class stability tests |
| Behavior | none — seeded values match the prior implicit ordering |

Two commits per the separate-commits rule: (1) generator + registry + test, (2) regenerated `Generated/`.

## Open questions / caveats for reviewers

1. **Manifest location** — currently `Generated/EnumValues.json`. Freshness is covered by the existing "Detect Generation Drift" CI step (it's committed under `Generated/`), but that step is non-blocking like all generated-drift here. Do we want it enforced for the manifest specifically?
2. **Tombstones** — removed members keep their int forever (never reused). Alternative: prune + accept that a re-added member gets a new value. Current choice favors maximum stability.
3. **Red/green** — the stability test asserts the registry invariant (mid-list insert doesn't shift existing values); since the fix replaces the positional behavior, there's no literal pre-existing red commit.
4. **Cross-SDK** — the same class of issue exists in the Python/TS SDKs; consistent resolution would port this pattern there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)