### PR TITLE
chore(gen): sync upstream spec (businessId on job result types)

### DIFF
--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -29791,6 +29791,7 @@
         ],
         "type": "object",
         "required": [
+          "businessId",
           "customHeaders",
           "deadline",
           "elementId",
@@ -29935,6 +29936,15 @@
               }
             ]
           },
+          "businessId": {
+            "description": "The business ID of the owning process instance, inherited when the job was created.\nThis is `null` for jobs created before version 8.10 and for jobs whose owning process\ninstance has no business ID.\n",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BusinessId"
+              }
+            ]
+          },
           "priority": {
             "description": "The priority of the job. Higher values indicate higher priority. Jobs created before 8.10 have no stored priority; the API returns 0 for such jobs.\n",
             "type": "integer",
@@ -29964,6 +29974,10 @@
           },
           {
             "propertyName": "priority",
+            "addedInVersion": "8.10"
+          },
+          {
+            "propertyName": "businessId",
             "addedInVersion": "8.10"
           }
         ]
@@ -30419,6 +30433,7 @@
       "JobSearchResult": {
         "type": "object",
         "required": [
+          "businessId",
           "creationTime",
           "customHeaders",
           "deadline",
@@ -30553,6 +30568,15 @@
               }
             ]
           },
+          "businessId": {
+            "description": "The business ID of the owning process instance, inherited when the job was created.\nThis is `null` for jobs created before version 8.10 and for jobs whose owning process\ninstance has no business ID.\n",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BusinessId"
+              }
+            ]
+          },
           "retries": {
             "description": "The amount of retries left to this job.",
             "type": "integer",
@@ -30605,6 +30629,10 @@
           },
           {
             "propertyName": "priority",
+            "addedInVersion": "8.10"
+          },
+          {
+            "propertyName": "businessId",
             "addedInVersion": "8.10"
           }
         ]

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:9d03097114dc146e0d6358fa42ec4032548cf62b4b4af3e8bebc558c9188894e",
+  "specHash": "sha256:0664b8f0c7c9f1fff9e2378f2bd78c8d1b0282f7f177cfc1834c63317af1c10e",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -1212,6 +1212,15 @@ public sealed class ActivatedJobResult
     public ProcessInstanceKey? RootProcessInstanceKey { get; set; }
 
     /// <summary>
+    /// The business ID of the owning process instance, inherited when the job was created.
+    /// This is `null` for jobs created before version 8.10 and for jobs whose owning process
+    /// instance has no business ID.
+    /// 
+    /// </summary>
+    [JsonPropertyName("businessId")]
+    public BusinessId? BusinessId { get; set; }
+
+    /// <summary>
     /// The priority of the job. Higher values indicate higher priority. Jobs created before 8.10 have no stored priority; the API returns 0 for such jobs.
     /// 
     /// </summary>
@@ -17176,6 +17185,15 @@ public sealed class JobSearchResult
     /// </summary>
     [JsonPropertyName("rootProcessInstanceKey")]
     public ProcessInstanceKey? RootProcessInstanceKey { get; set; }
+
+    /// <summary>
+    /// The business ID of the owning process instance, inherited when the job was created.
+    /// This is `null` for jobs created before version 8.10 and for jobs whose owning process
+    /// instance has no business ID.
+    /// 
+    /// </summary>
+    [JsonPropertyName("businessId")]
+    public BusinessId? BusinessId { get; set; }
 
     /// <summary>
     /// The amount of retries left to this job.

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:9d03097114dc146e0d6358fa42ec4032548cf62b4b4af3e8bebc558c9188894e";
+    public const string SpecHash = "sha256:0664b8f0c7c9f1fff9e2378f2bd78c8d1b0282f7f177cfc1834c63317af1c10e";
 }

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -130,7 +130,7 @@ public static class ConfigurationHydrator
         // IConfiguration section (appsettings.json etc.) — between env and overrides in precedence
         if (configuration != null)
         {
-            var configValues = ExtractFromConfiguration(configuration);
+            var configValues = ExtractFromConfiguration((IConfiguration)configuration);
             foreach (var (k, v) in configValues)
             {
                 // Configuration wins over env vars but loses to explicit overrides

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -26,6 +26,7 @@ TYPE Camunda.Orchestration.Sdk.ActivatedJob : sealed class
 
 TYPE Camunda.Orchestration.Sdk.ActivatedJobResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.BusinessId? BusinessId { get; set; } [JsonPropertyName("businessId")]
   PROP Camunda.Orchestration.Sdk.ElementId ElementId { get; set; } [JsonPropertyName("elementId")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.JobKey JobKey { get; set; } [JsonPropertyName("jobKey")]
@@ -3914,6 +3915,7 @@ TYPE Camunda.Orchestration.Sdk.JobSearchQuerySortRequestField : enum interfaces=
 
 TYPE Camunda.Orchestration.Sdk.JobSearchResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.BusinessId? BusinessId { get; set; } [JsonPropertyName("businessId")]
   PROP Camunda.Orchestration.Sdk.ElementId? ElementId { get; set; } [JsonPropertyName("elementId")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.JobKey JobKey { get; set; } [JsonPropertyName("jobKey")]


### PR DESCRIPTION
## Why

CI regenerates the SDK from current upstream on every run and compares against the committed `PublicApi.shipped.txt` baseline. Upstream's `businessId` rollout (8.10) has since added `businessId` to job-bearing result types, so the baseline is stale and **every PR off `main` currently fails** `PublicApiSurfaceTests` (e.g. #282). This re-syncs `main`.

## What

- Regenerate `Generated/` against current upstream → adds `BusinessId? BusinessId` to the affected job result types.
- Refresh `PublicApi.shipped.txt`.
- Incidental `ConfigurationHydrator` analyzer fix applied by `dotnet format` (explicit `IConfiguration` cast) — needed for the `format --verify-no-changes` gate.

## Validation

- Build (Release) + examples: ✅
- `dotnet test`: **1086 passed** (net8.0 + net10.0)

Once merged, the open workflow/prototype PRs (#282, #281) go green on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)