### PR TITLE
spec refresh + changeClusterMode example

### DIFF
--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -189,6 +189,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.ChangeClusterModeAsync(System.String,System.Nullable{System.Boolean},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Client.cs#ChangeClusterMode)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.CompleteJobAsync(Camunda.Orchestration.Sdk.JobKey,Camunda.Orchestration.Sdk.JobCompletionRequest,System.Threading.CancellationToken)
 example:
 - *content

--- a/examples/Client.cs
+++ b/examples/Client.cs
@@ -28,4 +28,25 @@ public static class ClientExamples
     }
     // </GetTopology>
     #endregion GetTopology
+
+    #region ChangeClusterMode
+
+    // <ChangeClusterMode>
+    public static async Task ChangeClusterModeExample()
+    {
+        using var client = CamundaClient.Create();
+
+        // Pass dryRun: true to validate the request and inspect the resulting plan
+        // without applying it. Omit it (or set it to false) to trigger the transition.
+        var change = await client.ChangeClusterModeAsync("RECOVERING", dryRun: true);
+
+        Console.WriteLine($"Cluster change {change.ChangeId}:");
+        foreach (var operation in change.PlannedChanges)
+        {
+            var suffix = operation.Mode is null ? "" : $" -> {operation.Mode}";
+            Console.WriteLine($"  {operation.Operation}{suffix}");
+        }
+    }
+    // </ChangeClusterMode>
+    #endregion ChangeClusterMode
 }

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -48,6 +48,13 @@
       "label": "Get cluster topology"
     }
   ],
+  "changeClusterMode": [
+    {
+      "file": "Client.cs",
+      "region": "ChangeClusterMode",
+      "label": "Change cluster mode"
+    }
+  ],
   "createProcessInstance": [
     {
       "file": "ProcessInstance.cs",

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -122,6 +122,9 @@
       "name": "Process instance"
     },
     {
+      "name": "Recovery"
+    },
+    {
       "name": "Resource"
     },
     {
@@ -608,12 +611,12 @@
         "summary": "Create agent instance history item",
         "description": "Appends a single history item to an agent instance's conversation history.\nThe created item has commitStatus PENDING until the job identified by jobLease\ncompletes successfully, at which point it transitions to COMMITTED. If the job\nfails or is superseded by a retry, the item is marked DISCARDED.\n",
         "x-semantic-establishes": {
-          "kind": "AgentInstanceIteration",
+          "kind": "AgentInstanceLoopIteration",
           "identifiedBy": [
             {
               "in": "body",
-              "name": "iteration",
-              "semanticType": "IterationId"
+              "name": "loopIteration",
+              "semanticType": "LoopIterationId"
             }
           ]
         },
@@ -18598,6 +18601,101 @@
         "x-added-in-version": "8.5"
       }
     },
+    "/mode": {
+      "patch": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Recovery"
+        ],
+        "operationId": "changeClusterMode",
+        "x-required-permissions": [],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Change cluster mode",
+        "description": "Transitions the cluster between processing and recovery mode. This is a non-blocking operation: the request is acknowledged once the change has been accepted, before the transition itself has completed. Entering recovery mode deactivates all partitions so that only a restricted set of read-only operations remains available; exiting recovery mode returns the cluster to normal processing. Returns the planned cluster change so its progress can be monitored via the topology.",
+        "parameters": [
+          {
+            "name": "mode",
+            "in": "query",
+            "required": true,
+            "description": "The target cluster mode.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "PROCESSING",
+                "RECOVERING"
+              ]
+            }
+          },
+          {
+            "name": "dryRun",
+            "in": "query",
+            "required": false,
+            "description": "If true, the requested change is only validated and the resulting plan is returned, without applying it to the cluster.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The mode change request was accepted; returns the planned cluster changes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClusterModeChangeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/users": {
       "post": {
         "x-eventually-consistent": false,
@@ -20724,7 +20822,7 @@
             ]
           },
           "metrics": {
-            "description": "Aggregated metrics across all iterations of this agent instance.",
+            "description": "Aggregated metrics across all loopIterations of this agent instance.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/AgentInstanceMetrics"
@@ -21168,12 +21266,12 @@
             "description": "Opaque lease token received from the job activation response.",
             "type": "string"
           },
-          "iteration": {
-            "description": "Sequential iteration number this item belongs to. Omit if not grouping items into iterations.",
+          "loopIteration": {
+            "description": "The loopIteration this item belongs to. A loopIteration is one pass through the agent\nfeedback loop: one LLM call, its tool dispatches, and their results. Omit if not grouping\nitems by loopIteration.\n",
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/IterationId"
+                "$ref": "#/components/schemas/LoopIterationId"
               }
             ]
           },
@@ -21248,7 +21346,7 @@
             "enum": [
               "producedAt",
               "historyItemKey",
-              "iteration"
+              "loopIteration"
             ]
           },
           "order": {
@@ -21319,8 +21417,8 @@
               }
             ]
           },
-          "iteration": {
-            "description": "The iteration number.",
+          "loopIteration": {
+            "description": "Filter by loopIteration number. A loopIteration is one pass through the agent feedback loop (one LLM call, its tool dispatches, and their results).",
             "allOf": [
               {
                 "$ref": "#/components/schemas/IntegerFilterProperty"
@@ -21375,9 +21473,9 @@
           "content",
           "elementInstanceKey",
           "historyItemKey",
-          "iteration",
           "jobKey",
           "jobLease",
+          "loopIteration",
           "metrics",
           "producedAt",
           "role",
@@ -21420,12 +21518,12 @@
             "description": "The lease token of the activation that produced this item.",
             "type": "string"
           },
-          "iteration": {
-            "description": "The sequential iteration number this item belongs to. Null if not provided by the connector.",
+          "loopIteration": {
+            "description": "The loopIteration this item belongs to. A loopIteration is one pass through the agent\nfeedback loop: one LLM call, its tool dispatches, and their results. Null if not provided\nby the connector.\n",
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/IterationId"
+                "$ref": "#/components/schemas/LoopIterationId"
               }
             ]
           },
@@ -21564,7 +21662,7 @@
       "AgentInstanceObjectContent": {
         "type": "object",
         "title": "Object content",
-        "description": "An arbitrary structured content block.",
+        "description": "An arbitrary structured content block. Accepts any valid JSON value:\nobjects, arrays, numbers, booleans, or strings.\nUse TEXT content for human-readable natural language;\nuse OBJECT content for machine-readable structured data.\n",
         "additionalProperties": false,
         "required": [
           "contentType",
@@ -21577,9 +21675,7 @@
             "example": "OBJECT"
           },
           "object": {
-            "description": "Arbitrary structured content.",
-            "type": "object",
-            "additionalProperties": true
+            "description": "Arbitrary structured content — any valid JSON value (object, array, number, boolean, or string)."
           }
         }
       },
@@ -24576,6 +24672,49 @@
               "unhealthy",
               "dead"
             ]
+          }
+        }
+      },
+      "ClusterModeChangeResponse": {
+        "description": "The planned changes resulting from a cluster mode transition request.",
+        "type": "object",
+        "required": [
+          "changeId",
+          "plannedChanges"
+        ],
+        "properties": {
+          "changeId": {
+            "description": "The ID of the cluster change that was triggered by the request.",
+            "type": "string",
+            "example": "7"
+          },
+          "plannedChanges": {
+            "description": "The ordered list of operations that will be applied to complete the change.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClusterModeChangeOperation"
+            }
+          }
+        }
+      },
+      "ClusterModeChangeOperation": {
+        "description": "A single operation that is part of a cluster mode change.",
+        "type": "object",
+        "required": [
+          "mode",
+          "operation"
+        ],
+        "properties": {
+          "operation": {
+            "description": "The type of the operation.",
+            "type": "string",
+            "example": "ModeChangeOperation"
+          },
+          "mode": {
+            "description": "The target mode of the operation, if applicable.",
+            "type": "string",
+            "nullable": true,
+            "example": "RECOVERING"
           }
         }
       },
@@ -29687,12 +29826,12 @@
         "maxLength": 256,
         "example": "order-12345"
       },
-      "IterationId": {
-        "description": "A client-provided sequential integer identifying a logical iteration: one LLM\ncall, its tool dispatches, and their results. Must be a positive integer,\nincreasing with each iteration. Established by the\nconnector when appending the first history item of an iteration.\n",
+      "LoopIterationId": {
+        "description": "A client-provided sequential integer identifying one pass through the agent\nfeedback loop: one LLM call, its tool dispatches, and their results. Must be\na positive integer, increasing with each loopIteration. Established by the\nconnector when appending the first history item of a loopIteration.\n",
         "type": "integer",
         "format": "int32",
         "minimum": 1,
-        "x-semantic-type": "IterationId",
+        "x-semantic-type": "LoopIterationId",
         "x-semantic-client-minted": true,
         "example": 1
       },
@@ -31172,6 +31311,11 @@
             ],
             "description": "The tenant filtering strategy - determines whether to use provided tenant IDs or assigned tenant IDs from the authenticated principal's authorized tenants.\n",
             "default": "PROVIDED"
+          },
+          "withLease": {
+            "description": "Whether to activate the jobs with a lease. When true, each activated job is assigned a distinct, opaque lease token, returned as ActivatedJobResult.leaseToken. The lease fences the complete, fail, and throw-error commands against a superseded activation of the same job (for example, after the job timed out or failed and was re-activated by another worker): a command carrying a stale lease token is rejected rather than racing with the newer activation. Once a job has been activated with a lease, it is served only to leasing workers of that job type; a homogeneous fleet per job type is recommended. Omit or set to false to activate jobs without a lease.\n",
+            "type": "boolean",
+            "nullable": true
           }
         },
         "required": [
@@ -31183,6 +31327,10 @@
           {
             "propertyName": "tenantFilter",
             "addedInVersion": "8.9"
+          },
+          {
+            "propertyName": "withLease",
+            "addedInVersion": "8.10"
           }
         ]
       },
@@ -31217,7 +31365,9 @@
           "elementInstanceKey",
           "jobKey",
           "kind",
+          "leaseToken",
           "listenerEventType",
+          "physicalTenantId",
           "priority",
           "processDefinitionId",
           "processDefinitionKey",
@@ -31296,6 +31446,10 @@
             ],
             "description": "The ID of the tenant that owns the job."
           },
+          "physicalTenantId": {
+            "type": "string",
+            "description": "The ID of the physical tenant that the job-activation request was routed to;\nthe default physical tenant when the request did not specify one.\n"
+          },
           "jobKey": {
             "allOf": [
               {
@@ -31368,6 +31522,11 @@
             "description": "The priority of the job. Higher values indicate higher priority. Jobs created before 8.10 have no stored priority; the API returns 0 for such jobs.\n",
             "type": "integer",
             "format": "int32"
+          },
+          "leaseToken": {
+            "description": "The lease token identifying this activation. This is `null` when the job was\nactivated without a lease.\n",
+            "nullable": true,
+            "type": "string"
           }
         },
         "x-properties-added-in-version": [
@@ -31397,6 +31556,14 @@
           },
           {
             "propertyName": "businessId",
+            "addedInVersion": "8.10"
+          },
+          {
+            "propertyName": "leaseToken",
+            "addedInVersion": "8.10"
+          },
+          {
+            "propertyName": "physicalTenantId",
             "addedInVersion": "8.10"
           }
         ]
@@ -32380,6 +32547,7 @@
           "MIGRATED",
           "PRIORITY_UPDATED",
           "RETRIES_UPDATED",
+          "TIMEOUT_UPDATED",
           "TIMED_OUT"
         ]
       },

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:73ad42fb782f5c72dd84bdc40ef81313976c3f4083436c18c7019e7e0a3295cc",
+  "specHash": "sha256:280d2e6b69d447778def1673ffe33375e21960b31e259ddade66fc7feea6a3e1",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -3157,12 +3157,12 @@
           }
         ],
         "x-semantic-establishes": {
-          "kind": "AgentInstanceIteration",
+          "kind": "AgentInstanceLoopIteration",
           "identifiedBy": [
             {
               "in": "body",
-              "name": "iteration",
-              "semanticType": "IterationId"
+              "name": "loopIteration",
+              "semanticType": "LoopIterationId"
             }
           ]
         },
@@ -10103,6 +10103,42 @@
       }
     },
     {
+      "operationId": "changeClusterMode",
+      "path": "/mode",
+      "method": "patch",
+      "tags": [
+        "Recovery"
+      ],
+      "summary": "Change cluster mode",
+      "description": "Transitions the cluster between processing and recovery mode. This is a non-blocking operation: the request is acknowledged once the change has been accepted, before the transition itself has completed. Entering recovery mode deactivates all partitions so that only a restricted set of read-only operations remains available; exiting recovery mode returns the cluster to normal processing. Returns the planned cluster change so its progress can be monitored via the topology.",
+      "eventuallyConsistent": false,
+      "hasRequestBody": false,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [],
+      "queryParams": [
+        {
+          "name": "mode",
+          "required": true
+        },
+        {
+          "name": "dryRun",
+          "required": false
+        }
+      ],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "cluster.yaml",
+      "requestBodyContentTypes": [],
+      "successResponseSchemaRef": "ClusterModeChangeResponse",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "createUser",
       "path": "/users",
       "method": "post",
@@ -11042,7 +11078,7 @@
   "integrity": {
     "totalSemanticKeys": 41,
     "totalUnions": 64,
-    "totalOperations": 195,
+    "totalOperations": 196,
     "totalEventuallyConsistent": 91,
     "totalDeprecatedEnumSchemas": 2,
     "totalSemanticProviders": 23

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -48,14 +48,24 @@ echo ""
 echo "--- Step 7: Check README snippets are in sync ---"
 python3 scripts/sync-readme-snippets.py --check
 
-# Step 8: Unit tests (acceptance gate — integration tests are separate)
+# Step 8: Check SDK example coverage (operation-map vs. bundled spec)
 echo ""
-echo "--- Step 8: Unit tests ---"
+echo "--- Step 8: Check SDK example coverage ---"
+node scripts/check-example-coverage.js
+
+# Step 9: Check DocFX overwrite completeness (every public method has an entry)
+echo ""
+echo "--- Step 9: Check overwrite completeness ---"
+node scripts/check-overwrite-completeness.js
+
+# Step 10: Unit tests (acceptance gate — integration tests are separate)
+echo ""
+echo "--- Step 10: Unit tests ---"
 dotnet test test/Camunda.Orchestration.Sdk.Tests --configuration Release --no-build
 
- # Step 8: Build documentation
+# Step 11: Build documentation
 echo ""
-echo "--- Step 8: Build documentation ---"
+echo "--- Step 11: Build documentation ---"
 bash scripts/build-docs.sh
 
 echo ""

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -736,6 +736,60 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Change cluster mode
+    /// Transitions the cluster between processing and recovery mode. This is a non-blocking operation: the request is acknowledged once the change has been accepted, before the transition itself has completed. Entering recovery mode deactivates all partitions so that only a restricted set of read-only operations remains available; exiting recovery mode returns the cluster to normal processing. Returns the planned cluster change so its progress can be monitored via the topology.
+    /// </summary>
+    /// <remarks>
+    /// Operation: changeClusterMode
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ChangeClusterModeExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     // Pass dryRun: true to validate the request and inspect the resulting plan
+    ///     // without applying it. Omit it (or set it to false) to trigger the transition.
+    ///     var change = await client.ChangeClusterModeAsync(&quot;RECOVERING&quot;, dryRun: true);
+    /// 
+    ///     Console.WriteLine($&quot;Cluster change {change.ChangeId}:&quot;);
+    ///     foreach (var operation in change.PlannedChanges)
+    ///     {
+    ///         var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
+    ///         Console.WriteLine($&quot;  {operation.Operation}{suffix}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ChangeClusterModeExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     // Pass dryRun: true to validate the request and inspect the resulting plan
+    ///     // without applying it. Omit it (or set it to false) to trigger the transition.
+    ///     var change = await client.ChangeClusterModeAsync(&quot;RECOVERING&quot;, dryRun: true);
+    /// 
+    ///     Console.WriteLine($&quot;Cluster change {change.ChangeId}:&quot;);
+    ///     foreach (var operation in change.PlannedChanges)
+    ///     {
+    ///         var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
+    ///         Console.WriteLine($&quot;  {operation.Operation}{suffix}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<ClusterModeChangeResponse> ChangeClusterModeAsync(string mode, bool? dryRun = null, CancellationToken ct = default)
+    {
+        var queryParts = new List<string>();
+        queryParts.Add("mode=" + Uri.EscapeDataString(mode.ToString()!));
+        if (dryRun != null) queryParts.Add("dryRun=" + Uri.EscapeDataString(dryRun.ToString()!));
+        var path = queryParts.Count > 0 ? $"/mode?{string.Join("&", queryParts)}" : $"/mode";
+        return await InvokeWithRetryAsync(() => SendAsync<ClusterModeChangeResponse>(HttpMethod.Patch, path, null, ct), "changeClusterMode", false, ct);
+    }
+
+    /// <summary>
     /// Complete job
     /// Complete a job with the given payload, which allows completing the associated service task.
     /// 

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -17,8 +17,8 @@ public enum AgentInstanceHistorySearchQuerySortRequestField
     ProducedAt,
     [JsonPropertyName("historyItemKey")]
     HistoryItemKey,
-    [JsonPropertyName("iteration")]
-    Iteration,
+    [JsonPropertyName("loopIteration")]
+    LoopIteration,
 }
 
 /// <summary>
@@ -1153,6 +1153,14 @@ public sealed class ActivatedJobResult
     public TenantId TenantId { get; set; }
 
     /// <summary>
+    /// The ID of the physical tenant that the job-activation request was routed to;
+    /// the default physical tenant when the request did not specify one.
+    /// 
+    /// </summary>
+    [JsonPropertyName("physicalTenantId")]
+    public string PhysicalTenantId { get; set; } = null!;
+
+    /// <summary>
     /// The key, a unique identifier for the job.
     /// </summary>
     [JsonPropertyName("jobKey")]
@@ -1226,6 +1234,14 @@ public sealed class ActivatedJobResult
     /// </summary>
     [JsonPropertyName("priority")]
     public int Priority { get; set; }
+
+    /// <summary>
+    /// The lease token identifying this activation. This is `null` when the job was
+    /// activated without a lease.
+    /// 
+    /// </summary>
+    [JsonPropertyName("leaseToken")]
+    public string? LeaseToken { get; set; }
 
 }
 
@@ -3925,10 +3941,10 @@ public sealed class AgentInstanceHistoryFilter
     public JobKeyFilterProperty? JobKey { get; set; }
 
     /// <summary>
-    /// The iteration number.
+    /// Filter by loopIteration number. A loopIteration is one pass through the agent feedback loop (one LLM call, its tool dispatches, and their results).
     /// </summary>
-    [JsonPropertyName("iteration")]
-    public IntegerFilterProperty? Iteration { get; set; }
+    [JsonPropertyName("loopIteration")]
+    public IntegerFilterProperty? LoopIteration { get; set; }
 
     /// <summary>
     /// The commit status of the history item. Defaults to COMMITTED only.
@@ -4009,10 +4025,13 @@ public sealed class AgentInstanceHistoryItemRequest
     public string JobLease { get; set; } = null!;
 
     /// <summary>
-    /// Sequential iteration number this item belongs to. Omit if not grouping items into iterations.
+    /// The loopIteration this item belongs to. A loopIteration is one pass through the agent
+    /// feedback loop: one LLM call, its tool dispatches, and their results. Omit if not grouping
+    /// items by loopIteration.
+    /// 
     /// </summary>
-    [JsonPropertyName("iteration")]
-    public IterationId? Iteration { get; set; }
+    [JsonPropertyName("loopIteration")]
+    public LoopIterationId? LoopIteration { get; set; }
 
     /// <summary>
     /// The role of this history item in the conversation.
@@ -4086,10 +4105,13 @@ public sealed class AgentInstanceHistoryItemResult
     public string JobLease { get; set; } = null!;
 
     /// <summary>
-    /// The sequential iteration number this item belongs to. Null if not provided by the connector.
+    /// The loopIteration this item belongs to. A loopIteration is one pass through the agent
+    /// feedback loop: one LLM call, its tool dispatches, and their results. Null if not provided
+    /// by the connector.
+    /// 
     /// </summary>
-    [JsonPropertyName("iteration")]
-    public IterationId? Iteration { get; set; }
+    [JsonPropertyName("loopIteration")]
+    public LoopIterationId? LoopIteration { get; set; }
 
     /// <summary>
     /// The role of this history item in the conversation.
@@ -4634,12 +4656,16 @@ public sealed class AgentInstanceMetricsDelta
 }
 
 /// <summary>
-/// An arbitrary structured content block.
+/// An arbitrary structured content block. Accepts any valid JSON value:
+/// objects, arrays, numbers, booleans, or strings.
+/// Use TEXT content for human-readable natural language;
+/// use OBJECT content for machine-readable structured data.
+/// 
 /// </summary>
 public sealed class AgentInstanceObjectContent : AgentInstanceMessageContent
 {
     /// <summary>
-    /// Arbitrary structured content.
+    /// Arbitrary structured content — any valid JSON value (object, array, number, boolean, or string).
     /// </summary>
     [JsonPropertyName("object")]
     public object Object { get; set; } = null!;
@@ -4670,7 +4696,7 @@ public sealed class AgentInstanceResult
     public AgentInstanceDefinition Definition { get; set; } = null!;
 
     /// <summary>
-    /// Aggregated metrics across all iterations of this agent instance.
+    /// Aggregated metrics across all loopIterations of this agent instance.
     /// </summary>
     [JsonPropertyName("metrics")]
     public AgentInstanceMetrics Metrics { get; set; } = null!;
@@ -8308,6 +8334,44 @@ public enum CloudStage
     Int,
     [JsonPropertyName("prod")]
     Prod,
+}
+
+/// <summary>
+/// A single operation that is part of a cluster mode change.
+/// </summary>
+public sealed class ClusterModeChangeOperation
+{
+    /// <summary>
+    /// The type of the operation.
+    /// </summary>
+    [JsonPropertyName("operation")]
+    public string Operation { get; set; } = null!;
+
+    /// <summary>
+    /// The target mode of the operation, if applicable.
+    /// </summary>
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; }
+
+}
+
+/// <summary>
+/// The planned changes resulting from a cluster mode transition request.
+/// </summary>
+public sealed class ClusterModeChangeResponse
+{
+    /// <summary>
+    /// The ID of the cluster change that was triggered by the request.
+    /// </summary>
+    [JsonPropertyName("changeId")]
+    public string ChangeId { get; set; } = null!;
+
+    /// <summary>
+    /// The ordered list of operations that will be applied to complete the change.
+    /// </summary>
+    [JsonPropertyName("plannedChanges")]
+    public List<ClusterModeChangeOperation> PlannedChanges { get; set; } = null!;
+
 }
 
 /// <summary>
@@ -15810,33 +15874,6 @@ internal sealed class IntegerFilterPropertyJsonConverter : global::System.Text.J
 }
 
 /// <summary>
-/// A client-provided sequential integer identifying a logical iteration: one LLM
-/// call, its tool dispatches, and their results. Must be a positive integer,
-/// increasing with each iteration. Established by the
-/// connector when appending the first history item of an iteration.
-/// 
-/// </summary>
-public readonly record struct IterationId : global::Camunda.Orchestration.Sdk.ICamundaLongKey
-{
-    /// <summary>The underlying long value.</summary>
-    public long Value { get; }
-
-    private IterationId(long value) => Value = value;
-
-    /// <summary>
-    /// Creates a <see cref="IterationId"/> from a raw long value.
-    /// Use this when side-loading values not received from an API call.
-    /// </summary>
-    public static IterationId AssumeExists(long value)
-    {
-        return new IterationId(value);
-    }
-
-    /// <inheritdoc />
-    public override string ToString() => Value.ToString()!;
-}
-
-/// <summary>
 /// JobActivationRequest
 /// </summary>
 public sealed class JobActivationRequest : global::Camunda.Orchestration.Sdk.ITenantIdsSettable
@@ -15891,6 +15928,13 @@ public sealed class JobActivationRequest : global::Camunda.Orchestration.Sdk.ITe
     /// </summary>
     [JsonPropertyName("tenantFilter")]
     public TenantFilterEnum? TenantFilter { get; set; }
+
+    /// <summary>
+    /// Whether to activate the jobs with a lease. When true, each activated job is assigned a distinct, opaque lease token, returned as ActivatedJobResult.leaseToken. The lease fences the complete, fail, and throw-error commands against a superseded activation of the same job (for example, after the job timed out or failed and was re-activated by another worker): a command carrying a stale lease token is rejected rather than racing with the newer activation. Once a job has been activated with a lease, it is served only to leasing workers of that job type; a homogeneous fleet per job type is recommended. Omit or set to false to activate jobs without a lease.
+    /// 
+    /// </summary>
+    [JsonPropertyName("withLease")]
+    public bool? WithLease { get; set; }
 
     /// <inheritdoc />
     public void SetDefaultTenantIds(string tenantId)
@@ -17268,6 +17312,8 @@ public enum JobStateEnum
     PRIORITYUPDATED,
     [JsonPropertyName("RETRIES_UPDATED")]
     RETRIESUPDATED,
+    [JsonPropertyName("TIMEOUT_UPDATED")]
+    TIMEOUTUPDATED,
     [JsonPropertyName("TIMED_OUT")]
     TIMEDOUT,
 }
@@ -17887,6 +17933,33 @@ public readonly record struct LongKey : global::Camunda.Orchestration.Sdk.ICamun
     /// <summary>Returns true if the value satisfies this type's constraints.</summary>
     public static bool IsValid(string value) =>
         global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value, pattern: "^-?[0-9]+$", minLength: 1, maxLength: 25);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// A client-provided sequential integer identifying one pass through the agent
+/// feedback loop: one LLM call, its tool dispatches, and their results. Must be
+/// a positive integer, increasing with each loopIteration. Established by the
+/// connector when appending the first history item of a loopIteration.
+/// 
+/// </summary>
+public readonly record struct LoopIterationId : global::Camunda.Orchestration.Sdk.ICamundaLongKey
+{
+    /// <summary>The underlying long value.</summary>
+    public long Value { get; }
+
+    private LoopIterationId(long value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="LoopIterationId"/> from a raw long value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static LoopIterationId AssumeExists(long value)
+    {
+        return new LoopIterationId(value);
+    }
 
     /// <inheritdoc />
     public override string ToString() => Value.ToString()!;

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:73ad42fb782f5c72dd84bdc40ef81313976c3f4083436c18c7019e7e0a3295cc";
+    public const string SpecHash = "sha256:280d2e6b69d447778def1673ffe33375e21960b31e259ddade66fc7feea6a3e1";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -45,8 +45,10 @@ TYPE Camunda.Orchestration.Sdk.ActivatedJobResult : sealed class
   PROP System.Int64 Deadline { get; set; } [JsonPropertyName("deadline")]
   PROP System.Object CustomHeaders { get; set; } [JsonPropertyName("customHeaders")]
   PROP System.Object Variables { get; set; } [JsonPropertyName("variables")]
+  PROP System.String PhysicalTenantId { get; set; } [JsonPropertyName("physicalTenantId")]
   PROP System.String Type { get; set; } [JsonPropertyName("type")]
   PROP System.String Worker { get; set; } [JsonPropertyName("worker")]
+  PROP System.String? LeaseToken { get; set; } [JsonPropertyName("leaseToken")]
 
 TYPE Camunda.Orchestration.Sdk.AdHocSubProcessActivateActivitiesInstruction : sealed class
   CTOR ()
@@ -565,7 +567,7 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryFilter : sealed class
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleFilterProperty? Role { get; set; } [JsonPropertyName("role")]
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? ProducedAt { get; set; } [JsonPropertyName("producedAt")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
-  PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? Iteration { get; set; } [JsonPropertyName("iteration")]
+  PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? LoopIteration { get; set; } [JsonPropertyName("loopIteration")]
   PROP Camunda.Orchestration.Sdk.JobKeyFilterProperty? JobKey { get; set; } [JsonPropertyName("jobKey")]
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemCreationResult : sealed class
@@ -583,8 +585,8 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemRequest : sealed class
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics? Metrics { get; set; } [JsonPropertyName("metrics")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum Role { get; set; } [JsonPropertyName("role")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
-  PROP Camunda.Orchestration.Sdk.IterationId? Iteration { get; set; } [JsonPropertyName("iteration")]
   PROP Camunda.Orchestration.Sdk.JobKey JobKey { get; set; } [JsonPropertyName("jobKey")]
+  PROP Camunda.Orchestration.Sdk.LoopIterationId? LoopIteration { get; set; } [JsonPropertyName("loopIteration")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceMessageContent> Content { get; set; } [JsonPropertyName("content")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceToolCall>? ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
   PROP System.DateTimeOffset ProducedAt { get; set; } [JsonPropertyName("producedAt")]
@@ -598,8 +600,8 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemResult : sealed class
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum Role { get; set; } [JsonPropertyName("role")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceKey AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
-  PROP Camunda.Orchestration.Sdk.IterationId? Iteration { get; set; } [JsonPropertyName("iteration")]
   PROP Camunda.Orchestration.Sdk.JobKey JobKey { get; set; } [JsonPropertyName("jobKey")]
+  PROP Camunda.Orchestration.Sdk.LoopIterationId? LoopIteration { get; set; } [JsonPropertyName("loopIteration")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceMessageContent> Content { get; set; } [JsonPropertyName("content")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceToolCall> ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
   PROP System.DateTimeOffset ProducedAt { get; set; } [JsonPropertyName("producedAt")]
@@ -651,7 +653,7 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQuerySortRequestField :
   underlying=System.Int32
   MEMBER ProducedAt = 0 json="producedAt"
   MEMBER HistoryItemKey = 1 json="historyItemKey"
-  MEMBER Iteration = 2 json="iteration"
+  MEMBER LoopIteration = 2 json="loopIteration"
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceKey : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentInstanceKey>]
   PROP System.String Value { get; }
@@ -1610,6 +1612,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationResponse> GetBatchOperationAsync(Camunda.Orchestration.Sdk.BatchOperationKey batchOperationKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationResponse>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult> SearchBatchOperationsAsync(Camunda.Orchestration.Sdk.BatchOperationSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.CamundaUserResult> GetAuthenticationAsync(System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> ChangeClusterModeAsync(System.String mode, System.Boolean? dryRun = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> CreateGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.CreateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> CreateTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.CreateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> GetGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.ClusterVariableName name, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ClusterVariableResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1852,6 +1855,16 @@ TYPE Camunda.Orchestration.Sdk.CloudStage : enum interfaces=[System.IComparable,
   MEMBER Dev = 0 json="dev"
   MEMBER Int = 1 json="int"
   MEMBER Prod = 2 json="prod"
+
+TYPE Camunda.Orchestration.Sdk.ClusterModeChangeOperation : sealed class
+  CTOR ()
+  PROP System.String Operation { get; set; } [JsonPropertyName("operation")]
+  PROP System.String? Mode { get; set; } [JsonPropertyName("mode")]
+
+TYPE Camunda.Orchestration.Sdk.ClusterModeChangeResponse : sealed class
+  CTOR ()
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ClusterModeChangeOperation> PlannedChanges { get; set; } [JsonPropertyName("plannedChanges")]
+  PROP System.String ChangeId { get; set; } [JsonPropertyName("changeId")]
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableName : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ClusterVariableName>]
   PROP System.String Value { get; }
@@ -3630,17 +3643,10 @@ TYPE Camunda.Orchestration.Sdk.IntegerFilterProperty : sealed class
   PROP System.Int32? Lte { get; set; } [JsonPropertyName("$lte")]
   PROP System.Int32? Neq { get; set; } [JsonPropertyName("$neq")]
 
-TYPE Camunda.Orchestration.Sdk.IterationId : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaLongKey,System.IEquatable<Camunda.Orchestration.Sdk.IterationId>]
-  PROP System.Int64 Value { get; }
-  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.IterationId other)
-  METHOD static Camunda.Orchestration.Sdk.IterationId AssumeExists(System.Int64 value)
-  METHOD virtual System.Boolean Equals(System.Object obj)
-  METHOD virtual System.Int32 GetHashCode()
-  METHOD virtual System.String ToString()
-
 TYPE Camunda.Orchestration.Sdk.JobActivationRequest : sealed class interfaces=[Camunda.Orchestration.Sdk.ITenantIdsSettable]
   CTOR ()
   PROP Camunda.Orchestration.Sdk.TenantFilterEnum? TenantFilter { get; set; } [JsonPropertyName("tenantFilter")]
+  PROP System.Boolean? WithLease { get; set; } [JsonPropertyName("withLease")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.TenantId>? TenantIds { get; set; } [JsonPropertyName("tenantIds")]
   PROP System.Collections.Generic.List<System.String>? FetchVariable { get; set; } [JsonPropertyName("fetchVariable")]
   PROP System.Int32 MaxJobsToActivate { get; set; } [JsonPropertyName("maxJobsToActivate")]
@@ -3954,7 +3960,8 @@ TYPE Camunda.Orchestration.Sdk.JobStateEnum : enum interfaces=[System.IComparabl
   MEMBER MIGRATED = 5 json="MIGRATED"
   MEMBER PRIORITYUPDATED = 6 json="PRIORITY_UPDATED"
   MEMBER RETRIESUPDATED = 7 json="RETRIES_UPDATED"
-  MEMBER TIMEDOUT = 8 json="TIMED_OUT"
+  MEMBER TIMEOUTUPDATED = 8 json="TIMEOUT_UPDATED"
+  MEMBER TIMEDOUT = 9 json="TIMED_OUT"
 
 TYPE Camunda.Orchestration.Sdk.JobStateExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.JobStateExactMatch>]
   PROP System.String Value { get; }
@@ -4107,6 +4114,14 @@ TYPE Camunda.Orchestration.Sdk.LongKey : struct interfaces=[Camunda.Orchestratio
   METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.LongKey other)
   METHOD static Camunda.Orchestration.Sdk.LongKey AssumeExists(System.String value)
   METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.LoopIterationId : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaLongKey,System.IEquatable<Camunda.Orchestration.Sdk.LoopIterationId>]
+  PROP System.Int64 Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.LoopIterationId other)
+  METHOD static Camunda.Orchestration.Sdk.LoopIterationId AssumeExists(System.Int64 value)
   METHOD virtual System.Boolean Equals(System.Object obj)
   METHOD virtual System.Int32 GetHashCode()
   METHOD virtual System.String ToString()


### PR DESCRIPTION
## What

Adds `changeClusterMode` example coverage (99% → 100%) and includes the regenerated SDK so the branch is self-contained.

Files in this PR:

- `examples/Client.cs` — new compilable `ChangeClusterMode` example region.
- `examples/operation-map.json` — maps `changeClusterMode` to the new region.
- `docs/overwrite/CamundaClient.md` — overwrite entry for the example.
- `test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt` — refreshed public API baseline.
- `src/Camunda.Orchestration.Sdk/Generated/*` + `external-spec/bundled/*` — regenerated sources and bundled spec (separate `chore(gen)` commit).
- `scripts/build.sh` — runs the example-coverage and overwrite-completeness checks locally, matching CI.

## Why

`changeClusterMode` (`PATCH /mode`, new in Camunda 8.10) was the only operation flagged as missing by the example-coverage check. Closes #317.

## Notes

- **Generated sources are committed**, per this repo's convention (AGENTS.md pre-push checklist + the two-commit rule). The regeneration is a dedicated `chore(gen): regenerate Generated/ for changeClusterMode` commit so `docs/examples` compiles from a fresh checkout without a prior regeneration step, and so `Generated/*`, the bundled spec, and `PublicApi.shipped.txt` stay consistent.
- **Upstream drift is intentional, not accidental scope creep.** Regenerating against `main` HEAD folds in pre-existing upstream changes: `ActivatedJobResult` properties, the `Iteration` → `LoopIteration` rename, and `JobStateEnum` value shifts. These appear in `Generated/*`, the bundled spec, and the refreshed baseline together.

## Versioning / breaking change

Regenerating surfaces breaking public-API changes into the committed/released surface for the first time, so this PR signals them for semantic-release via a `BREAKING CHANGE:` footer (`chore(gen): signal breaking API surface changes from spec refresh`) and carries the `breaking-change-approved` label to bypass the breaking-change guard.

Breaking changes in the public surface:

- `Iteration` → `LoopIteration` rename: struct `IterationId` removed, `LoopIterationId` added; JSON wire field `iteration` → `loopIteration` (source **and** wire breaking).
- `JobStateEnum` adds `TIMEOUTUPDATED` (`= 8`, wire `TIMEOUT_UPDATED`) — additive on the wire (name-serialized), source-breaking for anyone casting to/from the underlying int.
- `ActivatedJobResult` adds new properties.

**Version impact (verified against `semantic-release@25.0.5`):** on `main` the next version is `10.0.0-alpha.4` — identical to what a plain `feat`/`fix` would produce. The breaking marker does **not** overshoot to `11.0.0`, because the `10.0.0` major line is already open via the pending alpha prereleases (semver's pre-major rule: `inc('10.0.0-alpha.3', 'major') === '10.0.0'`). Stable `9.x` consumers are unaffected. **This change must not be backported to `stable/9`** (maintenance `range: 9.x` would refuse a major bump).

## Validation

- `dotnet build docs/examples/Examples.csproj -c Release` → 0 warnings, 0 errors.
- Public API surface test passes against the committed baseline.
- `node scripts/check-example-coverage.js` → 196/196, 100%.
