### PR TITLE
docs: add restore example coverage

### DIFF
--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -1283,6 +1283,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.RestoreAsync(Camunda.Orchestration.Sdk.RestoreRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Client.cs#Restore)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.RunWorkersAsync(System.Nullable{System.TimeSpan},System.Threading.CancellationToken)
 example:
 - *content

--- a/examples/Client.cs
+++ b/examples/Client.cs
@@ -49,4 +49,29 @@ public static class ClientExamples
     }
     // </ChangeClusterMode>
     #endregion ChangeClusterMode
+
+    #region Restore
+
+    // <Restore>
+    public static async Task RestoreExample()
+    {
+        using var client = CamundaClient.Create();
+
+        // The cluster must be in recovery mode before a restore is accepted.
+        // Provide either a list of backup IDs (one per partition) or a time
+        // range (From/To) that selects the backups to restore, but not both.
+        var change = await client.RestoreAsync(new RestoreRequest
+        {
+            BackupIds = new List<long> { 100, 101 },
+        });
+
+        Console.WriteLine($"Cluster change {change.ChangeId}:");
+        foreach (var operation in change.PlannedChanges)
+        {
+            var suffix = operation.Mode is null ? "" : $" -> {operation.Mode}";
+            Console.WriteLine($"  {operation.Operation}{suffix}");
+        }
+    }
+    // </Restore>
+    #endregion Restore
 }

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -55,6 +55,13 @@
       "label": "Change cluster mode"
     }
   ],
+  "restore": [
+    {
+      "file": "Client.cs",
+      "region": "Restore",
+      "label": "Restore from a backup"
+    }
+  ],
   "createProcessInstance": [
     {
       "file": "ProcessInstance.cs",

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -18696,6 +18696,89 @@
         "x-added-in-version": "8.10"
       }
     },
+    "/restore": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Recovery"
+        ],
+        "operationId": "restore",
+        "x-required-permissions": [],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Restore from a backup",
+        "description": "Restores the cluster from a backup. The restore is described either by a single backup ID or by a time range (`from`/`to`) that selects the backups to restore. This endpoint is only accessible while the cluster is in recovery mode; requests are rejected otherwise. The request is validated and acknowledged, but the restore itself is performed asynchronously.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestoreRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "The restore request was accepted; returns the planned cluster changes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClusterModeChangeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The cluster is not in recovery mode, so the restore cannot be accepted."
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/users": {
       "post": {
         "x-eventually-consistent": false,
@@ -24715,6 +24798,39 @@
             "type": "string",
             "nullable": true,
             "example": "RECOVERING"
+          }
+        }
+      },
+      "RestoreRequest": {
+        "description": "Describes a restore request. Provide either a list of backup IDs or a time range (`from`/`to`) that selects the backups to restore; the two are mutually exclusive.",
+        "type": "object",
+        "properties": {
+          "from": {
+            "description": "The start of the time range to restore from, as an ISO 8601 timestamp.",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2024-01-01T10:00:00Z"
+          },
+          "to": {
+            "description": "The end of the time range to restore from, as an ISO 8601 timestamp.",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2024-01-01T12:00:00Z"
+          },
+          "backupIds": {
+            "description": "The IDs of the backups to restore from, one per partition.",
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "example": [
+              100,
+              101
+            ]
           }
         }
       },
@@ -31524,7 +31640,7 @@
             "format": "int32"
           },
           "leaseToken": {
-            "description": "The lease token identifying this activation. This is `null` when the job was\nactivated without a lease.\n",
+            "description": "The lease token identifying this activation. This is `null` when the job was activated without a lease.\n",
             "nullable": true,
             "type": "string"
           }
@@ -32247,8 +32363,19 @@
             "description": "JSON object that will instantiate the variables at the local scope of the job's associated task.\n",
             "type": "object",
             "additionalProperties": true
+          },
+          "leaseToken": {
+            "description": "The token identifying a leased job's activation, obtained from `ActivatedJobResult.leaseToken`.\nFor a leased job, the matching token must be supplied to prove the command comes from the worker that holds the current lease; a command with no token is rejected. A command carrying a stale token is likewise rejected, fencing the job against a superseded activation (for example, after the job timed out or failed and was re-activated by another worker).\nA job that was activated without a lease requires no token.\n",
+            "type": "string",
+            "nullable": true
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "leaseToken",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "JobErrorRequest": {
         "type": "object",
@@ -32268,10 +32395,21 @@
             "description": "JSON object that will instantiate the variables at the local scope of the error catch event that catches the thrown error.\n",
             "type": "object",
             "nullable": true
+          },
+          "leaseToken": {
+            "description": "The token identifying a leased job's activation, obtained from `ActivatedJobResult.leaseToken`.\nFor a leased job, the matching token must be supplied to prove the command comes from the worker that holds the current lease; a command with no token is rejected. A command carrying a stale token is likewise rejected, fencing the job against a superseded activation (for example, after the job timed out or failed and was re-activated by another worker).\nA job that was activated without a lease requires no token.\n",
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [
           "errorCode"
+        ],
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "leaseToken",
+            "addedInVersion": "8.10"
+          }
         ]
       },
       "JobCompletionRequest": {
@@ -32286,12 +32424,21 @@
           },
           "result": {
             "$ref": "#/components/schemas/JobResult"
+          },
+          "leaseToken": {
+            "description": "The token identifying a leased job's activation, obtained from `ActivatedJobResult.leaseToken`.\nFor a leased job, the matching token must be supplied to prove the command comes from the worker that holds the current lease; a command with no token is rejected. A command carrying a stale token is likewise rejected, fencing the job against a superseded activation (for example, after the job timed out or failed and was re-activated by another worker).\nA job that was activated without a lease requires no token.\n",
+            "type": "string",
+            "nullable": true
           }
         },
         "x-properties-added-in-version": [
           {
             "propertyName": "result",
             "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "leaseToken",
+            "addedInVersion": "8.10"
           }
         ]
       },
@@ -32446,6 +32593,11 @@
           },
           "operationReference": {
             "$ref": "#/components/schemas/OperationReference"
+          },
+          "leaseToken": {
+            "description": "The token identifying a leased job's activation, obtained from `ActivatedJobResult.leaseToken`.\nFor a leased job, a supplied token is validated to prove the command comes from the worker that holds the current lease; a command carrying a stale token is rejected, fencing the job against a superseded activation (for example, after the job timed out or failed and was re-activated by another worker).\nAn update without a token always applies to support operator and bulk updates of leased jobs. Note that this is different from lifecycle requests like complete, fail, and throw-error that always require a token for leased jobs.\nA job that was activated without a lease requires no token.\n",
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [
@@ -32455,6 +32607,10 @@
           {
             "propertyName": "operationReference",
             "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "leaseToken",
+            "addedInVersion": "8.10"
           }
         ]
       },

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:280d2e6b69d447778def1673ffe33375e21960b31e259ddade66fc7feea6a3e1",
+  "specHash": "sha256:bf97c32b4090a2316b417ebf3d024c5476a4d941b24e8dce133e785685effe26",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -10139,6 +10139,36 @@
       }
     },
     {
+      "operationId": "restore",
+      "path": "/restore",
+      "method": "post",
+      "tags": [
+        "Recovery"
+      ],
+      "summary": "Restore from a backup",
+      "description": "Restores the cluster from a backup. The restore is described either by a single backup ID or by a time range (`from`/`to`) that selects the backups to restore. This endpoint is only accessible while the cluster is in recovery mode; requests are rejected otherwise. The request is validated and acknowledged, but the restore itself is performed asynchronously.",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": true,
+      "pathParams": [],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "cluster.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "RestoreRequest",
+      "successResponseSchemaRef": "ClusterModeChangeResponse",
+      "successStatus": 202,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "createUser",
       "path": "/users",
       "method": "post",
@@ -11078,7 +11108,7 @@
   "integrity": {
     "totalSemanticKeys": 41,
     "totalUnions": 64,
-    "totalOperations": 196,
+    "totalOperations": 197,
     "totalEventuallyConsistent": 91,
     "totalDeprecatedEnumSchemas": 2,
     "totalSemanticProviders": 23

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -5515,6 +5515,65 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Restore from a backup
+    /// Restores the cluster from a backup. The restore is described either by a single backup ID or by a time range (`from`/`to`) that selects the backups to restore. This endpoint is only accessible while the cluster is in recovery mode; requests are rejected otherwise. The request is validated and acknowledged, but the restore itself is performed asynchronously.
+    /// </summary>
+    /// <remarks>
+    /// Operation: restore
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task RestoreExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     // The cluster must be in recovery mode before a restore is accepted.
+    ///     // Provide either a list of backup IDs (one per partition) or a time
+    ///     // range (From/To) that selects the backups to restore, but not both.
+    ///     var change = await client.RestoreAsync(new RestoreRequest
+    ///     {
+    ///         BackupIds = new List&lt;long&gt; { 100, 101 },
+    ///     });
+    /// 
+    ///     Console.WriteLine($&quot;Cluster change {change.ChangeId}:&quot;);
+    ///     foreach (var operation in change.PlannedChanges)
+    ///     {
+    ///         var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
+    ///         Console.WriteLine($&quot;  {operation.Operation}{suffix}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task RestoreExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     // The cluster must be in recovery mode before a restore is accepted.
+    ///     // Provide either a list of backup IDs (one per partition) or a time
+    ///     // range (From/To) that selects the backups to restore, but not both.
+    ///     var change = await client.RestoreAsync(new RestoreRequest
+    ///     {
+    ///         BackupIds = new List&lt;long&gt; { 100, 101 },
+    ///     });
+    /// 
+    ///     Console.WriteLine($&quot;Cluster change {change.ChangeId}:&quot;);
+    ///     foreach (var operation in change.PlannedChanges)
+    ///     {
+    ///         var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
+    ///         Console.WriteLine($&quot;  {operation.Operation}{suffix}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<ClusterModeChangeResponse> RestoreAsync(RestoreRequest body, CancellationToken ct = default)
+    {
+        var path = $"/restore";
+        return await InvokeWithRetryAsync(() => SendAsync<ClusterModeChangeResponse>(HttpMethod.Post, path, body, ct), "restore", false, ct);
+    }
+
+    /// <summary>
     /// Resume Batch operation
     /// Resumes a suspended batch operation.
     /// This is done asynchronously, the progress can be tracked using the batch operation status endpoint (/batch-operations/{batchOperationKey}).

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -1236,8 +1236,7 @@ public sealed class ActivatedJobResult
     public int Priority { get; set; }
 
     /// <summary>
-    /// The lease token identifying this activation. This is `null` when the job was
-    /// activated without a lease.
+    /// The lease token identifying this activation. This is `null` when the job was activated without a lease.
     /// 
     /// </summary>
     [JsonPropertyName("leaseToken")]
@@ -16029,6 +16028,15 @@ public sealed class JobCompletionRequest
     [JsonPropertyName("result")]
     public JobResult? Result { get; set; }
 
+    /// <summary>
+    /// The token identifying a leased job&apos;s activation, obtained from `ActivatedJobResult.leaseToken`.
+    /// For a leased job, the matching token must be supplied to prove the command comes from the worker that holds the current lease; a command with no token is rejected. A command carrying a stale token is likewise rejected, fencing the job against a superseded activation (for example, after the job timed out or failed and was re-activated by another worker).
+    /// A job that was activated without a lease requires no token.
+    /// 
+    /// </summary>
+    [JsonPropertyName("leaseToken")]
+    public string? LeaseToken { get; set; }
+
 }
 
 /// <summary>
@@ -16056,6 +16064,15 @@ public sealed class JobErrorRequest
     /// </summary>
     [JsonPropertyName("variables")]
     public object? Variables { get; set; }
+
+    /// <summary>
+    /// The token identifying a leased job&apos;s activation, obtained from `ActivatedJobResult.leaseToken`.
+    /// For a leased job, the matching token must be supplied to prove the command comes from the worker that holds the current lease; a command with no token is rejected. A command carrying a stale token is likewise rejected, fencing the job against a superseded activation (for example, after the job timed out or failed and was re-activated by another worker).
+    /// A job that was activated without a lease requires no token.
+    /// 
+    /// </summary>
+    [JsonPropertyName("leaseToken")]
+    public string? LeaseToken { get; set; }
 
 }
 
@@ -16190,6 +16207,15 @@ public sealed class JobFailRequest
     /// </summary>
     [JsonPropertyName("variables")]
     public object? Variables { get; set; }
+
+    /// <summary>
+    /// The token identifying a leased job&apos;s activation, obtained from `ActivatedJobResult.leaseToken`.
+    /// For a leased job, the matching token must be supplied to prove the command comes from the worker that holds the current lease; a command with no token is rejected. A command carrying a stale token is likewise rejected, fencing the job against a superseded activation (for example, after the job timed out or failed and was re-activated by another worker).
+    /// A job that was activated without a lease requires no token.
+    /// 
+    /// </summary>
+    [JsonPropertyName("leaseToken")]
+    public string? LeaseToken { get; set; }
 
 }
 
@@ -17694,6 +17720,16 @@ public sealed class JobUpdateRequest
     /// </summary>
     [JsonPropertyName("operationReference")]
     public OperationReference? OperationReference { get; set; }
+
+    /// <summary>
+    /// The token identifying a leased job&apos;s activation, obtained from `ActivatedJobResult.leaseToken`.
+    /// For a leased job, a supplied token is validated to prove the command comes from the worker that holds the current lease; a command carrying a stale token is rejected, fencing the job against a superseded activation (for example, after the job timed out or failed and was re-activated by another worker).
+    /// An update without a token always applies to support operator and bulk updates of leased jobs. Note that this is different from lifecycle requests like complete, fail, and throw-error that always require a token for leased jobs.
+    /// A job that was activated without a lease requires no token.
+    /// 
+    /// </summary>
+    [JsonPropertyName("leaseToken")]
+    public string? LeaseToken { get; set; }
 
 }
 
@@ -22841,6 +22877,31 @@ public enum ResourceTypeEnum
     USER,
     [JsonPropertyName("USER_TASK")]
     USERTASK,
+}
+
+/// <summary>
+/// Describes a restore request. Provide either a list of backup IDs or a time range (`from`/`to`) that selects the backups to restore; the two are mutually exclusive.
+/// </summary>
+public sealed class RestoreRequest
+{
+    /// <summary>
+    /// The start of the time range to restore from, as an ISO 8601 timestamp.
+    /// </summary>
+    [JsonPropertyName("from")]
+    public DateTimeOffset? From { get; set; }
+
+    /// <summary>
+    /// The end of the time range to restore from, as an ISO 8601 timestamp.
+    /// </summary>
+    [JsonPropertyName("to")]
+    public DateTimeOffset? To { get; set; }
+
+    /// <summary>
+    /// The IDs of the backups to restore from, one per partition.
+    /// </summary>
+    [JsonPropertyName("backupIds")]
+    public List<long>? BackupIds { get; set; }
+
 }
 
 /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:280d2e6b69d447778def1673ffe33375e21960b31e259ddade66fc7feea6a3e1";
+    public const string SpecHash = "sha256:bf97c32b4090a2316b417ebf3d024c5476a4d941b24e8dce133e785685effe26";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -1613,6 +1613,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult> SearchBatchOperationsAsync(Camunda.Orchestration.Sdk.BatchOperationSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.CamundaUserResult> GetAuthenticationAsync(System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> ChangeClusterModeAsync(System.String mode, System.Boolean? dryRun = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> RestoreAsync(Camunda.Orchestration.Sdk.RestoreRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> CreateGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.CreateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> CreateTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.CreateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> GetGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.ClusterVariableName name, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ClusterVariableResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -3676,12 +3677,14 @@ TYPE Camunda.Orchestration.Sdk.JobCompletionRequest : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.JobResult? Result { get; set; } [JsonPropertyName("result")]
   PROP System.Object? Variables { get; set; } [JsonPropertyName("variables")]
+  PROP System.String? LeaseToken { get; set; } [JsonPropertyName("leaseToken")]
 
 TYPE Camunda.Orchestration.Sdk.JobErrorRequest : sealed class
   CTOR ()
   PROP System.Object? Variables { get; set; } [JsonPropertyName("variables")]
   PROP System.String ErrorCode { get; set; } [JsonPropertyName("errorCode")]
   PROP System.String? ErrorMessage { get; set; } [JsonPropertyName("errorMessage")]
+  PROP System.String? LeaseToken { get; set; } [JsonPropertyName("leaseToken")]
 
 TYPE Camunda.Orchestration.Sdk.JobErrorStatisticsFilter : sealed class
   CTOR ()
@@ -3713,6 +3716,7 @@ TYPE Camunda.Orchestration.Sdk.JobFailRequest : sealed class
   PROP System.Int64? RetryBackOff { get; set; } [JsonPropertyName("retryBackOff")]
   PROP System.Object? Variables { get; set; } [JsonPropertyName("variables")]
   PROP System.String? ErrorMessage { get; set; } [JsonPropertyName("errorMessage")]
+  PROP System.String? LeaseToken { get; set; } [JsonPropertyName("leaseToken")]
 
 TYPE Camunda.Orchestration.Sdk.JobFailureException : sealed class base=System.Exception interfaces=[System.Runtime.Serialization.ISerializable]
   CTOR (System.String message, System.Int32? retries = null, System.Int64? retryBackOffMs = null)
@@ -4034,6 +4038,7 @@ TYPE Camunda.Orchestration.Sdk.JobUpdateRequest : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.JobChangeset Changeset { get; set; } [JsonPropertyName("changeset")]
   PROP Camunda.Orchestration.Sdk.OperationReference? OperationReference { get; set; } [JsonPropertyName("operationReference")]
+  PROP System.String? LeaseToken { get; set; } [JsonPropertyName("leaseToken")]
 
 TYPE Camunda.Orchestration.Sdk.JobWaitStateDetails : sealed class base=Camunda.Orchestration.Sdk.WaitStateDetails
   CTOR ()
@@ -5216,6 +5221,12 @@ TYPE Camunda.Orchestration.Sdk.ResourceTypeEnum : enum interfaces=[System.ICompa
   MEMBER TENANT = 17 json="TENANT"
   MEMBER USER = 18 json="USER"
   MEMBER USERTASK = 19 json="USER_TASK"
+
+TYPE Camunda.Orchestration.Sdk.RestoreRequest : sealed class
+  CTOR ()
+  PROP System.Collections.Generic.List<System.Int64>? BackupIds { get; set; } [JsonPropertyName("backupIds")]
+  PROP System.DateTimeOffset? From { get; set; } [JsonPropertyName("from")]
+  PROP System.DateTimeOffset? To { get; set; } [JsonPropertyName("to")]
 
 TYPE Camunda.Orchestration.Sdk.RetryDecision : struct interfaces=[System.IEquatable<Camunda.Orchestration.Sdk.RetryDecision>]
   CTOR (System.Boolean Retryable, System.String Reason)


### PR DESCRIPTION
## Description

Adds example coverage for the `restore` operation (`POST /restore`, tag `Recovery`, added in 8.10), closing the coverage gap reported in #320.

- Add a `Restore` region example to `examples/Client.cs` (Recovery domain, alongside `ChangeClusterMode`), demonstrating `RestoreAsync` with backup IDs and noting the `From`/`To` time-range alternative.
- Add the `restore` entry to `examples/operation-map.json`.
- Add the DocFX overwrite block for `RestoreAsync` in `docs/overwrite/CamundaClient.md`.

Regenerating pulled the latest upstream spec, so the regen commit also carries expected unrelated drift: new nullable `leaseToken` properties on four job-related models. The public API baseline (`PublicApi.shipped.txt`) was refreshed to reflect `RestoreAsync`, `RestoreRequest`, and that drift.

Changes are split per the repo's two-commit rule:
1. `docs:` — hand-written example + operation-map + overwrite entry
2. `chore(gen):` — regenerated bundled spec, `Generated/*`, and public API baseline

## Verification

- Example coverage: 100% (197/197)
- Overwrite completeness: pass
- `dotnet build docs/examples/Examples.csproj`: 0 warnings/errors
- Unit tests: 1091 passed
- README snippets: in sync
- Formatting verified on changed files

Closes #320
