### PR TITLE
refactor: single source of truth for config options (ConfigSchema)

### DIFF
--- a/src/Camunda.Orchestration.Sdk/Runtime/CamundaConfig.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/CamundaConfig.cs
@@ -28,14 +28,14 @@ public sealed class CamundaConfig
 {
     public string RestAddress { get; init; } = string.Empty;
     public string TokenAudience { get; init; } = string.Empty;
-    public string DefaultTenantId { get; init; } = "<default>";
+    public string DefaultTenantId { get; init; } = ConfigSchema.StringDefault(ConfigKeys.DefaultTenantId);
 
     public HttpRetryConfig HttpRetry { get; init; } = new();
     public BackpressureConfig Backpressure { get; init; } = new();
     public OAuthConfig OAuth { get; init; } = new();
     public AuthConfig Auth { get; init; } = new();
     public ValidationConfig Validation { get; init; } = new();
-    public string LogLevel { get; init; } = "error";
+    public string LogLevel { get; init; } = ConfigSchema.StringDefault(ConfigKeys.LogLevel);
     public EventualConfig? Eventual { get; init; }
     public WorkerDefaultsConfig? WorkerDefaults { get; init; }
     public TlsConfig? Tls { get; init; }
@@ -43,24 +43,24 @@ public sealed class CamundaConfig
 
 public sealed class HttpRetryConfig
 {
-    public int MaxAttempts { get; init; } = 3;
-    public int BaseDelayMs { get; init; } = 100;
-    public int MaxDelayMs { get; init; } = 2000;
+    public int MaxAttempts { get; init; } = ConfigSchema.IntDefault(ConfigKeys.HttpRetryMaxAttempts);
+    public int BaseDelayMs { get; init; } = ConfigSchema.IntDefault(ConfigKeys.HttpRetryBaseDelayMs);
+    public int MaxDelayMs { get; init; } = ConfigSchema.IntDefault(ConfigKeys.HttpRetryMaxDelayMs);
 }
 
 public sealed class BackpressureConfig
 {
     public bool Enabled { get; init; } = true;
-    public string Profile { get; init; } = "BALANCED";
+    public string Profile { get; init; } = ConfigSchema.StringDefault(ConfigKeys.BackpressureProfile);
     public bool ObserveOnly { get; init; }
-    public int InitialMax { get; init; } = 16;
-    public double SoftFactor { get; init; } = 0.70;
-    public double SevereFactor { get; init; } = 0.50;
-    public int RecoveryIntervalMs { get; init; } = 1000;
-    public int RecoveryStep { get; init; } = 1;
-    public int DecayQuietMs { get; init; } = 2000;
-    public int Floor { get; init; } = 1;
-    public int SevereThreshold { get; init; } = 3;
+    public int InitialMax { get; init; } = ConfigSchema.IntDefault(ConfigKeys.BackpressureInitialMax);
+    public double SoftFactor { get; init; } = ConfigSchema.IntDefault(ConfigKeys.BackpressureSoftFactor) / 100.0;
+    public double SevereFactor { get; init; } = ConfigSchema.IntDefault(ConfigKeys.BackpressureSevereFactor) / 100.0;
+    public int RecoveryIntervalMs { get; init; } = ConfigSchema.IntDefault(ConfigKeys.BackpressureRecoveryIntervalMs);
+    public int RecoveryStep { get; init; } = ConfigSchema.IntDefault(ConfigKeys.BackpressureRecoveryStep);
+    public int DecayQuietMs { get; init; } = ConfigSchema.IntDefault(ConfigKeys.BackpressureDecayQuietMs);
+    public int Floor { get; init; } = ConfigSchema.IntDefault(ConfigKeys.BackpressureFloor);
+    public int SevereThreshold { get; init; } = ConfigSchema.IntDefault(ConfigKeys.BackpressureSevereThreshold);
 }
 
 public sealed class OAuthConfig
@@ -68,16 +68,16 @@ public sealed class OAuthConfig
     public string? ClientId { get; init; }
     public string? ClientSecret { get; init; }
     public string OAuthUrl { get; init; } = string.Empty;
-    public string GrantType { get; init; } = "client_credentials";
+    public string GrantType { get; init; } = ConfigSchema.StringDefault(ConfigKeys.OAuthGrantType);
     public string? Scope { get; init; }
-    public int TimeoutMs { get; init; } = 5000;
+    public int TimeoutMs { get; init; } = ConfigSchema.IntDefault(ConfigKeys.OAuthTimeoutMs);
     public OAuthRetryConfig Retry { get; init; } = new();
 }
 
 public sealed class OAuthRetryConfig
 {
-    public int Max { get; init; } = 5;
-    public int BaseDelayMs { get; init; } = 1000;
+    public int Max { get; init; } = ConfigSchema.IntDefault(ConfigKeys.OAuthRetryMax);
+    public int BaseDelayMs { get; init; } = ConfigSchema.IntDefault(ConfigKeys.OAuthRetryBaseDelayMs);
 }
 
 public sealed class AuthConfig
@@ -96,12 +96,12 @@ public sealed class ValidationConfig
 {
     public ValidationMode Request { get; init; } = ValidationMode.None;
     public ValidationMode Response { get; init; } = ValidationMode.None;
-    public string Raw { get; init; } = "req:none,res:none";
+    public string Raw { get; init; } = ConfigSchema.StringDefault(ConfigKeys.Validation);
 }
 
 public sealed class EventualConfig
 {
-    public int PollDefaultMs { get; init; } = 500;
+    public int PollDefaultMs { get; init; } = ConfigSchema.IntDefault(ConfigKeys.EventualPollDefaultMs);
 }
 
 public sealed class WorkerDefaultsConfig

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigSchema.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigSchema.cs
@@ -95,7 +95,7 @@ internal sealed class ConfigKeyDescriptor
 /// The canonical configuration schema. Every default value, alias, and
 /// <c>IConfiguration</c> binding path is declared exactly once here; the hydrator and
 /// the <see cref="CamundaConfig"/> classes derive from it rather than restating literals.
-/// Mirrors the JS SDK's <c>SCHEMA</c> (issue #145).
+/// Mirrors the JS SDK's <c>SCHEMA</c> (see camunda/orchestration-cluster-api-js#145).
 /// </summary>
 internal static class ConfigSchema
 {
@@ -180,5 +180,5 @@ internal static class ConfigSchema
 
     /// <summary>Schema default for an integer key.</summary>
     public static int IntDefault(string envVar) =>
-        int.Parse(RequireDefault(envVar), System.Globalization.CultureInfo.InvariantCulture);
+        int.Parse(RequireDefault(envVar), System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture);
 }

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigSchema.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigSchema.cs
@@ -56,6 +56,7 @@ internal enum ConfigValueType
 {
     String,
     Int,
+    SignedInt,
     Bool,
     Enum,
 }
@@ -132,7 +133,7 @@ internal static class ConfigSchema
         new() { EnvVar = ConfigKeys.EventualPollDefaultMs, Type = ConfigValueType.Int, Default = "500", ConfigPaths = ["Eventual:PollDefaultMs"], Doc = "Default poll interval (ms) for eventually consistent endpoints." },
         new() { EnvVar = ConfigKeys.WorkerTimeout, Type = ConfigValueType.Int, ConfigPaths = ["Worker:Timeout"], Doc = "Default job timeout (ms) for all workers." },
         new() { EnvVar = ConfigKeys.WorkerMaxConcurrentJobs, Type = ConfigValueType.Int, ConfigPaths = ["Worker:MaxConcurrentJobs"], Doc = "Default max parallel jobs for all workers." },
-        new() { EnvVar = ConfigKeys.WorkerRequestTimeout, Type = ConfigValueType.Int, ConfigPaths = ["Worker:RequestTimeout"], Doc = "Default long-poll timeout (ms) for all workers." },
+        new() { EnvVar = ConfigKeys.WorkerRequestTimeout, Type = ConfigValueType.SignedInt, ConfigPaths = ["Worker:RequestTimeout"], Doc = "Default long-poll timeout (ms) for all workers; a negative value disables long polling." },
         new() { EnvVar = ConfigKeys.WorkerName, ConfigPaths = ["Worker:Name"], Doc = "Default worker name for all workers." },
         new() { EnvVar = ConfigKeys.WorkerStartupJitterMaxSeconds, Type = ConfigValueType.Int, ConfigPaths = ["Worker:StartupJitterMaxSeconds"], Doc = "Default startup jitter (seconds) for all workers." },
         new() { EnvVar = ConfigKeys.MtlsCert, Doc = "Inline PEM client certificate." },

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigSchema.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigSchema.cs
@@ -1,0 +1,183 @@
+namespace Camunda.Orchestration.Sdk;
+
+/// <summary>
+/// Canonical <c>CAMUNDA_*</c> environment variable names. Referencing these constants
+/// (rather than string literals) keeps key usages compile-checked across the schema,
+/// the hydrator, and the config classes.
+/// </summary>
+internal static class ConfigKeys
+{
+    public const string RestAddress = "CAMUNDA_REST_ADDRESS";
+    public const string TokenAudience = "CAMUNDA_TOKEN_AUDIENCE";
+    public const string DefaultTenantId = "CAMUNDA_DEFAULT_TENANT_ID";
+    public const string AuthStrategy = "CAMUNDA_AUTH_STRATEGY";
+    public const string ClientId = "CAMUNDA_CLIENT_ID";
+    public const string ClientSecret = "CAMUNDA_CLIENT_SECRET";
+    public const string BasicAuthUsername = "CAMUNDA_BASIC_AUTH_USERNAME";
+    public const string BasicAuthPassword = "CAMUNDA_BASIC_AUTH_PASSWORD";
+    public const string OAuthUrl = "CAMUNDA_OAUTH_URL";
+    public const string OAuthGrantType = "CAMUNDA_OAUTH_GRANT_TYPE";
+    public const string OAuthScope = "CAMUNDA_OAUTH_SCOPE";
+    public const string OAuthCacheDir = "CAMUNDA_OAUTH_CACHE_DIR";
+    public const string OAuthTimeoutMs = "CAMUNDA_OAUTH_TIMEOUT_MS";
+    public const string OAuthRetryMax = "CAMUNDA_OAUTH_RETRY_MAX";
+    public const string OAuthRetryBaseDelayMs = "CAMUNDA_OAUTH_RETRY_BASE_DELAY_MS";
+    public const string LogLevel = "CAMUNDA_SDK_LOG_LEVEL";
+    public const string Validation = "CAMUNDA_SDK_VALIDATION";
+    public const string HttpRetryMaxAttempts = "CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS";
+    public const string HttpRetryBaseDelayMs = "CAMUNDA_SDK_HTTP_RETRY_BASE_DELAY_MS";
+    public const string HttpRetryMaxDelayMs = "CAMUNDA_SDK_HTTP_RETRY_MAX_DELAY_MS";
+    public const string BackpressureProfile = "CAMUNDA_SDK_BACKPRESSURE_PROFILE";
+    public const string BackpressureInitialMax = "CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX";
+    public const string BackpressureSoftFactor = "CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR";
+    public const string BackpressureSevereFactor = "CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR";
+    public const string BackpressureRecoveryIntervalMs = "CAMUNDA_SDK_BACKPRESSURE_RECOVERY_INTERVAL_MS";
+    public const string BackpressureRecoveryStep = "CAMUNDA_SDK_BACKPRESSURE_RECOVERY_STEP";
+    public const string BackpressureDecayQuietMs = "CAMUNDA_SDK_BACKPRESSURE_DECAY_QUIET_MS";
+    public const string BackpressureFloor = "CAMUNDA_SDK_BACKPRESSURE_FLOOR";
+    public const string BackpressureSevereThreshold = "CAMUNDA_SDK_BACKPRESSURE_SEVERE_THRESHOLD";
+    public const string EventualPollDefaultMs = "CAMUNDA_SDK_EVENTUAL_POLL_DEFAULT_MS";
+    public const string WorkerTimeout = "CAMUNDA_WORKER_TIMEOUT";
+    public const string WorkerMaxConcurrentJobs = "CAMUNDA_WORKER_MAX_CONCURRENT_JOBS";
+    public const string WorkerRequestTimeout = "CAMUNDA_WORKER_REQUEST_TIMEOUT";
+    public const string WorkerName = "CAMUNDA_WORKER_NAME";
+    public const string WorkerStartupJitterMaxSeconds = "CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS";
+    public const string MtlsCert = "CAMUNDA_MTLS_CERT";
+    public const string MtlsKey = "CAMUNDA_MTLS_KEY";
+    public const string MtlsCa = "CAMUNDA_MTLS_CA";
+    public const string MtlsCertPath = "CAMUNDA_MTLS_CERT_PATH";
+    public const string MtlsKeyPath = "CAMUNDA_MTLS_KEY_PATH";
+    public const string MtlsCaPath = "CAMUNDA_MTLS_CA_PATH";
+    public const string MtlsKeyPassphrase = "CAMUNDA_MTLS_KEY_PASSPHRASE";
+}
+
+/// <summary>Primitive type of a configuration value (for parsing / validation).</summary>
+internal enum ConfigValueType
+{
+    String,
+    Int,
+    Bool,
+    Enum,
+}
+
+/// <summary>
+/// Describes a single configuration key. The schema is the single source of truth for
+/// each key's default value, canonical env-var name, legacy aliases, and
+/// <c>IConfiguration</c> binding paths.
+/// </summary>
+internal sealed class ConfigKeyDescriptor
+{
+    /// <summary>Canonical <c>CAMUNDA_*</c> environment variable name.</summary>
+    public required string EnvVar { get; init; }
+
+    public ConfigValueType Type { get; init; } = ConfigValueType.String;
+
+    /// <summary>Default value in canonical string form; <c>null</c> when the key has no default.</summary>
+    public string? Default { get; init; }
+
+    /// <summary>Allowed values for <see cref="ConfigValueType.Enum"/> keys.</summary>
+    public string[]? Choices { get; init; }
+
+    /// <summary>Legacy env-var names accepted as fallbacks when the canonical key is unset.</summary>
+    public string[] Aliases { get; init; } = [];
+
+    /// <summary>PascalCase <c>IConfiguration</c> binding paths that map to this key.</summary>
+    public string[] ConfigPaths { get; init; } = [];
+
+    /// <summary>Whether the value must be redacted in logs / diagnostics.</summary>
+    public bool Secret { get; init; }
+
+    public string? Doc { get; init; }
+}
+
+/// <summary>
+/// The canonical configuration schema. Every default value, alias, and
+/// <c>IConfiguration</c> binding path is declared exactly once here; the hydrator and
+/// the <see cref="CamundaConfig"/> classes derive from it rather than restating literals.
+/// Mirrors the JS SDK's <c>SCHEMA</c> (issue #145).
+/// </summary>
+internal static class ConfigSchema
+{
+    public static readonly IReadOnlyList<ConfigKeyDescriptor> All =
+    [
+        new() { EnvVar = ConfigKeys.RestAddress, Default = "http://localhost:8080/v2", Aliases = ["ZEEBE_REST_ADDRESS"], ConfigPaths = ["RestAddress"], Doc = "Base REST endpoint address." },
+        new() { EnvVar = ConfigKeys.TokenAudience, Default = "zeebe.camunda.io", ConfigPaths = ["TokenAudience"], Doc = "Token audience for OAuth flows." },
+        new() { EnvVar = ConfigKeys.DefaultTenantId, Default = "<default>", ConfigPaths = ["DefaultTenantId"], Doc = "Default tenant id applied when none is provided." },
+        new() { EnvVar = ConfigKeys.AuthStrategy, Type = ConfigValueType.Enum, Choices = ["NONE", "OAUTH", "BASIC"], Default = "NONE", ConfigPaths = ["Auth:Strategy"], Doc = "Authentication strategy." },
+        new() { EnvVar = ConfigKeys.ClientId, ConfigPaths = ["Auth:ClientId", "OAuth:ClientId"], Doc = "OAuth client id (required when strategy is OAUTH)." },
+        new() { EnvVar = ConfigKeys.ClientSecret, Secret = true, ConfigPaths = ["Auth:ClientSecret", "OAuth:ClientSecret"], Doc = "OAuth client secret (required when strategy is OAUTH)." },
+        new() { EnvVar = ConfigKeys.BasicAuthUsername, ConfigPaths = ["Auth:BasicUsername"], Doc = "Basic auth username (required when strategy is BASIC)." },
+        new() { EnvVar = ConfigKeys.BasicAuthPassword, Secret = true, ConfigPaths = ["Auth:BasicPassword"], Doc = "Basic auth password (required when strategy is BASIC)." },
+        new() { EnvVar = ConfigKeys.OAuthUrl, Default = "https://login.cloud.camunda.io/oauth/token", ConfigPaths = ["OAuth:Url"], Doc = "OAuth token URL." },
+        new() { EnvVar = ConfigKeys.OAuthGrantType, Default = "client_credentials", ConfigPaths = ["OAuth:GrantType"], Doc = "OAuth grant type." },
+        new() { EnvVar = ConfigKeys.OAuthScope, ConfigPaths = ["OAuth:Scope"], Doc = "Optional OAuth scope." },
+        new() { EnvVar = ConfigKeys.OAuthCacheDir, Doc = "Directory for disk caching OAuth tokens." },
+        new() { EnvVar = ConfigKeys.OAuthTimeoutMs, Type = ConfigValueType.Int, Default = "5000", ConfigPaths = ["OAuth:TimeoutMs"], Doc = "Timeout in ms for OAuth token fetch." },
+        new() { EnvVar = ConfigKeys.OAuthRetryMax, Type = ConfigValueType.Int, Default = "5", ConfigPaths = ["OAuth:RetryMax"], Doc = "Maximum OAuth token fetch attempts." },
+        new() { EnvVar = ConfigKeys.OAuthRetryBaseDelayMs, Type = ConfigValueType.Int, Default = "1000", ConfigPaths = ["OAuth:RetryBaseDelayMs"], Doc = "Base delay (ms) for OAuth retry backoff." },
+        new() { EnvVar = ConfigKeys.LogLevel, Default = "error", ConfigPaths = ["LogLevel"], Doc = "SDK log level." },
+        new() { EnvVar = ConfigKeys.Validation, Default = "req:none,res:none", ConfigPaths = ["Validation"], Doc = "Validation mini-language controlling req/res modes." },
+        new() { EnvVar = ConfigKeys.HttpRetryMaxAttempts, Type = ConfigValueType.Int, Default = "3", ConfigPaths = ["HttpRetry:MaxAttempts"], Doc = "Maximum total HTTP attempts for transient failures." },
+        new() { EnvVar = ConfigKeys.HttpRetryBaseDelayMs, Type = ConfigValueType.Int, Default = "100", ConfigPaths = ["HttpRetry:BaseDelayMs"], Doc = "Base delay (ms) for HTTP retry backoff." },
+        new() { EnvVar = ConfigKeys.HttpRetryMaxDelayMs, Type = ConfigValueType.Int, Default = "2000", ConfigPaths = ["HttpRetry:MaxDelayMs"], Doc = "Maximum delay cap (ms) for HTTP retry backoff." },
+        new() { EnvVar = ConfigKeys.BackpressureProfile, Type = ConfigValueType.Enum, Choices = ["BALANCED", "CONSERVATIVE", "AGGRESSIVE", "LEGACY"], Default = "BALANCED", ConfigPaths = ["Backpressure:Profile"], Doc = "Preset profile for backpressure tuning." },
+        new() { EnvVar = ConfigKeys.BackpressureInitialMax, Type = ConfigValueType.Int, Default = "16", ConfigPaths = ["Backpressure:InitialMax"], Doc = "Initial bootstrap concurrency cap." },
+        new() { EnvVar = ConfigKeys.BackpressureSoftFactor, Type = ConfigValueType.Int, Default = "70", ConfigPaths = ["Backpressure:SoftFactor"], Doc = "Percentage multiplier on soft backpressure (e.g. 70 => 0.7x)." },
+        new() { EnvVar = ConfigKeys.BackpressureSevereFactor, Type = ConfigValueType.Int, Default = "50", ConfigPaths = ["Backpressure:SevereFactor"], Doc = "Percentage multiplier on severe backpressure (e.g. 50 => 0.5x)." },
+        new() { EnvVar = ConfigKeys.BackpressureRecoveryIntervalMs, Type = ConfigValueType.Int, Default = "1000", ConfigPaths = ["Backpressure:RecoveryIntervalMs"], Doc = "Interval (ms) between passive recovery checks." },
+        new() { EnvVar = ConfigKeys.BackpressureRecoveryStep, Type = ConfigValueType.Int, Default = "1", ConfigPaths = ["Backpressure:RecoveryStep"], Doc = "Permits regained per recovery interval." },
+        new() { EnvVar = ConfigKeys.BackpressureDecayQuietMs, Type = ConfigValueType.Int, Default = "2000", ConfigPaths = ["Backpressure:DecayQuietMs"], Doc = "Quiet period (ms) required to downgrade severity." },
+        new() { EnvVar = ConfigKeys.BackpressureFloor, Type = ConfigValueType.Int, Default = "1", ConfigPaths = ["Backpressure:Floor"], Doc = "Minimum floor concurrency when degraded." },
+        new() { EnvVar = ConfigKeys.BackpressureSevereThreshold, Type = ConfigValueType.Int, Default = "3", ConfigPaths = ["Backpressure:SevereThreshold"], Doc = "Consecutive events required to enter severe state." },
+        new() { EnvVar = ConfigKeys.EventualPollDefaultMs, Type = ConfigValueType.Int, Default = "500", ConfigPaths = ["Eventual:PollDefaultMs"], Doc = "Default poll interval (ms) for eventually consistent endpoints." },
+        new() { EnvVar = ConfigKeys.WorkerTimeout, Type = ConfigValueType.Int, ConfigPaths = ["Worker:Timeout"], Doc = "Default job timeout (ms) for all workers." },
+        new() { EnvVar = ConfigKeys.WorkerMaxConcurrentJobs, Type = ConfigValueType.Int, ConfigPaths = ["Worker:MaxConcurrentJobs"], Doc = "Default max parallel jobs for all workers." },
+        new() { EnvVar = ConfigKeys.WorkerRequestTimeout, Type = ConfigValueType.Int, ConfigPaths = ["Worker:RequestTimeout"], Doc = "Default long-poll timeout (ms) for all workers." },
+        new() { EnvVar = ConfigKeys.WorkerName, ConfigPaths = ["Worker:Name"], Doc = "Default worker name for all workers." },
+        new() { EnvVar = ConfigKeys.WorkerStartupJitterMaxSeconds, Type = ConfigValueType.Int, ConfigPaths = ["Worker:StartupJitterMaxSeconds"], Doc = "Default startup jitter (seconds) for all workers." },
+        new() { EnvVar = ConfigKeys.MtlsCert, Doc = "Inline PEM client certificate." },
+        new() { EnvVar = ConfigKeys.MtlsKey, Secret = true, Doc = "Inline PEM client private key." },
+        new() { EnvVar = ConfigKeys.MtlsCa, Doc = "Inline PEM CA bundle." },
+        new() { EnvVar = ConfigKeys.MtlsCertPath, Doc = "Path to client certificate (PEM)." },
+        new() { EnvVar = ConfigKeys.MtlsKeyPath, Doc = "Path to client private key (PEM)." },
+        new() { EnvVar = ConfigKeys.MtlsCaPath, Doc = "Path to CA certificate bundle (PEM)." },
+        new() { EnvVar = ConfigKeys.MtlsKeyPassphrase, Secret = true, Doc = "Optional passphrase for encrypted private key." },
+    ];
+
+    private static readonly Dictionary<string, ConfigKeyDescriptor> ByEnvVar =
+        All.ToDictionary(d => d.EnvVar, StringComparer.Ordinal);
+
+    /// <summary>Env-var name → canonical default string, for every key that declares a default.</summary>
+    public static readonly IReadOnlyDictionary<string, string> Defaults =
+        All.Where(d => d.Default != null).ToDictionary(d => d.EnvVar, d => d.Default!, StringComparer.Ordinal);
+
+    /// <summary><c>IConfiguration</c> binding path → canonical env-var name (case-insensitive).</summary>
+    public static readonly IReadOnlyDictionary<string, string> ConfigKeyMap =
+        All.SelectMany(d => d.ConfigPaths.Select(p => (Path: p, d.EnvVar)))
+           .ToDictionary(x => x.Path, x => x.EnvVar, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Env-var names whose values must be redacted.</summary>
+    public static readonly IReadOnlySet<string> SecretKeys =
+        All.Where(d => d.Secret).Select(d => d.EnvVar).ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>All canonical env-var names.</summary>
+    public static readonly IReadOnlyList<string> AllEnvVars = All.Select(d => d.EnvVar).ToList();
+
+    /// <summary>(legacy alias → canonical env-var) pairs declared in the schema.</summary>
+    public static readonly IReadOnlyList<(string Alias, string EnvVar)> Aliases =
+        All.SelectMany(d => d.Aliases.Select(a => (Alias: a, d.EnvVar))).ToList();
+
+    private static string RequireDefault(string envVar)
+    {
+        if (ByEnvVar.TryGetValue(envVar, out var d) && d.Default != null)
+            return d.Default;
+        throw new InvalidOperationException($"No schema default declared for '{envVar}'.");
+    }
+
+    /// <summary>Schema default for a string key.</summary>
+    public static string StringDefault(string envVar) => RequireDefault(envVar);
+
+    /// <summary>Schema default for an integer key.</summary>
+    public static int IntDefault(string envVar) =>
+        int.Parse(RequireDefault(envVar), System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -126,24 +126,24 @@ public static class ConfigurationHydrator
         }
 
         // Auth strategy inference
-        var userSetStrategy = input.ContainsKey("CAMUNDA_AUTH_STRATEGY");
+        var userSetStrategy = input.ContainsKey(ConfigKeys.AuthStrategy);
         if (!userSetStrategy &&
-            rawMap.GetValueOrDefault("CAMUNDA_AUTH_STRATEGY") == "NONE" &&
-            !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_OAUTH_URL")) &&
-            !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_CLIENT_ID")) &&
-            !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_CLIENT_SECRET")))
+            rawMap.GetValueOrDefault(ConfigKeys.AuthStrategy) == "NONE" &&
+            !string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.OAuthUrl)) &&
+            !string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.ClientId)) &&
+            !string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.ClientSecret)))
         {
-            rawMap["CAMUNDA_AUTH_STRATEGY"] = "OAUTH";
+            rawMap[ConfigKeys.AuthStrategy] = "OAUTH";
         }
 
         // Validate auth strategy
-        var authStrategyRaw = rawMap.GetValueOrDefault("CAMUNDA_AUTH_STRATEGY", "NONE")!.Trim().ToUpperInvariant();
+        var authStrategyRaw = rawMap.GetValueOrDefault(ConfigKeys.AuthStrategy, "NONE")!.Trim().ToUpperInvariant();
         if (!Enum.TryParse<AuthStrategy>(authStrategyRaw, true, out var authStrategy))
         {
             errors.Add(new ConfigErrorDetail
             {
                 Code = ConfigErrorCode.InvalidEnum,
-                Key = "CAMUNDA_AUTH_STRATEGY",
+                Key = ConfigKeys.AuthStrategy,
                 Message = $"Invalid auth strategy '{authStrategyRaw}'. Expected NONE|OAUTH|BASIC."
             });
             authStrategy = AuthStrategy.None;
@@ -153,12 +153,12 @@ public static class ConfigurationHydrator
         if (authStrategy == AuthStrategy.OAuth)
         {
             var missing = new List<string>();
-            if (string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_CLIENT_ID")))
-                missing.Add("CAMUNDA_CLIENT_ID");
-            if (string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_CLIENT_SECRET")))
-                missing.Add("CAMUNDA_CLIENT_SECRET");
-            if (string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_OAUTH_URL")))
-                missing.Add("CAMUNDA_OAUTH_URL");
+            if (string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.ClientId)))
+                missing.Add(ConfigKeys.ClientId);
+            if (string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.ClientSecret)))
+                missing.Add(ConfigKeys.ClientSecret);
+            if (string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.OAuthUrl)))
+                missing.Add(ConfigKeys.OAuthUrl);
             if (missing.Count > 0)
             {
                 errors.Add(new ConfigErrorDetail
@@ -171,10 +171,10 @@ public static class ConfigurationHydrator
         else if (authStrategy == AuthStrategy.Basic)
         {
             var missing = new List<string>();
-            if (string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_BASIC_AUTH_USERNAME")))
-                missing.Add("CAMUNDA_BASIC_AUTH_USERNAME");
-            if (string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_BASIC_AUTH_PASSWORD")))
-                missing.Add("CAMUNDA_BASIC_AUTH_PASSWORD");
+            if (string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.BasicAuthUsername)))
+                missing.Add(ConfigKeys.BasicAuthUsername);
+            if (string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.BasicAuthPassword)))
+                missing.Add(ConfigKeys.BasicAuthPassword);
             if (missing.Count > 0)
             {
                 errors.Add(new ConfigErrorDetail
@@ -189,10 +189,10 @@ public static class ConfigurationHydrator
         // CA-only is valid (trust a self-signed server cert without client identity).
         // Client cert and key must come as a pair.
         // A passphrase without a client key is invalid.
-        var mtlsCertProvided = !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_MTLS_CERT"))
-                            || !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_MTLS_CERT_PATH"));
-        var mtlsKeyProvided = !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_MTLS_KEY"))
-                           || !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_MTLS_KEY_PATH"));
+        var mtlsCertProvided = !string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.MtlsCert))
+                            || !string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.MtlsCertPath));
+        var mtlsKeyProvided = !string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.MtlsKey))
+                           || !string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.MtlsKeyPath));
         if (mtlsCertProvided != mtlsKeyProvided)
         {
             errors.Add(new ConfigErrorDetail
@@ -203,7 +203,7 @@ public static class ConfigurationHydrator
                     + "(CAMUNDA_MTLS_KEY or CAMUNDA_MTLS_KEY_PATH) must be provided together."
             });
         }
-        if (!string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_MTLS_KEY_PASSPHRASE")) && !mtlsKeyProvided)
+        if (!string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.MtlsKeyPassphrase)) && !mtlsKeyProvided)
         {
             errors.Add(new ConfigErrorDetail
             {
@@ -212,8 +212,8 @@ public static class ConfigurationHydrator
             });
         }
         var hasTls = mtlsCertProvided || mtlsKeyProvided
-            || !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_MTLS_CA"))
-            || !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_MTLS_CA_PATH"));
+            || !string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.MtlsCa))
+            || !string.IsNullOrEmpty(rawMap.GetValueOrDefault(ConfigKeys.MtlsCaPath));
 
         // Validate integers. Unsigned + invariant to match the contract in the error
         // message: rejects signs, digit separators, and decimals. Leading/trailing
@@ -272,18 +272,18 @@ public static class ConfigurationHydrator
         var eventualPollDefaultMs = ParseSchemaInt(ConfigKeys.EventualPollDefaultMs);
 
         // Parse optional worker defaults
-        int? workerTimeout = rawMap.ContainsKey("CAMUNDA_WORKER_TIMEOUT")
-            ? ParseInt("CAMUNDA_WORKER_TIMEOUT", 0)
+        int? workerTimeout = rawMap.ContainsKey(ConfigKeys.WorkerTimeout)
+            ? ParseInt(ConfigKeys.WorkerTimeout, 0)
             : null;
-        int? workerMaxConcurrent = rawMap.ContainsKey("CAMUNDA_WORKER_MAX_CONCURRENT_JOBS")
-            ? ParseInt("CAMUNDA_WORKER_MAX_CONCURRENT_JOBS", 0)
+        int? workerMaxConcurrent = rawMap.ContainsKey(ConfigKeys.WorkerMaxConcurrentJobs)
+            ? ParseInt(ConfigKeys.WorkerMaxConcurrentJobs, 0)
             : null;
         int? workerRequestTimeout = rawMap.ContainsKey(ConfigKeys.WorkerRequestTimeout)
             ? ParseSignedInt(ConfigKeys.WorkerRequestTimeout, 0)
             : null;
-        var workerName = rawMap.GetValueOrDefault("CAMUNDA_WORKER_NAME");
-        int? workerJitter = rawMap.ContainsKey("CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS")
-            ? ParseInt("CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS", 0)
+        var workerName = rawMap.GetValueOrDefault(ConfigKeys.WorkerName);
+        int? workerJitter = rawMap.ContainsKey(ConfigKeys.WorkerStartupJitterMaxSeconds)
+            ? ParseInt(ConfigKeys.WorkerStartupJitterMaxSeconds, 0)
             : null;
         var hasWorkerDefaults = workerTimeout != null || workerMaxConcurrent != null
             || workerRequestTimeout != null || workerName != null || workerJitter != null;
@@ -326,11 +326,11 @@ public static class ConfigurationHydrator
             },
             OAuth = new OAuthConfig
             {
-                ClientId = rawMap.GetValueOrDefault("CAMUNDA_CLIENT_ID"),
-                ClientSecret = rawMap.GetValueOrDefault("CAMUNDA_CLIENT_SECRET"),
+                ClientId = rawMap.GetValueOrDefault(ConfigKeys.ClientId),
+                ClientSecret = rawMap.GetValueOrDefault(ConfigKeys.ClientSecret),
                 OAuthUrl = rawMap.GetValueOrDefault(ConfigKeys.OAuthUrl, ConfigSchema.StringDefault(ConfigKeys.OAuthUrl))!,
                 GrantType = rawMap.GetValueOrDefault(ConfigKeys.OAuthGrantType, ConfigSchema.StringDefault(ConfigKeys.OAuthGrantType))!,
-                Scope = rawMap.GetValueOrDefault("CAMUNDA_OAUTH_SCOPE"),
+                Scope = rawMap.GetValueOrDefault(ConfigKeys.OAuthScope),
                 TimeoutMs = oauthTimeoutMs,
                 Retry = new OAuthRetryConfig
                 {
@@ -344,8 +344,8 @@ public static class ConfigurationHydrator
                 Basic = authStrategy == AuthStrategy.Basic
                     ? new BasicAuthConfig
                     {
-                        Username = rawMap.GetValueOrDefault("CAMUNDA_BASIC_AUTH_USERNAME"),
-                        Password = rawMap.GetValueOrDefault("CAMUNDA_BASIC_AUTH_PASSWORD"),
+                        Username = rawMap.GetValueOrDefault(ConfigKeys.BasicAuthUsername),
+                        Password = rawMap.GetValueOrDefault(ConfigKeys.BasicAuthPassword),
                     }
                     : null,
             },
@@ -368,13 +368,13 @@ public static class ConfigurationHydrator
             Tls = hasTls
                 ? new TlsConfig
                 {
-                    Cert = rawMap.GetValueOrDefault("CAMUNDA_MTLS_CERT"),
-                    CertPath = rawMap.GetValueOrDefault("CAMUNDA_MTLS_CERT_PATH"),
-                    Key = rawMap.GetValueOrDefault("CAMUNDA_MTLS_KEY"),
-                    KeyPath = rawMap.GetValueOrDefault("CAMUNDA_MTLS_KEY_PATH"),
-                    Ca = rawMap.GetValueOrDefault("CAMUNDA_MTLS_CA"),
-                    CaPath = rawMap.GetValueOrDefault("CAMUNDA_MTLS_CA_PATH"),
-                    KeyPassphrase = rawMap.GetValueOrDefault("CAMUNDA_MTLS_KEY_PASSPHRASE"),
+                    Cert = rawMap.GetValueOrDefault(ConfigKeys.MtlsCert),
+                    CertPath = rawMap.GetValueOrDefault(ConfigKeys.MtlsCertPath),
+                    Key = rawMap.GetValueOrDefault(ConfigKeys.MtlsKey),
+                    KeyPath = rawMap.GetValueOrDefault(ConfigKeys.MtlsKeyPath),
+                    Ca = rawMap.GetValueOrDefault(ConfigKeys.MtlsCa),
+                    CaPath = rawMap.GetValueOrDefault(ConfigKeys.MtlsCaPath),
+                    KeyPassphrase = rawMap.GetValueOrDefault(ConfigKeys.MtlsKeyPassphrase),
                 }
                 : null,
         };
@@ -401,7 +401,7 @@ public static class ConfigurationHydrator
                 errors.Add(new ConfigErrorDetail
                 {
                     Code = ConfigErrorCode.InvalidValidationSyntax,
-                    Key = "CAMUNDA_SDK_VALIDATION",
+                    Key = ConfigKeys.Validation,
                     Message = $"Malformed segment '{part}'"
                 });
                 continue;
@@ -415,7 +415,7 @@ public static class ConfigurationHydrator
                 errors.Add(new ConfigErrorDetail
                 {
                     Code = ConfigErrorCode.InvalidValidationSyntax,
-                    Key = "CAMUNDA_SDK_VALIDATION",
+                    Key = ConfigKeys.Validation,
                     Message = $"Unknown scope '{scope}'"
                 });
                 continue;
@@ -426,7 +426,7 @@ public static class ConfigurationHydrator
                 errors.Add(new ConfigErrorDetail
                 {
                     Code = ConfigErrorCode.InvalidValidationSyntax,
-                    Key = "CAMUNDA_SDK_VALIDATION",
+                    Key = ConfigKeys.Validation,
                     Message = $"Unknown mode '{mode}'"
                 });
                 continue;

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -42,10 +42,8 @@ public sealed class CamundaConfigurationException : Exception
 /// </summary>
 public static class ConfigurationHydrator
 {
-    // Defaults and secret keys are derived from the single-source ConfigSchema.
+    // Defaults are derived from the single-source ConfigSchema.
     private static readonly IReadOnlyDictionary<string, string> Defaults = ConfigSchema.Defaults;
-
-    private static readonly IReadOnlySet<string> SecretKeys = ConfigSchema.SecretKeys;
 
     /// <summary>
     /// Hydrate configuration from environment and optional overrides.

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -215,17 +215,34 @@ public static class ConfigurationHydrator
             || !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_MTLS_CA"))
             || !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_MTLS_CA_PATH"));
 
-        // Validate integers
+        // Validate integers. Unsigned + invariant to match the contract in the error
+        // message: rejects signs, whitespace, digit separators, and decimals.
         int ParseInt(string key, int fallback)
         {
             var raw = rawMap.GetValueOrDefault(key, fallback.ToString(System.Globalization.CultureInfo.InvariantCulture))!;
-            if (int.TryParse(raw, out var val))
+            if (int.TryParse(raw.Trim(), System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var val))
                 return val;
             errors.Add(new ConfigErrorDetail
             {
                 Code = ConfigErrorCode.InvalidInteger,
                 Key = key,
                 Message = $"Invalid integer '{raw}'. Only unsigned base-10 integers allowed."
+            });
+            return fallback;
+        }
+
+        // Signed integer parse (invariant) for keys documented to accept negatives,
+        // e.g. CAMUNDA_WORKER_REQUEST_TIMEOUT (negative = long polling disabled).
+        int ParseSignedInt(string key, int fallback)
+        {
+            var raw = rawMap.GetValueOrDefault(key, fallback.ToString(System.Globalization.CultureInfo.InvariantCulture))!;
+            if (int.TryParse(raw.Trim(), System.Globalization.NumberStyles.AllowLeadingSign, System.Globalization.CultureInfo.InvariantCulture, out var val))
+                return val;
+            errors.Add(new ConfigErrorDetail
+            {
+                Code = ConfigErrorCode.InvalidInteger,
+                Key = key,
+                Message = $"Invalid integer '{raw}'. Only base-10 integers (optionally negative) allowed."
             });
             return fallback;
         }
@@ -260,8 +277,8 @@ public static class ConfigurationHydrator
         int? workerMaxConcurrent = rawMap.ContainsKey("CAMUNDA_WORKER_MAX_CONCURRENT_JOBS")
             ? ParseInt("CAMUNDA_WORKER_MAX_CONCURRENT_JOBS", 0)
             : null;
-        int? workerRequestTimeout = rawMap.ContainsKey("CAMUNDA_WORKER_REQUEST_TIMEOUT")
-            ? ParseInt("CAMUNDA_WORKER_REQUEST_TIMEOUT", 0)
+        int? workerRequestTimeout = rawMap.ContainsKey(ConfigKeys.WorkerRequestTimeout)
+            ? ParseSignedInt(ConfigKeys.WorkerRequestTimeout, 0)
             : null;
         var workerName = rawMap.GetValueOrDefault("CAMUNDA_WORKER_NAME");
         int? workerJitter = rawMap.ContainsKey("CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS")

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -62,8 +62,9 @@ public static class ConfigurationHydrator
         {
             foreach (var (k, v) in env)
             {
-                if (v != null && v.Trim().Length > 0)
-                    input[k] = v.Trim();
+                var trimmed = v?.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
+                    input[k] = trimmed;
             }
         }
         else
@@ -71,15 +72,15 @@ public static class ConfigurationHydrator
             // Read every schema key (and its legacy aliases) from the actual environment.
             foreach (var key in ConfigSchema.AllEnvVars)
             {
-                var v = Environment.GetEnvironmentVariable(key);
-                if (v != null && v.Trim().Length > 0)
-                    input[key] = v.Trim();
+                var trimmed = Environment.GetEnvironmentVariable(key)?.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
+                    input[key] = trimmed;
             }
             foreach (var (alias, _) in ConfigSchema.Aliases)
             {
-                var v = Environment.GetEnvironmentVariable(alias);
-                if (v != null && v.Trim().Length > 0)
-                    input[alias] = v.Trim();
+                var trimmed = Environment.GetEnvironmentVariable(alias)?.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
+                    input[alias] = trimmed;
             }
         }
 
@@ -273,7 +274,7 @@ public static class ConfigurationHydrator
             throw new CamundaConfigurationException(errors);
 
         // Normalize restAddress to /v2
-        var restAddress = rawMap.GetValueOrDefault("CAMUNDA_REST_ADDRESS", "")!;
+        var restAddress = rawMap.GetValueOrDefault(ConfigKeys.RestAddress, ConfigSchema.StringDefault(ConfigKeys.RestAddress))!;
         if (!string.IsNullOrEmpty(restAddress) && !restAddress.TrimEnd('/').EndsWith("/v2", StringComparison.OrdinalIgnoreCase))
             restAddress = restAddress.TrimEnd('/') + "/v2";
 
@@ -283,7 +284,7 @@ public static class ConfigurationHydrator
         return new CamundaConfig
         {
             RestAddress = restAddress,
-            TokenAudience = rawMap.GetValueOrDefault("CAMUNDA_TOKEN_AUDIENCE", "")!,
+            TokenAudience = rawMap.GetValueOrDefault(ConfigKeys.TokenAudience, ConfigSchema.StringDefault(ConfigKeys.TokenAudience))!,
             DefaultTenantId = rawMap.GetValueOrDefault(ConfigKeys.DefaultTenantId, ConfigSchema.StringDefault(ConfigKeys.DefaultTenantId))!,
             HttpRetry = new HttpRetryConfig
             {
@@ -309,7 +310,7 @@ public static class ConfigurationHydrator
             {
                 ClientId = rawMap.GetValueOrDefault("CAMUNDA_CLIENT_ID"),
                 ClientSecret = rawMap.GetValueOrDefault("CAMUNDA_CLIENT_SECRET"),
-                OAuthUrl = rawMap.GetValueOrDefault("CAMUNDA_OAUTH_URL", "")!,
+                OAuthUrl = rawMap.GetValueOrDefault(ConfigKeys.OAuthUrl, ConfigSchema.StringDefault(ConfigKeys.OAuthUrl))!,
                 GrantType = rawMap.GetValueOrDefault(ConfigKeys.OAuthGrantType, ConfigSchema.StringDefault(ConfigKeys.OAuthGrantType))!,
                 Scope = rawMap.GetValueOrDefault("CAMUNDA_OAUTH_SCOPE"),
                 TimeoutMs = oauthTimeoutMs,

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -216,7 +216,8 @@ public static class ConfigurationHydrator
             || !string.IsNullOrEmpty(rawMap.GetValueOrDefault("CAMUNDA_MTLS_CA_PATH"));
 
         // Validate integers. Unsigned + invariant to match the contract in the error
-        // message: rejects signs, whitespace, digit separators, and decimals.
+        // message: rejects signs, digit separators, and decimals. Leading/trailing
+        // whitespace is trimmed first (env values are already trimmed at ingest).
         int ParseInt(string key, int fallback)
         {
             var raw = rawMap.GetValueOrDefault(key, fallback.ToString(System.Globalization.CultureInfo.InvariantCulture))!;

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -42,33 +42,10 @@ public sealed class CamundaConfigurationException : Exception
 /// </summary>
 public static class ConfigurationHydrator
 {
-    private static readonly Dictionary<string, string> Defaults = new()
-    {
-        ["CAMUNDA_REST_ADDRESS"] = "http://localhost:8080/v2",
-        ["CAMUNDA_TOKEN_AUDIENCE"] = "zeebe.camunda.io",
-        ["CAMUNDA_DEFAULT_TENANT_ID"] = "<default>",
-        ["CAMUNDA_AUTH_STRATEGY"] = "NONE",
-        ["CAMUNDA_OAUTH_URL"] = "https://login.cloud.camunda.io/oauth/token",
-        ["CAMUNDA_OAUTH_GRANT_TYPE"] = "client_credentials",
-        ["CAMUNDA_OAUTH_TIMEOUT_MS"] = "5000",
-        ["CAMUNDA_OAUTH_RETRY_MAX"] = "5",
-        ["CAMUNDA_OAUTH_RETRY_BASE_DELAY_MS"] = "1000",
-        ["CAMUNDA_SDK_LOG_LEVEL"] = "error",
-        ["CAMUNDA_SDK_VALIDATION"] = "req:none,res:none",
-        ["CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS"] = "3",
-        ["CAMUNDA_SDK_HTTP_RETRY_BASE_DELAY_MS"] = "100",
-        ["CAMUNDA_SDK_HTTP_RETRY_MAX_DELAY_MS"] = "2000",
-        ["CAMUNDA_SDK_BACKPRESSURE_PROFILE"] = "BALANCED",
-        ["CAMUNDA_SDK_EVENTUAL_POLL_DEFAULT_MS"] = "500",
-    };
+    // Defaults and secret keys are derived from the single-source ConfigSchema.
+    private static readonly IReadOnlyDictionary<string, string> Defaults = ConfigSchema.Defaults;
 
-    private static readonly HashSet<string> SecretKeys =
-    [
-        "CAMUNDA_CLIENT_SECRET",
-        "CAMUNDA_BASIC_AUTH_PASSWORD",
-        "CAMUNDA_MTLS_KEY",
-        "CAMUNDA_MTLS_KEY_PASSPHRASE",
-    ];
+    private static readonly IReadOnlySet<string> SecretKeys = ConfigSchema.SecretKeys;
 
     /// <summary>
     /// Hydrate configuration from environment and optional overrides.
@@ -93,31 +70,18 @@ public static class ConfigurationHydrator
         }
         else
         {
-            // Read from actual environment
-            foreach (var key in Defaults.Keys)
+            // Read every schema key (and its legacy aliases) from the actual environment.
+            foreach (var key in ConfigSchema.AllEnvVars)
             {
                 var v = Environment.GetEnvironmentVariable(key);
                 if (v != null && v.Trim().Length > 0)
                     input[key] = v.Trim();
             }
-            // Also check for CAMUNDA_CLIENT_ID, CAMUNDA_CLIENT_SECRET, etc.
-            foreach (var extra in new[]
-                     {
-                         "CAMUNDA_CLIENT_ID", "CAMUNDA_CLIENT_SECRET",
-                         "CAMUNDA_BASIC_AUTH_USERNAME", "CAMUNDA_BASIC_AUTH_PASSWORD",
-                         "CAMUNDA_OAUTH_SCOPE", "CAMUNDA_OAUTH_CACHE_DIR",
-                         "ZEEBE_REST_ADDRESS",
-                         "CAMUNDA_WORKER_TIMEOUT", "CAMUNDA_WORKER_MAX_CONCURRENT_JOBS",
-                         "CAMUNDA_WORKER_REQUEST_TIMEOUT", "CAMUNDA_WORKER_NAME",
-                         "CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS",
-                         "CAMUNDA_MTLS_CERT", "CAMUNDA_MTLS_KEY", "CAMUNDA_MTLS_CA",
-                         "CAMUNDA_MTLS_CERT_PATH", "CAMUNDA_MTLS_KEY_PATH", "CAMUNDA_MTLS_CA_PATH",
-                         "CAMUNDA_MTLS_KEY_PASSPHRASE"
-                     })
+            foreach (var (alias, _) in ConfigSchema.Aliases)
             {
-                var v = Environment.GetEnvironmentVariable(extra);
+                var v = Environment.GetEnvironmentVariable(alias);
                 if (v != null && v.Trim().Length > 0)
-                    input[extra] = v.Trim();
+                    input[alias] = v.Trim();
             }
         }
 
@@ -139,9 +103,12 @@ public static class ConfigurationHydrator
             }
         }
 
-        // Alias: ZEEBE_REST_ADDRESS → CAMUNDA_REST_ADDRESS
-        if (!input.ContainsKey("CAMUNDA_REST_ADDRESS") && input.TryGetValue("ZEEBE_REST_ADDRESS", out var zeebe))
-            input["CAMUNDA_REST_ADDRESS"] = zeebe;
+        // Aliases: accept schema-declared legacy env-var names when the canonical key is unset.
+        foreach (var (alias, envVar) in ConfigSchema.Aliases)
+        {
+            if (!input.ContainsKey(envVar) && input.TryGetValue(alias, out var aliasVal))
+                input[envVar] = aliasVal;
+        }
 
         // Fill defaults for missing keys
         foreach (var (k, def) in Defaults)
@@ -460,61 +427,11 @@ public static class ConfigurationHydrator
     }
 
     /// <summary>
-    /// Maps PascalCase <c>IConfiguration</c> keys (from <c>appsettings.json</c>) to canonical <c>CAMUNDA_*</c> env-var names.
-    /// Supports both flat keys (<c>"RestAddress"</c>) and nested sections (<c>"Auth:Strategy"</c>, <c>"Backpressure:Profile"</c>).
+    /// Maps PascalCase <c>IConfiguration</c> keys (from <c>appsettings.json</c>) to canonical
+    /// <c>CAMUNDA_*</c> env-var names. Derived from the single-source <see cref="ConfigSchema"/>
+    /// (each descriptor's <c>ConfigPaths</c>).
     /// </summary>
-    private static readonly Dictionary<string, string> ConfigKeyMap = new(StringComparer.OrdinalIgnoreCase)
-    {
-        // Top-level
-        ["RestAddress"] = "CAMUNDA_REST_ADDRESS",
-        ["TokenAudience"] = "CAMUNDA_TOKEN_AUDIENCE",
-        ["DefaultTenantId"] = "CAMUNDA_DEFAULT_TENANT_ID",
-        ["LogLevel"] = "CAMUNDA_SDK_LOG_LEVEL",
-        ["Validation"] = "CAMUNDA_SDK_VALIDATION",
-
-        // Auth section
-        ["Auth:Strategy"] = "CAMUNDA_AUTH_STRATEGY",
-        ["Auth:ClientId"] = "CAMUNDA_CLIENT_ID",
-        ["Auth:ClientSecret"] = "CAMUNDA_CLIENT_SECRET",
-        ["Auth:BasicUsername"] = "CAMUNDA_BASIC_AUTH_USERNAME",
-        ["Auth:BasicPassword"] = "CAMUNDA_BASIC_AUTH_PASSWORD",
-
-        // OAuth section
-        ["OAuth:Url"] = "CAMUNDA_OAUTH_URL",
-        ["OAuth:ClientId"] = "CAMUNDA_CLIENT_ID",
-        ["OAuth:ClientSecret"] = "CAMUNDA_CLIENT_SECRET",
-        ["OAuth:GrantType"] = "CAMUNDA_OAUTH_GRANT_TYPE",
-        ["OAuth:Scope"] = "CAMUNDA_OAUTH_SCOPE",
-        ["OAuth:TimeoutMs"] = "CAMUNDA_OAUTH_TIMEOUT_MS",
-        ["OAuth:RetryMax"] = "CAMUNDA_OAUTH_RETRY_MAX",
-        ["OAuth:RetryBaseDelayMs"] = "CAMUNDA_OAUTH_RETRY_BASE_DELAY_MS",
-
-        // HTTP Retry section
-        ["HttpRetry:MaxAttempts"] = "CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS",
-        ["HttpRetry:BaseDelayMs"] = "CAMUNDA_SDK_HTTP_RETRY_BASE_DELAY_MS",
-        ["HttpRetry:MaxDelayMs"] = "CAMUNDA_SDK_HTTP_RETRY_MAX_DELAY_MS",
-
-        // Backpressure section
-        ["Backpressure:Profile"] = "CAMUNDA_SDK_BACKPRESSURE_PROFILE",
-        ["Backpressure:InitialMax"] = "CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX",
-        ["Backpressure:SoftFactor"] = "CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR",
-        ["Backpressure:SevereFactor"] = "CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR",
-        ["Backpressure:RecoveryIntervalMs"] = "CAMUNDA_SDK_BACKPRESSURE_RECOVERY_INTERVAL_MS",
-        ["Backpressure:RecoveryStep"] = "CAMUNDA_SDK_BACKPRESSURE_RECOVERY_STEP",
-        ["Backpressure:DecayQuietMs"] = "CAMUNDA_SDK_BACKPRESSURE_DECAY_QUIET_MS",
-        ["Backpressure:Floor"] = "CAMUNDA_SDK_BACKPRESSURE_FLOOR",
-        ["Backpressure:SevereThreshold"] = "CAMUNDA_SDK_BACKPRESSURE_SEVERE_THRESHOLD",
-
-        // Eventual consistency
-        ["Eventual:PollDefaultMs"] = "CAMUNDA_SDK_EVENTUAL_POLL_DEFAULT_MS",
-
-        // Worker defaults
-        ["Worker:Timeout"] = "CAMUNDA_WORKER_TIMEOUT",
-        ["Worker:MaxConcurrentJobs"] = "CAMUNDA_WORKER_MAX_CONCURRENT_JOBS",
-        ["Worker:RequestTimeout"] = "CAMUNDA_WORKER_REQUEST_TIMEOUT",
-        ["Worker:Name"] = "CAMUNDA_WORKER_NAME",
-        ["Worker:StartupJitterMaxSeconds"] = "CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS",
-    };
+    private static readonly IReadOnlyDictionary<string, string> ConfigKeyMap = ConfigSchema.ConfigKeyMap;
 
     /// <summary>
     /// Extract configuration values from an <see cref="IConfiguration"/> section,

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -231,25 +231,28 @@ public static class ConfigurationHydrator
             return fallback;
         }
 
+        // Parse an integer key using its schema default as the fallback (no literal duplication).
+        int ParseSchemaInt(string key) => ParseInt(key, ConfigSchema.IntDefault(key));
+
         // Parse validation
-        var validation = ParseValidation(rawMap.GetValueOrDefault("CAMUNDA_SDK_VALIDATION", "req:none,res:none")!, errors);
+        var validation = ParseValidation(rawMap.GetValueOrDefault(ConfigKeys.Validation, ConfigSchema.StringDefault(ConfigKeys.Validation))!, errors);
 
         // Eagerly parse all integer config values so errors are collected before the check
-        var retryMaxAttempts = ParseInt("CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS", 3);
-        var retryBaseDelayMs = ParseInt("CAMUNDA_SDK_HTTP_RETRY_BASE_DELAY_MS", 100);
-        var retryMaxDelayMs = ParseInt("CAMUNDA_SDK_HTTP_RETRY_MAX_DELAY_MS", 2000);
-        var bpInitialMax = ParseInt("CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX", 16);
-        var bpSoftFactor = ParseInt("CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR", 70);
-        var bpSevereFactor = ParseInt("CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR", 50);
-        var bpRecoveryIntervalMs = ParseInt("CAMUNDA_SDK_BACKPRESSURE_RECOVERY_INTERVAL_MS", 1000);
-        var bpRecoveryStep = ParseInt("CAMUNDA_SDK_BACKPRESSURE_RECOVERY_STEP", 1);
-        var bpDecayQuietMs = ParseInt("CAMUNDA_SDK_BACKPRESSURE_DECAY_QUIET_MS", 2000);
-        var bpFloor = ParseInt("CAMUNDA_SDK_BACKPRESSURE_FLOOR", 1);
-        var bpSevereThreshold = ParseInt("CAMUNDA_SDK_BACKPRESSURE_SEVERE_THRESHOLD", 3);
-        var oauthTimeoutMs = ParseInt("CAMUNDA_OAUTH_TIMEOUT_MS", 5000);
-        var oauthRetryMax = ParseInt("CAMUNDA_OAUTH_RETRY_MAX", 5);
-        var oauthRetryBaseDelayMs = ParseInt("CAMUNDA_OAUTH_RETRY_BASE_DELAY_MS", 1000);
-        var eventualPollDefaultMs = ParseInt("CAMUNDA_SDK_EVENTUAL_POLL_DEFAULT_MS", 500);
+        var retryMaxAttempts = ParseSchemaInt(ConfigKeys.HttpRetryMaxAttempts);
+        var retryBaseDelayMs = ParseSchemaInt(ConfigKeys.HttpRetryBaseDelayMs);
+        var retryMaxDelayMs = ParseSchemaInt(ConfigKeys.HttpRetryMaxDelayMs);
+        var bpInitialMax = ParseSchemaInt(ConfigKeys.BackpressureInitialMax);
+        var bpSoftFactor = ParseSchemaInt(ConfigKeys.BackpressureSoftFactor);
+        var bpSevereFactor = ParseSchemaInt(ConfigKeys.BackpressureSevereFactor);
+        var bpRecoveryIntervalMs = ParseSchemaInt(ConfigKeys.BackpressureRecoveryIntervalMs);
+        var bpRecoveryStep = ParseSchemaInt(ConfigKeys.BackpressureRecoveryStep);
+        var bpDecayQuietMs = ParseSchemaInt(ConfigKeys.BackpressureDecayQuietMs);
+        var bpFloor = ParseSchemaInt(ConfigKeys.BackpressureFloor);
+        var bpSevereThreshold = ParseSchemaInt(ConfigKeys.BackpressureSevereThreshold);
+        var oauthTimeoutMs = ParseSchemaInt(ConfigKeys.OAuthTimeoutMs);
+        var oauthRetryMax = ParseSchemaInt(ConfigKeys.OAuthRetryMax);
+        var oauthRetryBaseDelayMs = ParseSchemaInt(ConfigKeys.OAuthRetryBaseDelayMs);
+        var eventualPollDefaultMs = ParseSchemaInt(ConfigKeys.EventualPollDefaultMs);
 
         // Parse optional worker defaults
         int? workerTimeout = rawMap.ContainsKey("CAMUNDA_WORKER_TIMEOUT")
@@ -277,13 +280,13 @@ public static class ConfigurationHydrator
             restAddress = restAddress.TrimEnd('/') + "/v2";
 
         // Backpressure profile
-        var profile = rawMap.GetValueOrDefault("CAMUNDA_SDK_BACKPRESSURE_PROFILE", "BALANCED")!.Trim().ToUpperInvariant();
+        var profile = rawMap.GetValueOrDefault(ConfigKeys.BackpressureProfile, ConfigSchema.StringDefault(ConfigKeys.BackpressureProfile))!.Trim().ToUpperInvariant();
 
         return new CamundaConfig
         {
             RestAddress = restAddress,
             TokenAudience = rawMap.GetValueOrDefault("CAMUNDA_TOKEN_AUDIENCE", "")!,
-            DefaultTenantId = rawMap.GetValueOrDefault("CAMUNDA_DEFAULT_TENANT_ID", "<default>")!,
+            DefaultTenantId = rawMap.GetValueOrDefault(ConfigKeys.DefaultTenantId, ConfigSchema.StringDefault(ConfigKeys.DefaultTenantId))!,
             HttpRetry = new HttpRetryConfig
             {
                 MaxAttempts = retryMaxAttempts,
@@ -309,7 +312,7 @@ public static class ConfigurationHydrator
                 ClientId = rawMap.GetValueOrDefault("CAMUNDA_CLIENT_ID"),
                 ClientSecret = rawMap.GetValueOrDefault("CAMUNDA_CLIENT_SECRET"),
                 OAuthUrl = rawMap.GetValueOrDefault("CAMUNDA_OAUTH_URL", "")!,
-                GrantType = rawMap.GetValueOrDefault("CAMUNDA_OAUTH_GRANT_TYPE", "client_credentials")!,
+                GrantType = rawMap.GetValueOrDefault(ConfigKeys.OAuthGrantType, ConfigSchema.StringDefault(ConfigKeys.OAuthGrantType))!,
                 Scope = rawMap.GetValueOrDefault("CAMUNDA_OAUTH_SCOPE"),
                 TimeoutMs = oauthTimeoutMs,
                 Retry = new OAuthRetryConfig
@@ -330,7 +333,7 @@ public static class ConfigurationHydrator
                     : null,
             },
             Validation = validation,
-            LogLevel = rawMap.GetValueOrDefault("CAMUNDA_SDK_LOG_LEVEL", "error")!,
+            LogLevel = rawMap.GetValueOrDefault(ConfigKeys.LogLevel, ConfigSchema.StringDefault(ConfigKeys.LogLevel))!,
             Eventual = new EventualConfig
             {
                 PollDefaultMs = eventualPollDefaultMs,

--- a/test/Camunda.Orchestration.Sdk.Tests/ConfigSingleSourceGuardTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ConfigSingleSourceGuardTests.cs
@@ -1,0 +1,105 @@
+namespace Camunda.Orchestration.Sdk.Tests;
+
+/// <summary>
+/// Guard tests for the "single source of truth for configuration defaults" refactor
+/// (mirrors the JS SDK's config-single-source guards / issue #145).
+///
+/// These lock in two invariants so that collapsing the currently triple-maintained
+/// defaults (CamundaConfig initializers, ConfigurationHydrator.Defaults, and the
+/// ParseInt fallbacks) into a single schema stays behaviour-preserving:
+///
+///   1. Hydration with no input yields the canonical default values.
+///   2. Directly-constructed sub-config objects (which are used as-is by runtime
+///      components and tests, e.g. `new BackpressureConfig()`) carry the SAME
+///      defaults that hydration produces.
+///
+/// They are written to pass against the pre-refactor code (green), and must stay
+/// green after the schema is introduced (green/green).
+/// </summary>
+public class ConfigSingleSourceGuardTests
+{
+    private static CamundaConfig HydrateEmpty() =>
+        ConfigurationHydrator.Hydrate(env: new Dictionary<string, string?>());
+
+    [Fact]
+    public void HydrationYieldsCanonicalDefaults()
+    {
+        var c = HydrateEmpty();
+
+        Assert.Equal("http://localhost:8080/v2", c.RestAddress);
+        Assert.Equal("zeebe.camunda.io", c.TokenAudience);
+        Assert.Equal("<default>", c.DefaultTenantId);
+        Assert.Equal("error", c.LogLevel);
+
+        Assert.Equal(3, c.HttpRetry.MaxAttempts);
+        Assert.Equal(100, c.HttpRetry.BaseDelayMs);
+        Assert.Equal(2000, c.HttpRetry.MaxDelayMs);
+
+        Assert.True(c.Backpressure.Enabled);
+        Assert.Equal("BALANCED", c.Backpressure.Profile);
+        Assert.False(c.Backpressure.ObserveOnly);
+        Assert.Equal(16, c.Backpressure.InitialMax);
+        Assert.Equal(0.70, c.Backpressure.SoftFactor);
+        Assert.Equal(0.50, c.Backpressure.SevereFactor);
+        Assert.Equal(1000, c.Backpressure.RecoveryIntervalMs);
+        Assert.Equal(1, c.Backpressure.RecoveryStep);
+        Assert.Equal(2000, c.Backpressure.DecayQuietMs);
+        Assert.Equal(1, c.Backpressure.Floor);
+        Assert.Equal(3, c.Backpressure.SevereThreshold);
+
+        Assert.Equal("https://login.cloud.camunda.io/oauth/token", c.OAuth.OAuthUrl);
+        Assert.Equal("client_credentials", c.OAuth.GrantType);
+        Assert.Equal(5000, c.OAuth.TimeoutMs);
+        Assert.Equal(5, c.OAuth.Retry.Max);
+        Assert.Equal(1000, c.OAuth.Retry.BaseDelayMs);
+
+        Assert.Equal(AuthStrategy.None, c.Auth.Strategy);
+        Assert.Equal(ValidationMode.None, c.Validation.Request);
+        Assert.Equal(ValidationMode.None, c.Validation.Response);
+        Assert.Equal("req:none,res:none", c.Validation.Raw);
+        Assert.Equal(500, c.Eventual!.PollDefaultMs);
+    }
+
+    /// <summary>
+    /// The sub-config classes are constructed directly (e.g. BackpressureManager and
+    /// several tests do `new BackpressureConfig()`), so their initializer defaults are
+    /// part of the contract. They must equal the values hydration produces — this is the
+    /// invariant that lets both sites be driven from one schema without drift.
+    /// Fields whose class default is intentionally a placeholder overwritten by the
+    /// hydrator (RestAddress, TokenAudience, OAuthUrl) are excluded.
+    /// </summary>
+    [Fact]
+    public void DirectlyConstructedSubConfigsMatchHydratedDefaults()
+    {
+        var c = HydrateEmpty();
+
+        var httpRetry = new HttpRetryConfig();
+        Assert.Equal(c.HttpRetry.MaxAttempts, httpRetry.MaxAttempts);
+        Assert.Equal(c.HttpRetry.BaseDelayMs, httpRetry.BaseDelayMs);
+        Assert.Equal(c.HttpRetry.MaxDelayMs, httpRetry.MaxDelayMs);
+
+        var backpressure = new BackpressureConfig();
+        Assert.Equal(c.Backpressure.Enabled, backpressure.Enabled);
+        Assert.Equal(c.Backpressure.Profile, backpressure.Profile);
+        Assert.Equal(c.Backpressure.ObserveOnly, backpressure.ObserveOnly);
+        Assert.Equal(c.Backpressure.InitialMax, backpressure.InitialMax);
+        Assert.Equal(c.Backpressure.SoftFactor, backpressure.SoftFactor);
+        Assert.Equal(c.Backpressure.SevereFactor, backpressure.SevereFactor);
+        Assert.Equal(c.Backpressure.RecoveryIntervalMs, backpressure.RecoveryIntervalMs);
+        Assert.Equal(c.Backpressure.RecoveryStep, backpressure.RecoveryStep);
+        Assert.Equal(c.Backpressure.DecayQuietMs, backpressure.DecayQuietMs);
+        Assert.Equal(c.Backpressure.Floor, backpressure.Floor);
+        Assert.Equal(c.Backpressure.SevereThreshold, backpressure.SevereThreshold);
+
+        var oauth = new OAuthConfig();
+        Assert.Equal(c.OAuth.GrantType, oauth.GrantType);
+        Assert.Equal(c.OAuth.TimeoutMs, oauth.TimeoutMs);
+
+        var oauthRetry = new OAuthRetryConfig();
+        Assert.Equal(c.OAuth.Retry.Max, oauthRetry.Max);
+        Assert.Equal(c.OAuth.Retry.BaseDelayMs, oauthRetry.BaseDelayMs);
+
+        var eventual = new EventualConfig();
+        Assert.Equal(c.Eventual!.PollDefaultMs, eventual.PollDefaultMs);
+    }
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/ConfigSingleSourceGuardTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ConfigSingleSourceGuardTests.cs
@@ -103,3 +103,92 @@ public class ConfigSingleSourceGuardTests
         Assert.Equal(c.Eventual!.PollDefaultMs, eventual.PollDefaultMs);
     }
 }
+
+/// <summary>
+/// Integrity guards for the <see cref="ConfigSchema"/> registry itself (single source of
+/// truth). These lock the schema's internal consistency and its wiring into the config
+/// classes, so drift is caught at test time rather than shipped.
+/// </summary>
+public class ConfigSchemaIntegrityTests
+{
+    [Fact]
+    public void IntTypedDefaultsAreParseable()
+    {
+        foreach (var d in ConfigSchema.All.Where(d => d.Type == ConfigValueType.Int && d.Default != null))
+        {
+            Assert.True(
+                int.TryParse(d.Default, out _),
+                $"{d.EnvVar} is declared Int but its default '{d.Default}' is not an integer.");
+        }
+    }
+
+    [Fact]
+    public void EnumDefaultsAreWithinChoices()
+    {
+        foreach (var d in ConfigSchema.All.Where(d => d.Type == ConfigValueType.Enum && d.Default != null))
+        {
+            Assert.NotNull(d.Choices);
+            Assert.Contains(d.Default, d.Choices!);
+        }
+    }
+
+    [Fact]
+    public void ConfigPathsMapToExactlyOneEnvVar()
+    {
+        var duplicates = ConfigSchema.All
+            .SelectMany(d => d.ConfigPaths.Select(p => (Path: p, d.EnvVar)))
+            .GroupBy(x => x.Path, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Select(x => x.EnvVar).Distinct().Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        Assert.Empty(duplicates);
+    }
+
+    [Fact]
+    public void EnvVarsAreUnique()
+    {
+        var dupes = ConfigSchema.All
+            .GroupBy(d => d.EnvVar, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        Assert.Empty(dupes);
+    }
+
+    /// <summary>
+    /// The sub-config initializer defaults must be sourced from the schema (not restated
+    /// literals). Assert equality directly against the schema so a divergent literal fails.
+    /// </summary>
+    [Fact]
+    public void SubConfigDefaultsAreSourcedFromSchema()
+    {
+        var httpRetry = new HttpRetryConfig();
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.HttpRetryMaxAttempts), httpRetry.MaxAttempts);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.HttpRetryBaseDelayMs), httpRetry.BaseDelayMs);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.HttpRetryMaxDelayMs), httpRetry.MaxDelayMs);
+
+        var bp = new BackpressureConfig();
+        Assert.Equal(ConfigSchema.StringDefault(ConfigKeys.BackpressureProfile), bp.Profile);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.BackpressureInitialMax), bp.InitialMax);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.BackpressureSoftFactor) / 100.0, bp.SoftFactor);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.BackpressureSevereFactor) / 100.0, bp.SevereFactor);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.BackpressureRecoveryIntervalMs), bp.RecoveryIntervalMs);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.BackpressureRecoveryStep), bp.RecoveryStep);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.BackpressureDecayQuietMs), bp.DecayQuietMs);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.BackpressureFloor), bp.Floor);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.BackpressureSevereThreshold), bp.SevereThreshold);
+
+        var oauth = new OAuthConfig();
+        Assert.Equal(ConfigSchema.StringDefault(ConfigKeys.OAuthGrantType), oauth.GrantType);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.OAuthTimeoutMs), oauth.TimeoutMs);
+
+        var oauthRetry = new OAuthRetryConfig();
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.OAuthRetryMax), oauthRetry.Max);
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.OAuthRetryBaseDelayMs), oauthRetry.BaseDelayMs);
+
+        Assert.Equal(ConfigSchema.IntDefault(ConfigKeys.EventualPollDefaultMs), new EventualConfig().PollDefaultMs);
+        Assert.Equal(ConfigSchema.StringDefault(ConfigKeys.Validation), new ValidationConfig().Raw);
+    }
+}

--- a/test/Camunda.Orchestration.Sdk.Tests/ConfigSingleSourceGuardTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ConfigSingleSourceGuardTests.cs
@@ -133,12 +133,15 @@ public class ConfigSchemaIntegrityTests
     }
 
     [Fact]
-    public void ConfigPathsMapToExactlyOneEnvVar()
+    public void ConfigPathsAreUnique()
     {
+        // ConfigSchema.ConfigKeyMap is built via ToDictionary, which throws on a duplicate
+        // path even when both map to the same env var — so the schema requires paths to be
+        // globally unique (case-insensitive), not merely non-conflicting.
         var duplicates = ConfigSchema.All
-            .SelectMany(d => d.ConfigPaths.Select(p => (Path: p, d.EnvVar)))
-            .GroupBy(x => x.Path, StringComparer.OrdinalIgnoreCase)
-            .Where(g => g.Select(x => x.EnvVar).Distinct().Count() > 1)
+            .SelectMany(d => d.ConfigPaths)
+            .GroupBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
             .Select(g => g.Key)
             .ToList();
 

--- a/test/Camunda.Orchestration.Sdk.Tests/ConfigSingleSourceGuardTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ConfigSingleSourceGuardTests.cs
@@ -117,8 +117,8 @@ public class ConfigSchemaIntegrityTests
         foreach (var d in ConfigSchema.All.Where(d => d.Type == ConfigValueType.Int && d.Default != null))
         {
             Assert.True(
-                int.TryParse(d.Default, out _),
-                $"{d.EnvVar} is declared Int but its default '{d.Default}' is not an integer.");
+                int.TryParse(d.Default, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out _),
+                $"{d.EnvVar} is declared Int but its default '{d.Default}' is not an unsigned invariant integer.");
         }
     }
 

--- a/test/Camunda.Orchestration.Sdk.Tests/ConfigSingleSourceGuardTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ConfigSingleSourceGuardTests.cs
@@ -2,7 +2,7 @@ namespace Camunda.Orchestration.Sdk.Tests;
 
 /// <summary>
 /// Guard tests for the "single source of truth for configuration defaults" refactor
-/// (mirrors the JS SDK's config-single-source guards / issue #145).
+/// (mirrors the JS SDK's config-single-source guards; see camunda/orchestration-cluster-api-js#145).
 ///
 /// These lock in two invariants so that collapsing the currently triple-maintained
 /// defaults (CamundaConfig initializers, ConfigurationHydrator.Defaults, and the

--- a/test/Camunda.Orchestration.Sdk.Tests/ConfigurationTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ConfigurationTests.cs
@@ -171,4 +171,25 @@ public class ConfigurationTests
         Assert.Equal("****efgh", ConfigurationHydrator.RedactSecret("abcdefgh"));
         Assert.Equal("**", ConfigurationHydrator.RedactSecret("ab"));
     }
+
+    [Fact]
+    public void RejectsNegativeValueForUnsignedIntegerKey()
+    {
+        // Unsigned int keys must reject a negative value, matching ParseInt's contract.
+        var act = () => ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?> { ["CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS"] = "-1" });
+
+        var ex = Assert.Throws<CamundaConfigurationException>(act);
+        Assert.Contains(ex.Errors, e => e.Code == ConfigErrorCode.InvalidInteger);
+    }
+
+    [Fact]
+    public void AcceptsNegativeWorkerRequestTimeout()
+    {
+        // CAMUNDA_WORKER_REQUEST_TIMEOUT is signed: a negative value disables long polling.
+        var config = ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?> { ["CAMUNDA_WORKER_REQUEST_TIMEOUT"] = "-1" });
+
+        Assert.Equal(-1, config.WorkerDefaults!.PollTimeoutMs);
+    }
 }


### PR DESCRIPTION
## What

Makes `ConfigSchema` the single source of truth for configuration options in the C# SDK, and adds guard tests to keep it that way. Ports the JS SDK's `SCHEMA` work (issue #145) to C#.

Previously each config default was declared up to **three** times — in the `CamundaConfig` sub-config `init` initializers, in `ConfigurationHydrator.Defaults`, and again in the `ParseInt` / `GetValueOrDefault` fallbacks — plus a hand-maintained `ConfigKeyMap` (IConfiguration path → env var) and a hardcoded extra-env-keys array and `ZEEBE_REST_ADDRESS` alias. Any of these could silently drift.

## How

- **New `Runtime/ConfigSchema.cs`** — one descriptor per key (`EnvVar`, `Type`, `Default`, `Choices`, `Aliases`, `ConfigPaths`, `Secret`, `Doc`), keyed by const names in `ConfigKeys`. Typed accessors `IntDefault` / `StringDefault` are usable directly in `init` initializers.
- **Hydrator derives from the schema** — `Defaults`, `SecretKeys`, `ConfigKeyMap`, env-var reading, and legacy-alias handling all come from `ConfigSchema` instead of separate literals. A `ParseSchemaInt(key)` helper uses the schema default as the parse fallback.
- **`CamundaConfig` initializers reference the schema** — each defaulted `init` value is `ConfigSchema.IntDefault/StringDefault(...)`. The sub-config classes are constructed directly (e.g. `new BackpressureConfig()` in `BackpressureManager` and tests), so their defaults are kept but now sourced from the schema rather than restated.

Each default value is now declared **exactly once**, in `ConfigSchema`.

No public API change (`CamundaOptions`, `CamundaConfig` shapes unchanged) and precedence is unchanged (`Config` overrides > `IConfiguration` > env > schema defaults) — behaviour-preserving.

## Guard tests (`ConfigSingleSourceGuardTests.cs`)

- **Behaviour:** hydration with no input yields the canonical defaults.
- **Class ↔ hydration:** directly-constructed sub-configs carry the same defaults hydration produces.
- **Schema integrity:** int defaults parse, enum defaults are within their choices, config paths map to exactly one env var, env vars are unique.
- **Class ↔ schema:** sub-config `init` defaults are sourced from the schema (a divergent literal fails the test).

Written green/green: the first two guards were committed and shown to pass against the pre-refactor code, then stayed green after the schema landed.

## Notable behaviour improvement

The 8 backpressure knob env vars (`CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX`, `_SOFT_FACTOR`, …) are now read from the real environment. Previously their defaults lived only in `ParseInt` fallbacks + class initializers and were **not** in the env-reading set, so setting them via a real environment variable (rather than an explicit `env`/overrides dict) was silently ignored. Bringing them into the schema fixes that.

## Out of scope

- `RequiredWhen` inference stays hardcoded in the hydrator (the OAUTH/BASIC required-field checks).
- No fully declarative key → `CamundaConfig`-path binder (the structural mapping stays hand-written; the guards cover default/consistency drift).

## Validation

- Full unit suite green: **1093/1093** on both `net8.0` and `net10.0`, including the config/worker/backpressure suites and the new guard tests.
- `dotnet format --verify-no-changes` clean on all changed files.

> Note: the `IntegrationTests` project requires a live Camunda (`CamundaFixture` connects to `http://localhost:8080/v2`); those are environment-dependent and unrelated to this change. A local Windows `dotnet format` run also flags pre-existing CRLF (`ENDOFLINE`) in several untouched files (`Generator/*`, `Changelog.Tests/*`, `IntegrationTests/*`, `tools/*`) — a `core.autocrlf` checkout artifact, not introduced here.
