### PR TITLE
docs: add searchProcessDefinitionVariableNames example coverage

### DIFF
--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -1603,6 +1603,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.SearchProcessDefinitionVariableNamesAsync(Camunda.Orchestration.Sdk.ProcessDefinitionKey,Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameSearchQuery,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameSearchQueryResult},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/ProcessDefinition.cs#SearchProcessDefinitionVariableNames)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.SearchProcessInstanceIncidentsAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey,Camunda.Orchestration.Sdk.IncidentSearchQuery,Camunda.Orchestration.Sdk.ConsistencyOptions{Camunda.Orchestration.Sdk.IncidentSearchQueryResult},System.Threading.CancellationToken)
 example:
 - *content

--- a/examples/ProcessDefinition.cs
+++ b/examples/ProcessDefinition.cs
@@ -51,6 +51,25 @@ public static class ProcessDefinitionExamples
     // </SearchProcessDefinitions>
     #endregion SearchProcessDefinitions
 
+    #region SearchProcessDefinitionVariableNames
+
+    // <SearchProcessDefinitionVariableNames>
+    public static async Task SearchProcessDefinitionVariableNamesExample(ProcessDefinitionKey processDefinitionKey)
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.SearchProcessDefinitionVariableNamesAsync(
+            processDefinitionKey,
+            new ProcessDefinitionVariableNameSearchQuery());
+
+        foreach (var variable in result.Items)
+        {
+            Console.WriteLine($"Variable name: {variable.Name}");
+        }
+    }
+    // </SearchProcessDefinitionVariableNames>
+    #endregion SearchProcessDefinitionVariableNames
+
     #region GetProcessDefinitionStatistics
 
     // <GetProcessDefinitionStatistics>

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -179,6 +179,13 @@
       "label": "Search process definitions"
     }
   ],
+  "searchProcessDefinitionVariableNames": [
+    {
+      "file": "ProcessDefinition.cs",
+      "region": "SearchProcessDefinitionVariableNames",
+      "label": "Search process definition variable names"
+    }
+  ],
   "getProcessDefinitionStatistics": [
     {
       "file": "ProcessDefinition.cs",

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -11533,6 +11533,113 @@
         "x-added-in-version": "8.8"
       }
     },
+    "/process-definitions/{processDefinitionKey}/variable-names/search": {
+      "post": {
+        "x-eventually-consistent": true,
+        "tags": [
+          "Process definition"
+        ],
+        "operationId": "searchProcessDefinitionVariableNames",
+        "x-permission-enforcement": "filter",
+        "x-required-permissions": [
+          {
+            "resourceType": "PROCESS_DEFINITION",
+            "permissionType": "READ_PROCESS_INSTANCE"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Search process definition variable names",
+        "description": "Search for distinct variable names defined on a process definition, optionally narrowed by the name filter.",
+        "parameters": [
+          {
+            "name": "processDefinitionKey",
+            "in": "path",
+            "required": true,
+            "description": "The assigned key of the process definition, which acts as a unique identifier for this process definition.",
+            "schema": {
+              "$ref": "#/components/schemas/ProcessDefinitionKey"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProcessDefinitionVariableNameSearchQuery"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The process definition variable name search result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessDefinitionVariableNameSearchQueryResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/process-definitions/{processDefinitionKey}/xml": {
       "get": {
         "x-eventually-consistent": true,
@@ -23333,6 +23440,7 @@
           "CREATE_BATCH_OPERATION_MIGRATE_PROCESS_INSTANCE",
           "CREATE_BATCH_OPERATION_MODIFY_PROCESS_INSTANCE",
           "CREATE_BATCH_OPERATION_RESOLVE_INCIDENT",
+          "CREATE_BATCH_OPERATION_SUSPEND_PROCESS_INSTANCE",
           "CREATE_BATCH_OPERATION_UPDATE_JOB",
           "CREATE_DECISION_INSTANCE",
           "CREATE_PROCESS_INSTANCE",
@@ -23356,6 +23464,7 @@
           "READ_USAGE_METRIC",
           "READ_USER_TASK",
           "READ_TASK_LISTENER",
+          "SUSPEND_PROCESS_INSTANCE",
           "UPDATE",
           "UPDATE_PROCESS_INSTANCE",
           "UPDATE_USER_TASK",
@@ -35501,8 +35610,18 @@
           "hasStartForm": {
             "description": "Indicates whether the start event of the process has an associated Form Key.",
             "type": "boolean"
+          },
+          "isDeleted": {
+            "description": "Filter by whether the process definition has been deleted.\nWhen not set, both deleted and non-deleted process definitions are returned.\nSet to `false` to exclude deleted definitions (recommended for most use cases).\nSet to `true` to return only deleted definitions that are still retained in secondary storage.\n",
+            "type": "boolean"
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "isDeleted",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "ProcessDefinitionSearchQueryResult": {
         "type": "object",
@@ -35528,6 +35647,7 @@
         "type": "object",
         "required": [
           "hasStartForm",
+          "isDeleted",
           "name",
           "processDefinitionId",
           "processDefinitionKey",
@@ -35583,8 +35703,18 @@
           "hasStartForm": {
             "description": "Indicates whether the start event of the process has an associated Form Key.",
             "type": "boolean"
+          },
+          "isDeleted": {
+            "description": "Whether this process definition has been deleted but is still retained in secondary storage.",
+            "type": "boolean"
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "isDeleted",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "ProcessDefinitionElementStatisticsQuery": {
         "description": "Process definition element statistics request.",
@@ -35655,6 +35785,75 @@
             "description": "The total number of completed instances of the element.",
             "type": "integer",
             "format": "int64"
+          }
+        }
+      },
+      "ProcessDefinitionVariableNameSearchQuery": {
+        "description": "Process definition variable name search query request.",
+        "additionalProperties": false,
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SearchQueryRequest"
+          }
+        ],
+        "properties": {
+          "filter": {
+            "description": "The process definition variable name search filters.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessDefinitionVariableNameFilter"
+              }
+            ]
+          }
+        }
+      },
+      "ProcessDefinitionVariableNameFilter": {
+        "description": "Process definition variable name filter request.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "The variable name search filter.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ]
+          }
+        }
+      },
+      "ProcessDefinitionVariableNameSearchQueryResult": {
+        "description": "Process definition variable name search query response.",
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SearchQueryResponse"
+          }
+        ],
+        "properties": {
+          "items": {
+            "description": "The matching variable names.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProcessDefinitionVariableNameSearchResult"
+            }
+          }
+        }
+      },
+      "ProcessDefinitionVariableNameSearchResult": {
+        "description": "Process definition variable name search response item.",
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "description": "The variable name.",
+            "type": "string"
           }
         }
       },

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:bf97c32b4090a2316b417ebf3d024c5476a4d941b24e8dce133e785685effe26",
+  "specHash": "sha256:83242850b1f3570de5fa8fb6d52f4741286347f3e1601c4f58617dd28211974e",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -2678,6 +2678,14 @@
     {
       "operationId": "getProcessDefinitionStatistics",
       "path": "/process-definitions/{processDefinitionKey}/statistics/element-instances",
+      "method": "post",
+      "tags": [
+        "Process definition"
+      ]
+    },
+    {
+      "operationId": "searchProcessDefinitionVariableNames",
+      "path": "/process-definitions/{processDefinitionKey}/variable-names/search",
       "method": "post",
       "tags": [
         "Process definition"
@@ -7264,6 +7272,44 @@
       }
     },
     {
+      "operationId": "searchProcessDefinitionVariableNames",
+      "path": "/process-definitions/{processDefinitionKey}/variable-names/search",
+      "method": "post",
+      "tags": [
+        "Process definition"
+      ],
+      "summary": "Search process definition variable names",
+      "description": "Search for distinct variable names defined on a process definition, optionally narrowed by the name filter.",
+      "eventuallyConsistent": true,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [
+        "processDefinitionKey"
+      ],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "process-definitions.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "ProcessDefinitionVariableNameSearchQuery",
+      "successResponseSchemaRef": "ProcessDefinitionVariableNameSearchQueryResult",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": true,
+        "x-permission-enforcement": "filter",
+        "x-required-permissions": [
+          {
+            "resourceType": "PROCESS_DEFINITION",
+            "permissionType": "READ_PROCESS_INSTANCE"
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "getProcessDefinitionXML",
       "path": "/process-definitions/{processDefinitionKey}/xml",
       "method": "get",
@@ -11108,8 +11154,8 @@
   "integrity": {
     "totalSemanticKeys": 41,
     "totalUnions": 64,
-    "totalOperations": 197,
-    "totalEventuallyConsistent": 91,
+    "totalOperations": 198,
+    "totalEventuallyConsistent": 92,
     "totalDeprecatedEnumSchemas": 2,
     "totalSemanticProviders": 23
   }

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -7155,6 +7155,60 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Search process definition variable names
+    /// Search for distinct variable names defined on a process definition, optionally narrowed by the name filter.
+    /// </summary>
+    /// <remarks>
+    /// Operation: searchProcessDefinitionVariableNames
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SearchProcessDefinitionVariableNamesExample(ProcessDefinitionKey processDefinitionKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SearchProcessDefinitionVariableNamesAsync(
+    ///         processDefinitionKey,
+    ///         new ProcessDefinitionVariableNameSearchQuery());
+    /// 
+    ///     foreach (var variable in result.Items)
+    ///     {
+    ///         Console.WriteLine($&quot;Variable name: {variable.Name}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SearchProcessDefinitionVariableNamesExample(ProcessDefinitionKey processDefinitionKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SearchProcessDefinitionVariableNamesAsync(
+    ///         processDefinitionKey,
+    ///         new ProcessDefinitionVariableNameSearchQuery());
+    /// 
+    ///     foreach (var variable in result.Items)
+    ///     {
+    ///         Console.WriteLine($&quot;Variable name: {variable.Name}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<ProcessDefinitionVariableNameSearchQueryResult> SearchProcessDefinitionVariableNamesAsync(ProcessDefinitionKey processDefinitionKey, ProcessDefinitionVariableNameSearchQuery body, ConsistencyOptions<ProcessDefinitionVariableNameSearchQueryResult>? consistency = null, CancellationToken ct = default)
+    {
+        var path = $"/process-definitions/{Uri.EscapeDataString(processDefinitionKey.ToString()!)}/variable-names/search";
+        if (consistency != null && consistency.WaitUpToMs > 0)
+        {
+            return await EventualPoller.PollAsync("searchProcessDefinitionVariableNames", false,
+                () => InvokeWithRetryAsync(() => SendAsync<ProcessDefinitionVariableNameSearchQueryResult>(HttpMethod.Post, path, body, ct), "searchProcessDefinitionVariableNames", false, ct),
+                consistency!, _logger, ct);
+        }
+
+        return await InvokeWithRetryAsync(() => SendAsync<ProcessDefinitionVariableNameSearchQueryResult>(HttpMethod.Post, path, body, ct), "searchProcessDefinitionVariableNames", false, ct);
+    }
+
+    /// <summary>
     /// Search process definitions
     /// Search for process definitions based on given criteria.
     /// </summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -19685,6 +19685,8 @@ public enum PermissionTypeEnum
     CREATEBATCHOPERATIONMODIFYPROCESSINSTANCE,
     [JsonPropertyName("CREATE_BATCH_OPERATION_RESOLVE_INCIDENT")]
     CREATEBATCHOPERATIONRESOLVEINCIDENT,
+    [JsonPropertyName("CREATE_BATCH_OPERATION_SUSPEND_PROCESS_INSTANCE")]
+    CREATEBATCHOPERATIONSUSPENDPROCESSINSTANCE,
     [JsonPropertyName("CREATE_BATCH_OPERATION_UPDATE_JOB")]
     CREATEBATCHOPERATIONUPDATEJOB,
     [JsonPropertyName("CREATE_DECISION_INSTANCE")]
@@ -19731,6 +19733,8 @@ public enum PermissionTypeEnum
     READUSERTASK,
     [JsonPropertyName("READ_TASK_LISTENER")]
     READTASKLISTENER,
+    [JsonPropertyName("SUSPEND_PROCESS_INSTANCE")]
+    SUSPENDPROCESSINSTANCE,
     [JsonPropertyName("UPDATE")]
     UPDATE,
     [JsonPropertyName("UPDATE_PROCESS_INSTANCE")]
@@ -19867,6 +19871,16 @@ public sealed class ProcessDefinitionFilter
     /// </summary>
     [JsonPropertyName("hasStartForm")]
     public bool? HasStartForm { get; set; }
+
+    /// <summary>
+    /// Filter by whether the process definition has been deleted.
+    /// When not set, both deleted and non-deleted process definitions are returned.
+    /// Set to `false` to exclude deleted definitions (recommended for most use cases).
+    /// Set to `true` to return only deleted definitions that are still retained in secondary storage.
+    /// 
+    /// </summary>
+    [JsonPropertyName("isDeleted")]
+    public bool? IsDeleted { get; set; }
 
 }
 
@@ -20589,6 +20603,12 @@ public sealed class ProcessDefinitionResult
     [JsonPropertyName("hasStartForm")]
     public bool HasStartForm { get; set; }
 
+    /// <summary>
+    /// Whether this process definition has been deleted but is still retained in secondary storage.
+    /// </summary>
+    [JsonPropertyName("isDeleted")]
+    public bool IsDeleted { get; set; }
+
 }
 
 /// <summary>
@@ -20810,6 +20830,70 @@ public sealed class ProcessDefinitionStatisticsFilter
     /// </summary>
     [JsonPropertyName("$or")]
     public List<BaseProcessInstanceFilterFields>? Or { get; set; }
+
+}
+
+/// <summary>
+/// Process definition variable name filter request.
+/// </summary>
+public sealed class ProcessDefinitionVariableNameFilter
+{
+    /// <summary>
+    /// The variable name search filter.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public StringFilterProperty? Name { get; set; }
+
+}
+
+/// <summary>
+/// Process definition variable name search query request.
+/// </summary>
+public sealed class ProcessDefinitionVariableNameSearchQuery
+{
+    /// <summary>
+    /// The process definition variable name search filters.
+    /// </summary>
+    [JsonPropertyName("filter")]
+    public ProcessDefinitionVariableNameFilter? Filter { get; set; }
+
+    /// <summary>
+    /// Pagination criteria.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public SearchQueryPageRequest? Page { get; set; }
+
+}
+
+/// <summary>
+/// Process definition variable name search query response.
+/// </summary>
+public sealed class ProcessDefinitionVariableNameSearchQueryResult
+{
+    /// <summary>
+    /// The matching variable names.
+    /// </summary>
+    [JsonPropertyName("items")]
+    public List<ProcessDefinitionVariableNameSearchResult> Items { get; set; } = null!;
+
+    /// <summary>
+    /// Pagination information about the search results.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public SearchQueryPageResponse Page { get; set; } = null!;
+
+}
+
+/// <summary>
+/// Process definition variable name search response item.
+/// </summary>
+public sealed class ProcessDefinitionVariableNameSearchResult
+{
+    /// <summary>
+    /// The variable name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
 
 }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:bf97c32b4090a2316b417ebf3d024c5476a4d941b24e8dce133e785685effe26";
+    public const string SpecHash = "sha256:83242850b1f3570de5fa8fb6d52f4741286347f3e1601c4f58617dd28211974e";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -1683,6 +1683,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessDefinitionMessageSubscriptionStatisticsQueryResult> GetProcessDefinitionMessageSubscriptionStatisticsAsync(Camunda.Orchestration.Sdk.ProcessDefinitionMessageSubscriptionStatisticsQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessDefinitionMessageSubscriptionStatisticsQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessDefinitionResult> GetProcessDefinitionAsync(Camunda.Orchestration.Sdk.ProcessDefinitionKey processDefinitionKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessDefinitionResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessDefinitionSearchQueryResult> SearchProcessDefinitionsAsync(Camunda.Orchestration.Sdk.ProcessDefinitionSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessDefinitionSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameSearchQueryResult> SearchProcessDefinitionVariableNamesAsync(Camunda.Orchestration.Sdk.ProcessDefinitionKey processDefinitionKey, Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessInstanceElementStatisticsQueryResult> GetProcessInstanceStatisticsAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessInstanceElementStatisticsQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessInstanceResult> GetProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessInstanceResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ProcessInstanceSearchQueryResult> SearchProcessInstancesAsync(Camunda.Orchestration.Sdk.ProcessInstanceSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.ProcessInstanceSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -4529,33 +4530,35 @@ TYPE Camunda.Orchestration.Sdk.PermissionTypeEnum : enum interfaces=[System.ICom
   MEMBER CREATEBATCHOPERATIONMIGRATEPROCESSINSTANCE = 12 json="CREATE_BATCH_OPERATION_MIGRATE_PROCESS_INSTANCE"
   MEMBER CREATEBATCHOPERATIONMODIFYPROCESSINSTANCE = 13 json="CREATE_BATCH_OPERATION_MODIFY_PROCESS_INSTANCE"
   MEMBER CREATEBATCHOPERATIONRESOLVEINCIDENT = 14 json="CREATE_BATCH_OPERATION_RESOLVE_INCIDENT"
-  MEMBER CREATEBATCHOPERATIONUPDATEJOB = 15 json="CREATE_BATCH_OPERATION_UPDATE_JOB"
-  MEMBER CREATEDECISIONINSTANCE = 16 json="CREATE_DECISION_INSTANCE"
-  MEMBER CREATEPROCESSINSTANCE = 17 json="CREATE_PROCESS_INSTANCE"
-  MEMBER CREATETASKLISTENER = 18 json="CREATE_TASK_LISTENER"
-  MEMBER DELETE = 19 json="DELETE"
-  MEMBER DELETEDECISIONINSTANCE = 20 json="DELETE_DECISION_INSTANCE"
-  MEMBER DELETEDRD = 21 json="DELETE_DRD"
-  MEMBER DELETEFORM = 22 json="DELETE_FORM"
-  MEMBER DELETEPROCESS = 23 json="DELETE_PROCESS"
-  MEMBER DELETEPROCESSINSTANCE = 24 json="DELETE_PROCESS_INSTANCE"
-  MEMBER DELETERESOURCE = 25 json="DELETE_RESOURCE"
-  MEMBER DELETETASKLISTENER = 26 json="DELETE_TASK_LISTENER"
-  MEMBER EVALUATE = 27 json="EVALUATE"
-  MEMBER MODIFYPROCESSINSTANCE = 28 json="MODIFY_PROCESS_INSTANCE"
-  MEMBER READ = 29 json="READ"
-  MEMBER READDECISIONDEFINITION = 30 json="READ_DECISION_DEFINITION"
-  MEMBER READDECISIONINSTANCE = 31 json="READ_DECISION_INSTANCE"
-  MEMBER READJOBMETRIC = 32 json="READ_JOB_METRIC"
-  MEMBER READPROCESSDEFINITION = 33 json="READ_PROCESS_DEFINITION"
-  MEMBER READPROCESSINSTANCE = 34 json="READ_PROCESS_INSTANCE"
-  MEMBER READUSAGEMETRIC = 35 json="READ_USAGE_METRIC"
-  MEMBER READUSERTASK = 36 json="READ_USER_TASK"
-  MEMBER READTASKLISTENER = 37 json="READ_TASK_LISTENER"
-  MEMBER UPDATE = 38 json="UPDATE"
-  MEMBER UPDATEPROCESSINSTANCE = 39 json="UPDATE_PROCESS_INSTANCE"
-  MEMBER UPDATEUSERTASK = 40 json="UPDATE_USER_TASK"
-  MEMBER UPDATETASKLISTENER = 41 json="UPDATE_TASK_LISTENER"
+  MEMBER CREATEBATCHOPERATIONSUSPENDPROCESSINSTANCE = 15 json="CREATE_BATCH_OPERATION_SUSPEND_PROCESS_INSTANCE"
+  MEMBER CREATEBATCHOPERATIONUPDATEJOB = 16 json="CREATE_BATCH_OPERATION_UPDATE_JOB"
+  MEMBER CREATEDECISIONINSTANCE = 17 json="CREATE_DECISION_INSTANCE"
+  MEMBER CREATEPROCESSINSTANCE = 18 json="CREATE_PROCESS_INSTANCE"
+  MEMBER CREATETASKLISTENER = 19 json="CREATE_TASK_LISTENER"
+  MEMBER DELETE = 20 json="DELETE"
+  MEMBER DELETEDECISIONINSTANCE = 21 json="DELETE_DECISION_INSTANCE"
+  MEMBER DELETEDRD = 22 json="DELETE_DRD"
+  MEMBER DELETEFORM = 23 json="DELETE_FORM"
+  MEMBER DELETEPROCESS = 24 json="DELETE_PROCESS"
+  MEMBER DELETEPROCESSINSTANCE = 25 json="DELETE_PROCESS_INSTANCE"
+  MEMBER DELETERESOURCE = 26 json="DELETE_RESOURCE"
+  MEMBER DELETETASKLISTENER = 27 json="DELETE_TASK_LISTENER"
+  MEMBER EVALUATE = 28 json="EVALUATE"
+  MEMBER MODIFYPROCESSINSTANCE = 29 json="MODIFY_PROCESS_INSTANCE"
+  MEMBER READ = 30 json="READ"
+  MEMBER READDECISIONDEFINITION = 31 json="READ_DECISION_DEFINITION"
+  MEMBER READDECISIONINSTANCE = 32 json="READ_DECISION_INSTANCE"
+  MEMBER READJOBMETRIC = 33 json="READ_JOB_METRIC"
+  MEMBER READPROCESSDEFINITION = 34 json="READ_PROCESS_DEFINITION"
+  MEMBER READPROCESSINSTANCE = 35 json="READ_PROCESS_INSTANCE"
+  MEMBER READUSAGEMETRIC = 36 json="READ_USAGE_METRIC"
+  MEMBER READUSERTASK = 37 json="READ_USER_TASK"
+  MEMBER READTASKLISTENER = 38 json="READ_TASK_LISTENER"
+  MEMBER SUSPENDPROCESSINSTANCE = 39 json="SUSPEND_PROCESS_INSTANCE"
+  MEMBER UPDATE = 40 json="UPDATE"
+  MEMBER UPDATEPROCESSINSTANCE = 41 json="UPDATE_PROCESS_INSTANCE"
+  MEMBER UPDATEUSERTASK = 42 json="UPDATE_USER_TASK"
+  MEMBER UPDATETASKLISTENER = 43 json="UPDATE_TASK_LISTENER"
 
 TYPE Camunda.Orchestration.Sdk.ProblemDetail : sealed class
   CTOR ()
@@ -4580,6 +4583,7 @@ TYPE Camunda.Orchestration.Sdk.ProcessDefinitionFilter : sealed class
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.TenantId? TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Boolean? HasStartForm { get; set; } [JsonPropertyName("hasStartForm")]
+  PROP System.Boolean? IsDeleted { get; set; } [JsonPropertyName("isDeleted")]
   PROP System.Boolean? IsLatestVersion { get; set; } [JsonPropertyName("isLatestVersion")]
   PROP System.Int32? Version { get; set; } [JsonPropertyName("version")]
   PROP System.String? ResourceName { get; set; } [JsonPropertyName("resourceName")]
@@ -4738,6 +4742,7 @@ TYPE Camunda.Orchestration.Sdk.ProcessDefinitionResult : sealed class
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Boolean HasStartForm { get; set; } [JsonPropertyName("hasStartForm")]
+  PROP System.Boolean IsDeleted { get; set; } [JsonPropertyName("isDeleted")]
   PROP System.Int32 Version { get; set; } [JsonPropertyName("version")]
   PROP System.String ResourceName { get; set; } [JsonPropertyName("resourceName")]
   PROP System.String? Name { get; set; } [JsonPropertyName("name")]
@@ -4792,6 +4797,24 @@ TYPE Camunda.Orchestration.Sdk.ProcessDefinitionStatisticsFilter : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.BaseProcessInstanceFilterFields>? Or { get; set; } [JsonPropertyName("$or")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.Tag>? Tags { get; set; } [JsonPropertyName("tags")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.VariableValueFilterProperty>? Variables { get; set; } [JsonPropertyName("variables")]
+
+TYPE Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.StringFilterProperty? Name { get; set; } [JsonPropertyName("name")]
+
+TYPE Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameSearchQuery : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameFilter? Filter { get; set; } [JsonPropertyName("filter")]
+  PROP Camunda.Orchestration.Sdk.SearchQueryPageRequest? Page { get; set; } [JsonPropertyName("page")]
+
+TYPE Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameSearchQueryResult : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameSearchResult> Items { get; set; } [JsonPropertyName("items")]
+
+TYPE Camunda.Orchestration.Sdk.ProcessDefinitionVariableNameSearchResult : sealed class
+  CTOR ()
+  PROP System.String Name { get; set; } [JsonPropertyName("name")]
 
 TYPE Camunda.Orchestration.Sdk.ProcessElementStatisticsResult : sealed class
   CTOR ()


### PR DESCRIPTION
## Description

Adds example coverage for the `searchProcessDefinitionVariableNames` operation (`POST /process-definitions/{processDefinitionKey}/variable-names/search`, tag `Process definition`, added in 8.10), closing the coverage gap reported in #331.

- Add a `SearchProcessDefinitionVariableNames` region example to `examples/ProcessDefinition.cs`, calling `SearchProcessDefinitionVariableNamesAsync(processDefinitionKey, new ProcessDefinitionVariableNameSearchQuery())` and printing each `variable.Name`.
- Add the `searchProcessDefinitionVariableNames` entry to `examples/operation-map.json`.
- Add the DocFX overwrite block for `SearchProcessDefinitionVariableNamesAsync` in `docs/overwrite/CamundaClient.md`.

Regenerating pulled the latest upstream spec, so the regen commit also carries expected unrelated drift: a new `isDeleted` filter property on process-definition filters and a newly inserted permission enum member (which renumbers subsequent members). The public API baseline (`PublicApi.shipped.txt`) was refreshed accordingly.

Changes are split per the repo's two-commit rule:
1. `docs:` — hand-written example + operation-map + overwrite entry
2. `chore(gen):` — regenerated bundled spec, `Generated/*`, and public API baseline

## Verification

- Example coverage: 100% (198/198)
- Overwrite completeness: pass
- `dotnet build docs/examples/Examples.csproj`: 0 warnings/errors
- Unit tests: 1095 passed
- README snippets: in sync

Closes #331
