### PR TITLE
docs: add examples for process instance suspend/resume/business-id operations

### DIFF
--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -1283,6 +1283,36 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.SuspendProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey,Camunda.Orchestration.Sdk.SuspendProcessInstanceRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/ProcessInstance.cs#SuspendProcessInstance)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.ResumeProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey,Camunda.Orchestration.Sdk.ResumeProcessInstanceRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/ProcessInstance.cs#ResumeProcessInstance)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.AssignProcessInstanceBusinessIdAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey,Camunda.Orchestration.Sdk.ProcessInstanceBusinessIdAssignmentInstruction,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/ProcessInstance.cs#AssignProcessInstanceBusinessId)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.RestoreAsync(Camunda.Orchestration.Sdk.RestoreRequest,System.Threading.CancellationToken)
 example:
 - *content
@@ -1310,6 +1340,26 @@ example:
 
 
 [!code-csharp[](../../examples/BatchOperation.cs#ResumeBatchOperation)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.SuspendProcessInstancesBatchOperationAsync(Camunda.Orchestration.Sdk.ProcessInstanceSuspensionBatchOperationRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/BatchOperation.cs#SuspendProcessInstancesBatchOperation)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.ResumeProcessInstancesBatchOperationAsync(Camunda.Orchestration.Sdk.ProcessInstanceResumptionBatchOperationRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/BatchOperation.cs#ResumeProcessInstancesBatchOperation)]
 
 
 ---

--- a/examples/BatchOperation.cs
+++ b/examples/BatchOperation.cs
@@ -208,4 +208,40 @@ public static class BatchOperationExamples
     }
     // </UpdateJobsBatchOperation>
     #endregion UpdateJobsBatchOperation
+
+    #region SuspendProcessInstancesBatchOperation
+
+    // <SuspendProcessInstancesBatchOperation>
+    public static async Task SuspendProcessInstancesBatchOperationExample()
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.SuspendProcessInstancesBatchOperationAsync(
+            new ProcessInstanceSuspensionBatchOperationRequest
+            {
+                Filter = new ProcessInstanceFilter(),
+            });
+
+        Console.WriteLine($"Batch operation key: {result.BatchOperationKey}");
+    }
+    // </SuspendProcessInstancesBatchOperation>
+    #endregion SuspendProcessInstancesBatchOperation
+
+    #region ResumeProcessInstancesBatchOperation
+
+    // <ResumeProcessInstancesBatchOperation>
+    public static async Task ResumeProcessInstancesBatchOperationExample()
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.ResumeProcessInstancesBatchOperationAsync(
+            new ProcessInstanceResumptionBatchOperationRequest
+            {
+                Filter = new ProcessInstanceFilter(),
+            });
+
+        Console.WriteLine($"Batch operation key: {result.BatchOperationKey}");
+    }
+    // </ResumeProcessInstancesBatchOperation>
+    #endregion ResumeProcessInstancesBatchOperation
 }

--- a/examples/ProcessInstance.cs
+++ b/examples/ProcessInstance.cs
@@ -228,4 +228,49 @@ public static class ProcessInstanceExamples
     }
     // </ResolveProcessInstanceIncidents>
     #endregion ResolveProcessInstanceIncidents
+
+    #region SuspendProcessInstance
+
+    // <SuspendProcessInstance>
+    public static async Task SuspendProcessInstanceExample(ProcessInstanceKey processInstanceKey)
+    {
+        using var client = CamundaClient.Create();
+
+        await client.SuspendProcessInstanceAsync(
+            processInstanceKey,
+            new SuspendProcessInstanceRequest());
+    }
+    // </SuspendProcessInstance>
+    #endregion SuspendProcessInstance
+
+    #region ResumeProcessInstance
+
+    // <ResumeProcessInstance>
+    public static async Task ResumeProcessInstanceExample(ProcessInstanceKey processInstanceKey)
+    {
+        using var client = CamundaClient.Create();
+
+        await client.ResumeProcessInstanceAsync(
+            processInstanceKey,
+            new ResumeProcessInstanceRequest());
+    }
+    // </ResumeProcessInstance>
+    #endregion ResumeProcessInstance
+
+    #region AssignProcessInstanceBusinessId
+
+    // <AssignProcessInstanceBusinessId>
+    public static async Task AssignProcessInstanceBusinessIdExample(ProcessInstanceKey processInstanceKey, BusinessId businessId)
+    {
+        using var client = CamundaClient.Create();
+
+        await client.AssignProcessInstanceBusinessIdAsync(
+            processInstanceKey,
+            new ProcessInstanceBusinessIdAssignmentInstruction
+            {
+                BusinessId = businessId,
+            });
+    }
+    // </AssignProcessInstanceBusinessId>
+    #endregion AssignProcessInstanceBusinessId
 }

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -158,6 +158,27 @@
       "label": "Resolve process instance incidents"
     }
   ],
+  "suspendProcessInstance": [
+    {
+      "file": "ProcessInstance.cs",
+      "region": "SuspendProcessInstance",
+      "label": "Suspend a process instance"
+    }
+  ],
+  "resumeProcessInstance": [
+    {
+      "file": "ProcessInstance.cs",
+      "region": "ResumeProcessInstance",
+      "label": "Resume a process instance"
+    }
+  ],
+  "assignProcessInstanceBusinessId": [
+    {
+      "file": "ProcessInstance.cs",
+      "region": "AssignProcessInstanceBusinessId",
+      "label": "Assign a business ID to a process instance"
+    }
+  ],
   "getProcessDefinition": [
     {
       "file": "ProcessDefinition.cs",
@@ -1078,6 +1099,20 @@
       "file": "BatchOperation.cs",
       "region": "UpdateJobsBatchOperation",
       "label": "Update jobs in batch"
+    }
+  ],
+  "suspendProcessInstancesBatchOperation": [
+    {
+      "file": "BatchOperation.cs",
+      "region": "SuspendProcessInstancesBatchOperation",
+      "label": "Suspend process instances in batch"
+    }
+  ],
+  "resumeProcessInstancesBatchOperation": [
+    {
+      "file": "BatchOperation.cs",
+      "region": "ResumeProcessInstancesBatchOperation",
+      "label": "Resume process instances in batch"
     }
   ],
   "getVariable": [

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -12482,6 +12482,109 @@
         "x-added-in-version": "8.8"
       }
     },
+    "/process-instances/resumption": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Process instance"
+        ],
+        "operationId": "resumeProcessInstancesBatchOperation",
+        "x-required-permissions": [
+          {
+            "anyOf": [
+              {
+                "resourceType": "BATCH",
+                "permissionType": "CREATE"
+              },
+              {
+                "resourceType": "BATCH",
+                "permissionType": "CREATE_BATCH_OPERATION_SUSPEND_PROCESS_INSTANCE"
+              }
+            ]
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Resume process instances (batch)",
+        "description": "Resumes multiple suspended process instances.\nSince only SUSPENDED root instances can be resumed, any given filters for state and\nparentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProcessInstanceResumptionBatchOperationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The batch operation request was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperationCreatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The process instance batch operation failed. More details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/process-instances/search": {
       "post": {
         "x-eventually-consistent": true,
@@ -12576,6 +12679,109 @@
           }
         },
         "x-added-in-version": "8.6"
+      }
+    },
+    "/process-instances/suspension": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Process instance"
+        ],
+        "operationId": "suspendProcessInstancesBatchOperation",
+        "x-required-permissions": [
+          {
+            "anyOf": [
+              {
+                "resourceType": "BATCH",
+                "permissionType": "CREATE"
+              },
+              {
+                "resourceType": "BATCH",
+                "permissionType": "CREATE_BATCH_OPERATION_SUSPEND_PROCESS_INSTANCE"
+              }
+            ]
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Suspend process instances (batch)",
+        "description": "Suspends multiple running process instances.\nSince only ACTIVE root instances can be suspended, any given filters for state and\nparentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProcessInstanceSuspensionBatchOperationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The batch operation request was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperationCreatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The process instance batch operation failed. More details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. The request is not allowed.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
       }
     },
     "/process-instances/{processInstanceKey}": {
@@ -12682,6 +12888,108 @@
           }
         },
         "x-added-in-version": "8.8"
+      }
+    },
+    "/process-instances/{processInstanceKey}/business-id-assignment": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Process instance"
+        ],
+        "operationId": "assignProcessInstanceBusinessId",
+        "x-required-permissions": [
+          {
+            "resourceType": "PROCESS_DEFINITION",
+            "permissionType": "UPDATE_PROCESS_INSTANCE"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Assign business id to process instance",
+        "description": "Assigns a business id to an already-running process instance that currently has none.\n\nThe assignment is single and irreversible: only artifacts created after the assignment\n(for example future jobs, user tasks, decision instances, and message subscriptions) carry\nthe business id, while existing artifacts are not retroactively enriched. Re-sending the\nsame business id succeeds as a no-op. This endpoint is only useful while business id\nuniqueness enforcement is disabled; when it is enabled, the request is rejected with a 409\nresponse.\n",
+        "parameters": [
+          {
+            "name": "processInstanceKey",
+            "in": "path",
+            "required": true,
+            "description": "The key of the process instance to assign the business id to.",
+            "schema": {
+              "$ref": "#/components/schemas/ProcessInstanceKey"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProcessInstanceBusinessIdAssignmentInstruction"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "The business id is assigned to the process instance."
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The process instance is not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The business id assignment failed because the process instance is not eligible, for example it already has a different business id, it is a call-activity child, or business id uniqueness enforcement is enabled. More details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
       }
     },
     "/process-instances/{processInstanceKey}/call-hierarchy": {
@@ -13441,6 +13749,108 @@
         "x-added-in-version": "8.6"
       }
     },
+    "/process-instances/{processInstanceKey}/resumption": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Process instance"
+        ],
+        "operationId": "resumeProcessInstance",
+        "x-required-permissions": [
+          {
+            "resourceType": "PROCESS_DEFINITION",
+            "permissionType": "SUSPEND_PROCESS_INSTANCE"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Resume process instance",
+        "description": "Resumes a suspended process instance, returning it to the ACTIVE state and continuing processing.\nOnly process instances in the SUSPENDED state can be resumed.\n",
+        "parameters": [
+          {
+            "name": "processInstanceKey",
+            "in": "path",
+            "required": true,
+            "description": "The key of the process instance to resume.",
+            "schema": {
+              "$ref": "#/components/schemas/ProcessInstanceKey"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResumeProcessInstanceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "The process instance is resumed."
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The process instance is not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The process instance is not in the SUSPENDED state and cannot be resumed.\nMore details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/process-instances/{processInstanceKey}/sequence-flows": {
       "get": {
         "x-eventually-consistent": true,
@@ -13719,6 +14129,108 @@
           },
           "500": {
             "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
+    "/process-instances/{processInstanceKey}/suspension": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Process instance"
+        ],
+        "operationId": "suspendProcessInstance",
+        "x-required-permissions": [
+          {
+            "resourceType": "PROCESS_DEFINITION",
+            "permissionType": "SUSPEND_PROCESS_INSTANCE"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Suspend process instance",
+        "description": "Suspends a running process instance, pausing further processing until it is resumed.\nOnly process instances in the ACTIVE state can be suspended.\n",
+        "parameters": [
+          {
+            "name": "processInstanceKey",
+            "in": "path",
+            "required": true,
+            "description": "The key of the process instance to suspend.",
+            "schema": {
+              "$ref": "#/components/schemas/ProcessInstanceKey"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SuspendProcessInstanceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "The process instance is suspended."
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The process instance is not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The process instance is not in the ACTIVE state and cannot be suspended.\nMore details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -21259,7 +21771,7 @@
         ],
         "properties": {
           "elementInstanceKey": {
-            "description": "The key of the AHSP or AI Agent Task element instance.\nThe engine uses this key to infer processInstanceKey, elementId,\nprocessDefinitionKey, and tenantId.\n",
+            "description": "The key of the AI Agent Sub-process or AI Agent Task element instance.\nThe engine uses this key to infer processInstanceKey, elementId,\nprocessDefinitionKey, and tenantId.\n",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ElementInstanceKey"
@@ -21740,7 +22252,8 @@
             }
           },
           "metrics": {
-            "description": "Per-call token and latency metrics. Zero-valued when not available.",
+            "description": "Per-call token and latency metrics. Null when metrics were not provided at creation time.",
+            "nullable": true,
             "allOf": [
               {
                 "$ref": "#/components/schemas/AgentInstanceHistoryItemMetrics"
@@ -21919,17 +22432,20 @@
         ],
         "properties": {
           "inputTokens": {
-            "description": "Input tokens consumed by this LLM call.",
+            "description": "Input tokens consumed by this LLM call. Null when not provided.",
+            "nullable": true,
             "type": "integer",
             "format": "int64"
           },
           "outputTokens": {
-            "description": "Output tokens produced by this LLM call.",
+            "description": "Output tokens produced by this LLM call. Null when not provided.",
+            "nullable": true,
             "type": "integer",
             "format": "int64"
           },
           "durationMs": {
-            "description": "Wall-clock duration of the LLM call in milliseconds.",
+            "description": "Wall-clock duration of the LLM call in milliseconds. Null when not provided.",
+            "nullable": true,
             "type": "integer",
             "format": "int64"
           }
@@ -24215,6 +24731,48 @@
           "targetElementId"
         ]
       },
+      "ProcessInstanceSuspensionBatchOperationRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "The process instance filter that defines which process instances should be suspended.",
+        "properties": {
+          "filter": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessInstanceFilter"
+              }
+            ],
+            "description": "The process instance filter."
+          },
+          "operationReference": {
+            "$ref": "#/components/schemas/OperationReference"
+          }
+        },
+        "required": [
+          "filter"
+        ]
+      },
+      "ProcessInstanceResumptionBatchOperationRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "The process instance filter that defines which process instances should be resumed.",
+        "properties": {
+          "filter": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessInstanceFilter"
+              }
+            ],
+            "description": "The process instance filter."
+          },
+          "operationReference": {
+            "$ref": "#/components/schemas/OperationReference"
+          }
+        },
+        "required": [
+          "filter"
+        ]
+      },
       "BatchOperationItemStateEnum": {
         "description": "The batch operation item state.",
         "type": "string",
@@ -24251,6 +24809,8 @@
           "MIGRATE_PROCESS_INSTANCE",
           "MODIFY_PROCESS_INSTANCE",
           "RESOLVE_INCIDENT",
+          "RESUME_PROCESS_INSTANCE",
+          "SUSPEND_PROCESS_INSTANCE",
           "UPDATE_JOB",
           "UPDATE_VARIABLE"
         ]
@@ -24461,8 +25021,29 @@
           "value": {
             "type": "object",
             "description": "The value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses."
+          },
+          "metadata": {
+            "description": "A generic key-value metadata bag attached to the cluster variable. Values must be strings or numbers. Limited to 100 entries and a configurable maximum serialized size (default: 100 entries at max key length of a cluster variable name (256 chars) plus the maximum value length, 8192 characters).",
+            "type": "object",
+            "maxProperties": 100,
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "metadata",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "UpdateClusterVariableRequest": {
         "type": "object",
@@ -24473,8 +25054,29 @@
           "value": {
             "type": "object",
             "description": "The new value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses."
+          },
+          "metadata": {
+            "description": "A generic key-value metadata bag attached to the cluster variable. Values must be strings or numbers. Limited to 100 entries and a configurable maximum serialized size (default: 100 entries at max key length of a cluster variable name (256 chars) plus the maximum value length, 8192 characters).",
+            "type": "object",
+            "maxProperties": 100,
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "metadata",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "ClusterVariableResult": {
         "type": "object",
@@ -24520,6 +25122,7 @@
         "description": "Cluster variable response item.",
         "type": "object",
         "required": [
+          "metadata",
           "name",
           "scope",
           "tenantId"
@@ -24540,8 +25143,29 @@
             "type": "string",
             "nullable": true,
             "description": "Only provided if the cluster variable scope is TENANT. Null for global scope variables."
+          },
+          "metadata": {
+            "description": "A generic key-value metadata bag attached to the cluster variable. Values are strings or numbers.",
+            "type": "object",
+            "maxProperties": 100,
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "metadata",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "ClusterVariableSearchQueryRequest": {
         "description": "Cluster variable search query request.",
@@ -37164,6 +37788,26 @@
           }
         }
       },
+      "SuspendProcessInstanceRequest": {
+        "type": "object",
+        "nullable": true,
+        "additionalProperties": false,
+        "properties": {
+          "operationReference": {
+            "$ref": "#/components/schemas/OperationReference"
+          }
+        }
+      },
+      "ResumeProcessInstanceRequest": {
+        "type": "object",
+        "nullable": true,
+        "additionalProperties": false,
+        "properties": {
+          "operationReference": {
+            "$ref": "#/components/schemas/OperationReference"
+          }
+        }
+      },
       "ProcessInstanceCallHierarchyEntry": {
         "type": "object",
         "required": [
@@ -37397,6 +38041,19 @@
             "propertyName": "targetElementId",
             "addedInVersion": "8.6"
           }
+        ]
+      },
+      "ProcessInstanceBusinessIdAssignmentInstruction": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "The instruction describing the business id to assign to a running process instance.\n",
+        "properties": {
+          "businessId": {
+            "$ref": "#/components/schemas/BusinessId"
+          }
+        },
+        "required": [
+          "businessId"
         ]
       },
       "ProcessInstanceModificationInstruction": {

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:83242850b1f3570de5fa8fb6d52f4741286347f3e1601c4f58617dd28211974e",
+  "specHash": "sha256:16fd114798a5e976be4d3d59829256c4e783a6ab29bc8ca2b4060cd37266c86d",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -7632,6 +7632,49 @@
       }
     },
     {
+      "operationId": "resumeProcessInstancesBatchOperation",
+      "path": "/process-instances/resumption",
+      "method": "post",
+      "tags": [
+        "Process instance"
+      ],
+      "summary": "Resume process instances (batch)",
+      "description": "Resumes multiple suspended process instances.\nSince only SUSPENDED root instances can be resumed, any given filters for state and\nparentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": true,
+      "pathParams": [],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "process-instances.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "ProcessInstanceResumptionBatchOperationRequest",
+      "successResponseSchemaRef": "BatchOperationCreatedResult",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [
+          {
+            "anyOf": [
+              {
+                "resourceType": "BATCH",
+                "permissionType": "CREATE"
+              },
+              {
+                "resourceType": "BATCH",
+                "permissionType": "CREATE_BATCH_OPERATION_SUSPEND_PROCESS_INSTANCE"
+              }
+            ]
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "searchProcessInstances",
       "path": "/process-instances/search",
       "method": "post",
@@ -7668,6 +7711,49 @@
       }
     },
     {
+      "operationId": "suspendProcessInstancesBatchOperation",
+      "path": "/process-instances/suspension",
+      "method": "post",
+      "tags": [
+        "Process instance"
+      ],
+      "summary": "Suspend process instances (batch)",
+      "description": "Suspends multiple running process instances.\nSince only ACTIVE root instances can be suspended, any given filters for state and\nparentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": true,
+      "pathParams": [],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "process-instances.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "ProcessInstanceSuspensionBatchOperationRequest",
+      "successResponseSchemaRef": "BatchOperationCreatedResult",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [
+          {
+            "anyOf": [
+              {
+                "resourceType": "BATCH",
+                "permissionType": "CREATE"
+              },
+              {
+                "resourceType": "BATCH",
+                "permissionType": "CREATE_BATCH_OPERATION_SUSPEND_PROCESS_INSTANCE"
+              }
+            ]
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "getProcessInstance",
       "path": "/process-instances/{processInstanceKey}",
       "method": "get",
@@ -7699,6 +7785,42 @@
           }
         ],
         "x-added-in-version": "8.8"
+      }
+    },
+    {
+      "operationId": "assignProcessInstanceBusinessId",
+      "path": "/process-instances/{processInstanceKey}/business-id-assignment",
+      "method": "post",
+      "tags": [
+        "Process instance"
+      ],
+      "summary": "Assign business id to process instance",
+      "description": "Assigns a business id to an already-running process instance that currently has none.\n\nThe assignment is single and irreversible: only artifacts created after the assignment\n(for example future jobs, user tasks, decision instances, and message subscriptions) carry\nthe business id, while existing artifacts are not retroactively enriched. Re-sending the\nsame business id succeeds as a no-op. This endpoint is only useful while business id\nuniqueness enforcement is disabled; when it is enabled, the request is rejected with a 409\nresponse.\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [
+        "processInstanceKey"
+      ],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "process-instances.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "ProcessInstanceBusinessIdAssignmentInstruction",
+      "successStatus": 204,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [
+          {
+            "resourceType": "PROCESS_DEFINITION",
+            "permissionType": "UPDATE_PROCESS_INSTANCE"
+          }
+        ],
+        "x-added-in-version": "8.10"
       }
     },
     {
@@ -7950,6 +8072,42 @@
       }
     },
     {
+      "operationId": "resumeProcessInstance",
+      "path": "/process-instances/{processInstanceKey}/resumption",
+      "method": "post",
+      "tags": [
+        "Process instance"
+      ],
+      "summary": "Resume process instance",
+      "description": "Resumes a suspended process instance, returning it to the ACTIVE state and continuing processing.\nOnly process instances in the SUSPENDED state can be resumed.\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [
+        "processInstanceKey"
+      ],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "process-instances.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "ResumeProcessInstanceRequest",
+      "successStatus": 204,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [
+          {
+            "resourceType": "PROCESS_DEFINITION",
+            "permissionType": "SUSPEND_PROCESS_INSTANCE"
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "getProcessInstanceSequenceFlows",
       "path": "/process-instances/{processInstanceKey}/sequence-flows",
       "method": "get",
@@ -8048,6 +8206,42 @@
           {
             "resourceType": "PROCESS_DEFINITION",
             "permissionType": "READ_PROCESS_INSTANCE"
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
+      "operationId": "suspendProcessInstance",
+      "path": "/process-instances/{processInstanceKey}/suspension",
+      "method": "post",
+      "tags": [
+        "Process instance"
+      ],
+      "summary": "Suspend process instance",
+      "description": "Suspends a running process instance, pausing further processing until it is resumed.\nOnly process instances in the ACTIVE state can be suspended.\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [
+        "processInstanceKey"
+      ],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "process-instances.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "SuspendProcessInstanceRequest",
+      "successStatus": 204,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [
+          {
+            "resourceType": "PROCESS_DEFINITION",
+            "permissionType": "SUSPEND_PROCESS_INSTANCE"
           }
         ],
         "x-added-in-version": "8.10"
@@ -11154,7 +11348,7 @@
   "integrity": {
     "totalSemanticKeys": 41,
     "totalUnions": 64,
-    "totalOperations": 198,
+    "totalOperations": 203,
     "totalEventuallyConsistent": 92,
     "totalDeprecatedEnumSchemas": 2,
     "totalSemanticProviders": 23

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -289,6 +289,57 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Assign business id to process instance
+    /// Assigns a business id to an already-running process instance that currently has none.
+    /// 
+    /// The assignment is single and irreversible: only artifacts created after the assignment
+    /// (for example future jobs, user tasks, decision instances, and message subscriptions) carry
+    /// the business id, while existing artifacts are not retroactively enriched. Re-sending the
+    /// same business id succeeds as a no-op. This endpoint is only useful while business id
+    /// uniqueness enforcement is disabled; when it is enabled, the request is rejected with a 409
+    /// response.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: assignProcessInstanceBusinessId
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task AssignProcessInstanceBusinessIdExample(ProcessInstanceKey processInstanceKey, BusinessId businessId)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     await client.AssignProcessInstanceBusinessIdAsync(
+    ///         processInstanceKey,
+    ///         new ProcessInstanceBusinessIdAssignmentInstruction
+    ///         {
+    ///             BusinessId = businessId,
+    ///         });
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task AssignProcessInstanceBusinessIdExample(ProcessInstanceKey processInstanceKey, BusinessId businessId)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     await client.AssignProcessInstanceBusinessIdAsync(
+    ///         processInstanceKey,
+    ///         new ProcessInstanceBusinessIdAssignmentInstruction
+    ///         {
+    ///             BusinessId = businessId,
+    ///         });
+    /// }
+    /// </code>
+    /// </example>
+    public async Task AssignProcessInstanceBusinessIdAsync(ProcessInstanceKey processInstanceKey, ProcessInstanceBusinessIdAssignmentInstruction body, CancellationToken ct = default)
+    {
+        var path = $"/process-instances/{Uri.EscapeDataString(processInstanceKey.ToString()!)}/business-id-assignment";
+        await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Post, path, body, ct); return 0; }, "assignProcessInstanceBusinessId", false, ct);
+    }
+
+    /// <summary>
     /// Assign a role to a client
     /// Assigns the specified role to the client. The client will inherit the authorizations associated with this role.
     /// </summary>
@@ -5609,6 +5660,94 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Resume process instance
+    /// Resumes a suspended process instance, returning it to the ACTIVE state and continuing processing.
+    /// Only process instances in the SUSPENDED state can be resumed.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: resumeProcessInstance
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ResumeProcessInstanceExample(ProcessInstanceKey processInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     await client.ResumeProcessInstanceAsync(
+    ///         processInstanceKey,
+    ///         new ResumeProcessInstanceRequest());
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ResumeProcessInstanceExample(ProcessInstanceKey processInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     await client.ResumeProcessInstanceAsync(
+    ///         processInstanceKey,
+    ///         new ResumeProcessInstanceRequest());
+    /// }
+    /// </code>
+    /// </example>
+    public async Task ResumeProcessInstanceAsync(ProcessInstanceKey processInstanceKey, ResumeProcessInstanceRequest body, CancellationToken ct = default)
+    {
+        var path = $"/process-instances/{Uri.EscapeDataString(processInstanceKey.ToString()!)}/resumption";
+        await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Post, path, body, ct); return 0; }, "resumeProcessInstance", false, ct);
+    }
+
+    /// <summary>
+    /// Resume process instances (batch)
+    /// Resumes multiple suspended process instances.
+    /// Since only SUSPENDED root instances can be resumed, any given filters for state and
+    /// parentProcessInstanceKey are ignored and overridden during this batch operation.
+    /// This is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: resumeProcessInstancesBatchOperation
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ResumeProcessInstancesBatchOperationExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.ResumeProcessInstancesBatchOperationAsync(
+    ///         new ProcessInstanceResumptionBatchOperationRequest
+    ///         {
+    ///             Filter = new ProcessInstanceFilter(),
+    ///         });
+    /// 
+    ///     Console.WriteLine($&quot;Batch operation key: {result.BatchOperationKey}&quot;);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ResumeProcessInstancesBatchOperationExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.ResumeProcessInstancesBatchOperationAsync(
+    ///         new ProcessInstanceResumptionBatchOperationRequest
+    ///         {
+    ///             Filter = new ProcessInstanceFilter(),
+    ///         });
+    /// 
+    ///     Console.WriteLine($&quot;Batch operation key: {result.BatchOperationKey}&quot;);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<BatchOperationCreatedResult> ResumeProcessInstancesBatchOperationAsync(ProcessInstanceResumptionBatchOperationRequest body, CancellationToken ct = default)
+    {
+        var path = $"/process-instances/resumption";
+        return await InvokeWithRetryAsync(() => SendAsync<BatchOperationCreatedResult>(HttpMethod.Post, path, body, ct), "resumeProcessInstancesBatchOperation", false, ct);
+    }
+
+    /// <summary>
     /// Search agent instance history
     /// Searches the conversation history of an agent instance. Committed items
     /// are returned by default.
@@ -8166,6 +8305,94 @@ public partial class CamundaClient
     {
         var path = $"/batch-operations/{Uri.EscapeDataString(batchOperationKey.ToString()!)}/suspension";
         await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Post, path, null, ct); return 0; }, "suspendBatchOperation", false, ct);
+    }
+
+    /// <summary>
+    /// Suspend process instance
+    /// Suspends a running process instance, pausing further processing until it is resumed.
+    /// Only process instances in the ACTIVE state can be suspended.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: suspendProcessInstance
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SuspendProcessInstanceExample(ProcessInstanceKey processInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     await client.SuspendProcessInstanceAsync(
+    ///         processInstanceKey,
+    ///         new SuspendProcessInstanceRequest());
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SuspendProcessInstanceExample(ProcessInstanceKey processInstanceKey)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     await client.SuspendProcessInstanceAsync(
+    ///         processInstanceKey,
+    ///         new SuspendProcessInstanceRequest());
+    /// }
+    /// </code>
+    /// </example>
+    public async Task SuspendProcessInstanceAsync(ProcessInstanceKey processInstanceKey, SuspendProcessInstanceRequest body, CancellationToken ct = default)
+    {
+        var path = $"/process-instances/{Uri.EscapeDataString(processInstanceKey.ToString()!)}/suspension";
+        await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Post, path, body, ct); return 0; }, "suspendProcessInstance", false, ct);
+    }
+
+    /// <summary>
+    /// Suspend process instances (batch)
+    /// Suspends multiple running process instances.
+    /// Since only ACTIVE root instances can be suspended, any given filters for state and
+    /// parentProcessInstanceKey are ignored and overridden during this batch operation.
+    /// This is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: suspendProcessInstancesBatchOperation
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SuspendProcessInstancesBatchOperationExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SuspendProcessInstancesBatchOperationAsync(
+    ///         new ProcessInstanceSuspensionBatchOperationRequest
+    ///         {
+    ///             Filter = new ProcessInstanceFilter(),
+    ///         });
+    /// 
+    ///     Console.WriteLine($&quot;Batch operation key: {result.BatchOperationKey}&quot;);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task SuspendProcessInstancesBatchOperationExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.SuspendProcessInstancesBatchOperationAsync(
+    ///         new ProcessInstanceSuspensionBatchOperationRequest
+    ///         {
+    ///             Filter = new ProcessInstanceFilter(),
+    ///         });
+    /// 
+    ///     Console.WriteLine($&quot;Batch operation key: {result.BatchOperationKey}&quot;);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<BatchOperationCreatedResult> SuspendProcessInstancesBatchOperationAsync(ProcessInstanceSuspensionBatchOperationRequest body, CancellationToken ct = default)
+    {
+        var path = $"/process-instances/suspension";
+        return await InvokeWithRetryAsync(() => SendAsync<BatchOperationCreatedResult>(HttpMethod.Post, path, body, ct), "suspendProcessInstancesBatchOperation", false, ct);
     }
 
     /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -3592,7 +3592,7 @@ internal sealed class AgentHistoryItemKeyFilterPropertyJsonConverter : global::S
 public sealed class AgentInstanceCreationRequest
 {
     /// <summary>
-    /// The key of the AHSP or AI Agent Task element instance.
+    /// The key of the AI Agent Sub-process or AI Agent Task element instance.
     /// The engine uses this key to infer processInstanceKey, elementId,
     /// processDefinitionKey, and tenantId.
     /// 
@@ -3980,22 +3980,22 @@ public sealed class AgentInstanceHistoryItemCreationResult
 public sealed class AgentInstanceHistoryItemMetrics
 {
     /// <summary>
-    /// Input tokens consumed by this LLM call.
+    /// Input tokens consumed by this LLM call. Null when not provided.
     /// </summary>
     [JsonPropertyName("inputTokens")]
-    public long InputTokens { get; set; }
+    public long? InputTokens { get; set; }
 
     /// <summary>
-    /// Output tokens produced by this LLM call.
+    /// Output tokens produced by this LLM call. Null when not provided.
     /// </summary>
     [JsonPropertyName("outputTokens")]
-    public long OutputTokens { get; set; }
+    public long? OutputTokens { get; set; }
 
     /// <summary>
-    /// Wall-clock duration of the LLM call in milliseconds.
+    /// Wall-clock duration of the LLM call in milliseconds. Null when not provided.
     /// </summary>
     [JsonPropertyName("durationMs")]
-    public long DurationMs { get; set; }
+    public long? DurationMs { get; set; }
 
 }
 
@@ -4134,10 +4134,10 @@ public sealed class AgentInstanceHistoryItemResult
     public List<AgentInstanceToolCall> ToolCalls { get; set; } = null!;
 
     /// <summary>
-    /// Per-call token and latency metrics. Zero-valued when not available.
+    /// Per-call token and latency metrics. Null when metrics were not provided at creation time.
     /// </summary>
     [JsonPropertyName("metrics")]
-    public AgentInstanceHistoryItemMetrics Metrics { get; set; } = null!;
+    public AgentInstanceHistoryItemMetrics? Metrics { get; set; }
 
     /// <summary>
     /// The commit status of this history item.
@@ -7751,6 +7751,10 @@ public enum BatchOperationTypeEnum
     MODIFYPROCESSINSTANCE,
     [JsonPropertyName("RESOLVE_INCIDENT")]
     RESOLVEINCIDENT,
+    [JsonPropertyName("RESUME_PROCESS_INSTANCE")]
+    RESUMEPROCESSINSTANCE,
+    [JsonPropertyName("SUSPEND_PROCESS_INSTANCE")]
+    SUSPENDPROCESSINSTANCE,
     [JsonPropertyName("UPDATE_JOB")]
     UPDATEJOB,
     [JsonPropertyName("UPDATE_VARIABLE")]
@@ -8430,6 +8434,12 @@ public sealed class ClusterVariableResult
     [JsonPropertyName("tenantId")]
     public string? TenantId { get; set; }
 
+    /// <summary>
+    /// A generic key-value metadata bag attached to the cluster variable. Values are strings or numbers.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object> Metadata { get; set; } = null!;
+
 }
 
 /// <summary>
@@ -8454,6 +8464,12 @@ public sealed class ClusterVariableResultBase
     /// </summary>
     [JsonPropertyName("tenantId")]
     public string? TenantId { get; set; }
+
+    /// <summary>
+    /// A generic key-value metadata bag attached to the cluster variable. Values are strings or numbers.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object> Metadata { get; set; } = null!;
 
 }
 
@@ -8754,6 +8770,12 @@ public sealed class ClusterVariableSearchResult
     /// </summary>
     [JsonPropertyName("tenantId")]
     public string? TenantId { get; set; }
+
+    /// <summary>
+    /// A generic key-value metadata bag attached to the cluster variable. Values are strings or numbers.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object> Metadata { get; set; } = null!;
 
 }
 
@@ -9119,6 +9141,12 @@ public sealed class CreateClusterVariableRequest
     /// </summary>
     [JsonPropertyName("value")]
     public object Value { get; set; } = null!;
+
+    /// <summary>
+    /// A generic key-value metadata bag attached to the cluster variable. Values must be strings or numbers. Limited to 100 entries and a configurable maximum serialized size (default: 100 entries at max key length of a cluster variable name (256 chars) plus the maximum value length, 8192 characters).
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object>? Metadata { get; set; }
 
 }
 
@@ -20935,6 +20963,25 @@ public sealed class ProcessElementStatisticsResult
 }
 
 /// <summary>
+/// The instruction describing the business id to assign to a running process instance.
+/// 
+/// </summary>
+public sealed class ProcessInstanceBusinessIdAssignmentInstruction
+{
+    /// <summary>
+    /// An optional, user-defined string identifier that identifies the process instance
+    /// within the scope of a process definition (scoped by tenant). If provided and uniqueness
+    /// enforcement is enabled, the engine will reject creation if another root process instance
+    /// with the same business id is already active for the same process definition.
+    /// Note that any active child process instances with the same business id are not taken into account.
+    /// 
+    /// </summary>
+    [JsonPropertyName("businessId")]
+    public BusinessId BusinessId { get; set; }
+
+}
+
+/// <summary>
 /// ProcessInstanceCallHierarchyEntry
 /// </summary>
 public sealed class ProcessInstanceCallHierarchyEntry
@@ -22235,6 +22282,27 @@ public sealed class ProcessInstanceResult
 }
 
 /// <summary>
+/// The process instance filter that defines which process instances should be resumed.
+/// </summary>
+public sealed class ProcessInstanceResumptionBatchOperationRequest
+{
+    /// <summary>
+    /// The process instance filter.
+    /// </summary>
+    [JsonPropertyName("filter")]
+    public ProcessInstanceFilter Filter { get; set; } = null!;
+
+    /// <summary>
+    /// A reference key chosen by the user that will be part of all records resulting from this operation.
+    /// Must be &gt; 0 if provided.
+    /// 
+    /// </summary>
+    [JsonPropertyName("operationReference")]
+    public OperationReference? OperationReference { get; set; }
+
+}
+
+/// <summary>
 /// Process instance search request.
 /// </summary>
 public sealed class ProcessInstanceSearchQuery
@@ -22524,6 +22592,27 @@ internal sealed class ProcessInstanceStateFilterPropertyJsonConverter : global::
         }
         writer.WriteEndObject();
     }
+}
+
+/// <summary>
+/// The process instance filter that defines which process instances should be suspended.
+/// </summary>
+public sealed class ProcessInstanceSuspensionBatchOperationRequest
+{
+    /// <summary>
+    /// The process instance filter.
+    /// </summary>
+    [JsonPropertyName("filter")]
+    public ProcessInstanceFilter Filter { get; set; } = null!;
+
+    /// <summary>
+    /// A reference key chosen by the user that will be part of all records resulting from this operation.
+    /// Must be &gt; 0 if provided.
+    /// 
+    /// </summary>
+    [JsonPropertyName("operationReference")]
+    public OperationReference? OperationReference { get; set; }
+
 }
 
 /// <summary>
@@ -22985,6 +23074,21 @@ public sealed class RestoreRequest
     /// </summary>
     [JsonPropertyName("backupIds")]
     public List<long>? BackupIds { get; set; }
+
+}
+
+/// <summary>
+/// ResumeProcessInstanceRequest
+/// </summary>
+public sealed class ResumeProcessInstanceRequest
+{
+    /// <summary>
+    /// A reference key chosen by the user that will be part of all records resulting from this operation.
+    /// Must be &gt; 0 if provided.
+    /// 
+    /// </summary>
+    [JsonPropertyName("operationReference")]
+    public OperationReference? OperationReference { get; set; }
 
 }
 
@@ -24089,6 +24193,21 @@ internal sealed class StringFilterPropertyJsonConverter : global::System.Text.Js
 }
 
 /// <summary>
+/// SuspendProcessInstanceRequest
+/// </summary>
+public sealed class SuspendProcessInstanceRequest
+{
+    /// <summary>
+    /// A reference key chosen by the user that will be part of all records resulting from this operation.
+    /// Must be &gt; 0 if provided.
+    /// 
+    /// </summary>
+    [JsonPropertyName("operationReference")]
+    public OperationReference? OperationReference { get; set; }
+
+}
+
+/// <summary>
 /// Envelope for all system configuration sections. Each property
 /// represents a feature area.
 /// 
@@ -24726,6 +24845,12 @@ public sealed class UpdateClusterVariableRequest
     /// </summary>
     [JsonPropertyName("value")]
     public object Value { get; set; } = null!;
+
+    /// <summary>
+    /// A generic key-value metadata bag attached to the cluster variable. Values must be strings or numbers. Limited to 100 entries and a configurable maximum serialized size (default: 100 entries at max key length of a cluster variable name (256 chars) plus the maximum value length, 8192 characters).
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object>? Metadata { get; set; }
 
 }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:83242850b1f3570de5fa8fb6d52f4741286347f3e1601c4f58617dd28211974e";
+    public const string SpecHash = "sha256:16fd114798a5e976be4d3d59829256c4e783a6ab29bc8ca2b4060cd37266c86d";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -576,9 +576,9 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemCreationResult : sealed c
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics : sealed class
   CTOR ()
-  PROP System.Int64 DurationMs { get; set; } [JsonPropertyName("durationMs")]
-  PROP System.Int64 InputTokens { get; set; } [JsonPropertyName("inputTokens")]
-  PROP System.Int64 OutputTokens { get; set; } [JsonPropertyName("outputTokens")]
+  PROP System.Int64? DurationMs { get; set; } [JsonPropertyName("durationMs")]
+  PROP System.Int64? InputTokens { get; set; } [JsonPropertyName("inputTokens")]
+  PROP System.Int64? OutputTokens { get; set; } [JsonPropertyName("outputTokens")]
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemRequest : sealed class
   CTOR ()
@@ -596,7 +596,7 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey HistoryItemKey { get; set; } [JsonPropertyName("historyItemKey")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryCommitStatusEnum CommitStatus { get; set; } [JsonPropertyName("commitStatus")]
-  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics Metrics { get; set; } [JsonPropertyName("metrics")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics? Metrics { get; set; } [JsonPropertyName("metrics")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum Role { get; set; } [JsonPropertyName("role")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceKey AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
@@ -1460,8 +1460,10 @@ TYPE Camunda.Orchestration.Sdk.BatchOperationTypeEnum : enum interfaces=[System.
   MEMBER MIGRATEPROCESSINSTANCE = 6 json="MIGRATE_PROCESS_INSTANCE"
   MEMBER MODIFYPROCESSINSTANCE = 7 json="MODIFY_PROCESS_INSTANCE"
   MEMBER RESOLVEINCIDENT = 8 json="RESOLVE_INCIDENT"
-  MEMBER UPDATEJOB = 9 json="UPDATE_JOB"
-  MEMBER UPDATEVARIABLE = 10 json="UPDATE_VARIABLE"
+  MEMBER RESUMEPROCESSINSTANCE = 9 json="RESUME_PROCESS_INSTANCE"
+  MEMBER SUSPENDPROCESSINSTANCE = 10 json="SUSPEND_PROCESS_INSTANCE"
+  MEMBER UPDATEJOB = 11 json="UPDATE_JOB"
+  MEMBER UPDATEVARIABLE = 12 json="UPDATE_VARIABLE"
 
 TYPE Camunda.Orchestration.Sdk.BatchOperationTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.BatchOperationTypeExactMatch>]
   PROP System.String Value { get; }
@@ -1535,6 +1537,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task AssignGroupToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.GroupId groupId, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task AssignMappingRuleToGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task AssignMappingRuleToTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task AssignProcessInstanceBusinessIdAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ProcessInstanceBusinessIdAssignmentInstruction body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task AssignRoleToClientAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.ClientId clientId, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task AssignRoleToGroupAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.GroupId groupId, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task AssignRoleToMappingRuleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
@@ -1568,9 +1571,11 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task ResetClockAsync(System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task ResolveIncidentAsync(Camunda.Orchestration.Sdk.IncidentKey incidentKey, Camunda.Orchestration.Sdk.IncidentResolutionRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task ResumeBatchOperationAsync(Camunda.Orchestration.Sdk.BatchOperationKey batchOperationKey, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task ResumeProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ResumeProcessInstanceRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task RunWorkersAsync(System.TimeSpan? gracePeriod = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task StopAllWorkersAsync(System.TimeSpan? gracePeriod = null)
   METHOD System.Threading.Tasks.Task SuspendBatchOperationAsync(Camunda.Orchestration.Sdk.BatchOperationKey batchOperationKey, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task SuspendProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.SuspendProcessInstanceRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task ThrowJobErrorAsync(Camunda.Orchestration.Sdk.JobKey jobKey, Camunda.Orchestration.Sdk.JobErrorRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UnassignClientFromGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.ClientId clientId, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UnassignClientFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.ClientId clientId, System.Threading.CancellationToken ct = null)
@@ -1607,6 +1612,8 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationCreatedResult> ModifyProcessInstancesBatchOperationAsync(Camunda.Orchestration.Sdk.ProcessInstanceModificationBatchOperationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationCreatedResult> ResolveIncidentsBatchOperationAsync(Camunda.Orchestration.Sdk.ProcessInstanceIncidentResolutionBatchOperationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationCreatedResult> ResolveProcessInstanceIncidentsAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationCreatedResult> ResumeProcessInstancesBatchOperationAsync(Camunda.Orchestration.Sdk.ProcessInstanceResumptionBatchOperationRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationCreatedResult> SuspendProcessInstancesBatchOperationAsync(Camunda.Orchestration.Sdk.ProcessInstanceSuspensionBatchOperationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationCreatedResult> UpdateJobsBatchOperationAsync(Camunda.Orchestration.Sdk.JobBatchUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationItemSearchQueryResult> SearchBatchOperationItemsAsync(Camunda.Orchestration.Sdk.BatchOperationItemSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationItemSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationResponse> GetBatchOperationAsync(Camunda.Orchestration.Sdk.BatchOperationKey batchOperationKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationResponse>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1881,6 +1888,7 @@ TYPE Camunda.Orchestration.Sdk.ClusterVariableResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum Scope { get; set; } [JsonPropertyName("scope")]
+  PROP System.Collections.Generic.Dictionary<System.String,System.Object> Metadata { get; set; } [JsonPropertyName("metadata")]
   PROP System.String Value { get; set; } [JsonPropertyName("value")]
   PROP System.String? TenantId { get; set; } [JsonPropertyName("tenantId")]
 
@@ -1888,6 +1896,7 @@ TYPE Camunda.Orchestration.Sdk.ClusterVariableResultBase : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum Scope { get; set; } [JsonPropertyName("scope")]
+  PROP System.Collections.Generic.Dictionary<System.String,System.Object> Metadata { get; set; } [JsonPropertyName("metadata")]
   PROP System.String? TenantId { get; set; } [JsonPropertyName("tenantId")]
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableScopeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
@@ -1952,6 +1961,7 @@ TYPE Camunda.Orchestration.Sdk.ClusterVariableSearchResult : sealed class
   PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum Scope { get; set; } [JsonPropertyName("scope")]
   PROP System.Boolean IsTruncated { get; set; } [JsonPropertyName("isTruncated")]
+  PROP System.Collections.Generic.Dictionary<System.String,System.Object> Metadata { get; set; } [JsonPropertyName("metadata")]
   PROP System.String Value { get; set; } [JsonPropertyName("value")]
   PROP System.String? TenantId { get; set; } [JsonPropertyName("tenantId")]
 
@@ -2073,6 +2083,7 @@ TYPE Camunda.Orchestration.Sdk.CorrelatedMessageSubscriptionSearchQuerySortReque
 TYPE Camunda.Orchestration.Sdk.CreateClusterVariableRequest : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
+  PROP System.Collections.Generic.Dictionary<System.String,System.Object>? Metadata { get; set; } [JsonPropertyName("metadata")]
   PROP System.Object Value { get; set; } [JsonPropertyName("value")]
 
 TYPE Camunda.Orchestration.Sdk.CreateGlobalTaskListenerRequest : sealed class
@@ -4824,6 +4835,10 @@ TYPE Camunda.Orchestration.Sdk.ProcessElementStatisticsResult : sealed class
   PROP System.Int64 Completed { get; set; } [JsonPropertyName("completed")]
   PROP System.Int64 Incidents { get; set; } [JsonPropertyName("incidents")]
 
+TYPE Camunda.Orchestration.Sdk.ProcessInstanceBusinessIdAssignmentInstruction : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.BusinessId BusinessId { get; set; } [JsonPropertyName("businessId")]
+
 TYPE Camunda.Orchestration.Sdk.ProcessInstanceCallHierarchyEntry : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
@@ -5064,6 +5079,11 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceResult : sealed class
   PROP System.String? ProcessDefinitionName { get; set; } [JsonPropertyName("processDefinitionName")]
   PROP System.String? ProcessDefinitionVersionTag { get; set; } [JsonPropertyName("processDefinitionVersionTag")]
 
+TYPE Camunda.Orchestration.Sdk.ProcessInstanceResumptionBatchOperationRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.OperationReference? OperationReference { get; set; } [JsonPropertyName("operationReference")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceFilter Filter { get; set; } [JsonPropertyName("filter")]
+
 TYPE Camunda.Orchestration.Sdk.ProcessInstanceSearchQuery : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ProcessInstanceFilter? Filter { get; set; } [JsonPropertyName("filter")]
@@ -5137,6 +5157,11 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceStateFilterProperty : sealed class
   PROP Camunda.Orchestration.Sdk.ProcessInstanceStateEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ProcessInstanceStateEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.ProcessInstanceSuspensionBatchOperationRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.OperationReference? OperationReference { get; set; } [JsonPropertyName("operationReference")]
+  PROP Camunda.Orchestration.Sdk.ProcessInstanceFilter Filter { get; set; } [JsonPropertyName("filter")]
 
 TYPE Camunda.Orchestration.Sdk.ProcessInstanceWaitStateStatisticsQueryResult : sealed class
   CTOR ()
@@ -5250,6 +5275,10 @@ TYPE Camunda.Orchestration.Sdk.RestoreRequest : sealed class
   PROP System.Collections.Generic.List<System.Int64>? BackupIds { get; set; } [JsonPropertyName("backupIds")]
   PROP System.DateTimeOffset? From { get; set; } [JsonPropertyName("from")]
   PROP System.DateTimeOffset? To { get; set; } [JsonPropertyName("to")]
+
+TYPE Camunda.Orchestration.Sdk.ResumeProcessInstanceRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.OperationReference? OperationReference { get; set; } [JsonPropertyName("operationReference")]
 
 TYPE Camunda.Orchestration.Sdk.RetryDecision : struct interfaces=[System.IEquatable<Camunda.Orchestration.Sdk.RetryDecision>]
   CTOR (System.Boolean Retryable, System.String Reason)
@@ -5537,6 +5566,10 @@ TYPE Camunda.Orchestration.Sdk.StringFilterProperty : sealed class
   PROP System.String? ExactMatch { get; set; }
   PROP System.String? Neq { get; set; } [JsonPropertyName("$neq")]
 
+TYPE Camunda.Orchestration.Sdk.SuspendProcessInstanceRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.OperationReference? OperationReference { get; set; } [JsonPropertyName("operationReference")]
+
 TYPE Camunda.Orchestration.Sdk.SystemConfigurationResponse : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AuthenticationConfigurationResponse Authentication { get; set; } [JsonPropertyName("authentication")]
@@ -5742,6 +5775,7 @@ TYPE Camunda.Orchestration.Sdk.TypedVariablesException : class base=System.Excep
 
 TYPE Camunda.Orchestration.Sdk.UpdateClusterVariableRequest : sealed class
   CTOR ()
+  PROP System.Collections.Generic.Dictionary<System.String,System.Object>? Metadata { get; set; } [JsonPropertyName("metadata")]
   PROP System.Object Value { get; set; } [JsonPropertyName("value")]
 
 TYPE Camunda.Orchestration.Sdk.UpdateGlobalTaskListenerRequest : sealed class


### PR DESCRIPTION
Resolves #335.

Adds example coverage for the five process instance operations flagged by the daily coverage bot:

| Operation | Example file |
| --- | --- |
| `suspendProcessInstance` | `examples/ProcessInstance.cs` |
| `resumeProcessInstance` | `examples/ProcessInstance.cs` |
| `assignProcessInstanceBusinessId` | `examples/ProcessInstance.cs` |
| `suspendProcessInstancesBatchOperation` | `examples/BatchOperation.cs` |
| `resumeProcessInstancesBatchOperation` | `examples/BatchOperation.cs` |

Each operation gets a region-tagged example, an `operation-map.json` entry, and a DocFX overwrite entry mapping the method uid to the example.

Because these operations are new in the upstream 8.10 spec and were not yet in the committed generated SDK, the SDK was regenerated. Per the repo's separate-commits rule, the change is split into:

1. `docs:` — hand-written examples, `operation-map.json`, and DocFX overwrite entries.
2. `chore(gen):` — regenerated `Generated/*`, bundled spec, and the refreshed public API baseline.

### Validation

- Example coverage: **100% (203/203)**
- Overwrite completeness check: passes
- `dotnet build docs/examples/Examples.csproj`: succeeds (0 warnings/errors)
- All 1109 unit tests pass; `dotnet format --verify-no-changes` clean
- Public API baseline refreshed — diff contains only the 5 new methods, their request/model types, the new `RESUME_PROCESS_INSTANCE` / `SUSPEND_PROCESS_INSTANCE` enum members, and expected upstream spec drift.
