### PR TITLE
docs: add resolveSecrets example coverage

### DIFF
--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -1283,6 +1283,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.ResolveSecretsAsync(Camunda.Orchestration.Sdk.SecretResolveRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Secret.cs#ResolveSecrets)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.SuspendProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey,Camunda.Orchestration.Sdk.SuspendProcessInstanceRequest,System.Threading.CancellationToken)
 example:
 - *content

--- a/examples/Secret.cs
+++ b/examples/Secret.cs
@@ -21,9 +21,12 @@ public static class SecretExamples
 
         // Successfully resolved references are returned in Resolved; references that
         // could not be resolved are returned in Errors, each with a typed error code.
+        // Never log resolved.Value — it holds secret material. Pass it directly to the
+        // consumer that needs it (HTTP client, DB driver, ...) instead.
         foreach (var resolved in result.Resolved)
         {
-            Console.WriteLine($"Resolved {resolved.Reference}: {resolved.Value}");
+            Console.WriteLine($"Resolved {resolved.Reference} (value redacted)");
+            UseSecret(resolved.Value);
         }
 
         foreach (var error in result.Errors)
@@ -31,6 +34,9 @@ public static class SecretExamples
             Console.WriteLine($"Failed to resolve {error.Reference}: {error.Code} - {error.Message}");
         }
     }
+
+    // Hands the resolved secret to whatever needs it, without logging it.
+    private static void UseSecret(string value) { }
     // </ResolveSecrets>
     #endregion ResolveSecrets
 }

--- a/examples/Secret.cs
+++ b/examples/Secret.cs
@@ -1,0 +1,36 @@
+// Compilable usage examples for secret operations.
+// These examples are type-checked during build to guard against API regressions.
+using Camunda.Orchestration.Sdk;
+
+public static class SecretExamples
+{
+    #region ResolveSecrets
+    // <ResolveSecrets>
+    public static async Task ResolveSecretsExample()
+    {
+        using var client = CamundaClient.Create();
+
+        var result = await client.ResolveSecretsAsync(new SecretResolveRequest
+        {
+            References = new List<string>
+            {
+                "camunda.secrets.myApiToken",
+                "camunda.secrets.dbPassword",
+            },
+        });
+
+        // Successfully resolved references are returned in Resolved; references that
+        // could not be resolved are returned in Errors, each with a typed error code.
+        foreach (var resolved in result.Resolved)
+        {
+            Console.WriteLine($"Resolved {resolved.Reference}: {resolved.Value}");
+        }
+
+        foreach (var error in result.Errors)
+        {
+            Console.WriteLine($"Failed to resolve {error.Reference}: {error.Code} - {error.Message}");
+        }
+    }
+    // </ResolveSecrets>
+    #endregion ResolveSecrets
+}

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -1429,5 +1429,12 @@
       "region": "SearchUserTaskEffectiveVariables",
       "label": "Search user task effective variables"
     }
+  ],
+  "resolveSecrets": [
+    {
+      "file": "Secret.cs",
+      "region": "ResolveSecrets",
+      "label": "Resolve secrets"
+    }
   ]
 }

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -131,6 +131,9 @@
       "name": "Role"
     },
     {
+      "name": "Secret"
+    },
+    {
       "name": "Setup"
     },
     {
@@ -236,6 +239,16 @@
           },
           "404": {
             "description": "The elementInstanceKey does not correspond to an active element instance.\nMore details are provided in the response body.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "An agent instance already exists for the given element instance.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -16663,6 +16676,102 @@
         "x-added-in-version": "8.8"
       }
     },
+    "/secrets/resolve": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Secret"
+        ],
+        "operationId": "resolveSecrets",
+        "x-permission-enforcement": "filter",
+        "x-required-permissions": [
+          {
+            "resourceType": "SECRET",
+            "permissionType": "REVEAL"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Resolve secrets (alpha)",
+        "description": "Resolve a deduplicated batch of `camunda.secrets.*` references for the caller's\nphysical tenant in a single round-trip.\n\nEach reference is authorized and resolved independently. For valid requests, the endpoint\nalways responds with HTTP 200: successfully resolved references are returned in `resolved`,\nwhile references that could not be resolved (for example not found, malformed or over-long,\nor the caller lacks `SECRET:REVEAL` on that reference) are returned in `errors`. A failure of\none reference never fails the others. Only structurally invalid requests are rejected with\nHTTP 400: a missing or non-array `references` field, more than 20 references, or a null entry.\n\nThis endpoint is an alpha feature and may be subject to change in future releases.\n\nPhase 1: the secret backend is mocked. Only a fixed allow-list of references resolves;\nevery other authorized, valid reference returns `NOT_FOUND`.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SecretResolveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The batch was processed. Per-reference outcomes are split between `resolved` and\n`errors`; this status is returned even when some or all references failed.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretResolveResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/setup/user": {
       "post": {
         "x-eventually-consistent": false,
@@ -23971,6 +24080,7 @@
           "DELETE_TASK_LISTENER",
           "EVALUATE",
           "MODIFY_PROCESS_INSTANCE",
+          "PAUSE",
           "READ",
           "READ_DECISION_DEFINITION",
           "READ_DECISION_INSTANCE",
@@ -23980,6 +24090,8 @@
           "READ_USAGE_METRIC",
           "READ_USER_TASK",
           "READ_TASK_LISTENER",
+          "RESTORE",
+          "REVEAL",
           "SUSPEND_PROCESS_INSTANCE",
           "UPDATE",
           "UPDATE_PROCESS_INSTANCE",
@@ -23993,12 +24105,14 @@
         "enum": [
           "AUDIT_LOG",
           "AUTHORIZATION",
+          "BACKUP",
           "BATCH",
           "CLUSTER_VARIABLE",
           "COMPONENT",
           "DECISION_DEFINITION",
           "DECISION_REQUIREMENTS_DEFINITION",
           "DOCUMENT",
+          "EXPORTER",
           "EXPRESSION",
           "GLOBAL_LISTENER",
           "GROUP",
@@ -24007,6 +24121,7 @@
           "PROCESS_DEFINITION",
           "RESOURCE",
           "ROLE",
+          "SECRET",
           "SYSTEM",
           "TENANT",
           "USER",
@@ -24995,6 +25110,14 @@
           "timestamp"
         ]
       },
+      "ClusterVariableKindEnum": {
+        "type": "string",
+        "enum": [
+          "JSON",
+          "SECRET_REFERENCE"
+        ],
+        "description": "The kind of a cluster variable. JSON is the default. SECRET_REFERENCE allows the value to contain camunda.secrets.X references that are resolved at job activation time."
+      },
       "ClusterVariableScopeEnum": {
         "type": "string",
         "enum": [
@@ -25036,11 +25159,23 @@
                 }
               ]
             }
+          },
+          "kind": {
+            "description": "The kind of the cluster variable. Defaults to JSON if not specified.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterVariableKindEnum"
+              }
+            ]
           }
         },
         "x-properties-added-in-version": [
           {
             "propertyName": "metadata",
+            "addedInVersion": "8.10"
+          },
+          {
+            "propertyName": "kind",
             "addedInVersion": "8.10"
           }
         ]
@@ -25122,6 +25257,7 @@
         "description": "Cluster variable response item.",
         "type": "object",
         "required": [
+          "kind",
           "metadata",
           "name",
           "scope",
@@ -25158,11 +25294,18 @@
                 }
               ]
             }
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ClusterVariableKindEnum"
           }
         },
         "x-properties-added-in-version": [
           {
             "propertyName": "metadata",
+            "addedInVersion": "8.10"
+          },
+          {
+            "propertyName": "kind",
             "addedInVersion": "8.10"
           }
         ]
@@ -25254,6 +25397,97 @@
           "isTruncated": {
             "description": "Filter cluster variables by truncation status of their stored values. When true, returns only variables whose stored values are truncated (i.e., the value exceeds the storage size limit and is truncated in storage). When false, returns only variables with non-truncated stored values. This filter is based on the underlying storage characteristic, not the response format.\n",
             "type": "boolean"
+          },
+          "metadata": {
+            "description": "Filter by metadata entries. A map of metadata key to an advanced filter on that key's value. Metadata values are strings or numbers.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AdvancedMetadataValueFilter"
+            }
+          },
+          "kind": {
+            "description": "The kind filter for cluster variables.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterVariableKindFilterProperty"
+              }
+            ]
+          }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "kind",
+            "addedInVersion": "8.10"
+          },
+          {
+            "propertyName": "metadata",
+            "addedInVersion": "8.10"
+          }
+        ]
+      },
+      "AdvancedMetadataValueFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced filter on a metadata value (string or number).",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the metadata key exists.",
+            "type": "boolean"
+          },
+          "$gt": {
+            "description": "Greater than comparison with the provided value.",
+            "type": "number"
+          },
+          "$gte": {
+            "description": "Greater than or equal comparison with the provided value.",
+            "type": "number"
+          },
+          "$lt": {
+            "description": "Lower than comparison with the provided value.",
+            "type": "number"
+          },
+          "$lte": {
+            "description": "Lower than or equal comparison with the provided value.",
+            "type": "number"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          "$like": {
+            "$ref": "#/components/schemas/LikeFilter"
           }
         }
       },
@@ -25298,6 +25532,54 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ClusterVariableScopeEnum"
+            }
+          },
+          "$like": {
+            "$ref": "#/components/schemas/LikeFilter"
+          }
+        }
+      },
+      "ClusterVariableKindFilterProperty": {
+        "description": "ClusterVariableKindEnum property with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ClusterVariableKindExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedClusterVariableKindFilter"
+          }
+        ]
+      },
+      "AdvancedClusterVariableKindFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced ClusterVariableKindEnum filter.",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterVariableKindEnum"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClusterVariableKindEnum"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClusterVariableKindEnum"
             }
           },
           "$like": {
@@ -25416,6 +25698,7 @@
         "description": "Provides information on a broker node.",
         "type": "object",
         "required": [
+          "brokerId",
           "host",
           "nodeId",
           "partitions",
@@ -25424,10 +25707,16 @@
         ],
         "properties": {
           "nodeId": {
-            "description": "The unique (within a cluster) node ID for the broker.",
+            "description": "The node ID for the broker. The uniqueness of this identifier depends if the cluster is zone-aware or not. - non zone-aware: (default) nodeId is unique across the cluster - zone-aware:  (opt-in) nodeId is unique only within its zone. If you are migrating to a zone aware cluster, you must use `brokerId` instead. This property is deprecated, as it's been replaced by `brokerId`.\n",
             "type": "integer",
             "format": "int32",
+            "deprecated": true,
             "example": 0
+          },
+          "brokerId": {
+            "description": "The unique (within a cluster) broker identifier. When the cluster is not zoned, then it's a string that represents the nodeId (an integer). When the cluster is zoned, instead, it's of the form \"$zoneName_$nodeId\", providing uniqueness even across zones.\n",
+            "type": "string",
+            "example": "eu-west-1_0"
           },
           "host": {
             "description": "The hostname for reaching the broker.",
@@ -25452,7 +25741,13 @@
             "type": "string",
             "example": "8.8.0"
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "brokerId",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "Partition": {
         "description": "Provides information on a partition within a broker node.",
@@ -25460,7 +25755,8 @@
         "required": [
           "health",
           "partitionId",
-          "role"
+          "role",
+          "state"
         ],
         "properties": {
           "partitionId": {
@@ -25488,8 +25784,26 @@
               "unhealthy",
               "dead"
             ]
+          },
+          "state": {
+            "description": "Describes the current operational state of the partition within the cluster configuration.\n",
+            "type": "string",
+            "example": "active",
+            "enum": [
+              "unknown",
+              "joining",
+              "active",
+              "leaving",
+              "recovering"
+            ]
           }
-        }
+        },
+        "x-properties-added-in-version": [
+          {
+            "propertyName": "state",
+            "addedInVersion": "8.10"
+          }
+        ]
       },
       "ClusterModeChangeResponse": {
         "description": "The planned changes resulting from a cluster mode transition request.",
@@ -33162,6 +33476,15 @@
             "description": "The token identifying a leased job's activation, obtained from `ActivatedJobResult.leaseToken`.\nFor a leased job, the matching token must be supplied to prove the command comes from the worker that holds the current lease; a command with no token is rejected. A command carrying a stale token is likewise rejected, fencing the job against a superseded activation (for example, after the job timed out or failed and was re-activated by another worker).\nA job that was activated without a lease requires no token.\n",
             "type": "string",
             "nullable": true
+          },
+          "businessId": {
+            "nullable": true,
+            "description": "An optional business id to assign to the process instance the job belongs to, as part of completing the job, letting a worker set the identifier from work it just performed.\nThe business id can only be assigned to a root process instance: if the job belongs to a child process instance (one started by a call activity), the completion is rejected. An empty business id is likewise rejected. The assignment is single and irreversible and is only accepted while business id uniqueness is disabled. Only artifacts created after the assignment carry the business id; already-existing ones are not enriched. Completing with a business id that differs from one already assigned rejects the whole completion, leaving the job open; re-sending the identical business id is an idempotent no-op.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BusinessId"
+              }
+            ]
           }
         },
         "x-properties-added-in-version": [
@@ -33171,6 +33494,10 @@
           },
           {
             "propertyName": "leaseToken",
+            "addedInVersion": "8.10"
+          },
+          {
+            "propertyName": "businessId",
             "addedInVersion": "8.10"
           }
         ]
@@ -39082,6 +39409,95 @@
           }
         ]
       },
+      "SecretResolveRequest": {
+        "type": "object",
+        "required": [
+          "references"
+        ],
+        "properties": {
+          "references": {
+            "type": "array",
+            "maxItems": 20,
+            "description": "The secret references to resolve, each of the form `camunda.secrets.<name>`.\nDuplicate references are deduplicated by the server and resolved once.\nAt most 20 references may be requested in a single batch.\n",
+            "items": {
+              "type": "string",
+              "maxLength": 256,
+              "description": "A secret reference of the form `camunda.secrets.<name>`."
+            }
+          }
+        }
+      },
+      "SecretResolveResult": {
+        "type": "object",
+        "required": [
+          "errors",
+          "resolved"
+        ],
+        "description": "The per-reference outcome of a resolve request.",
+        "properties": {
+          "resolved": {
+            "type": "array",
+            "description": "The references that were successfully resolved.",
+            "items": {
+              "$ref": "#/components/schemas/ResolvedSecret"
+            }
+          },
+          "errors": {
+            "type": "array",
+            "description": "The references that could not be resolved, each with a typed error code.",
+            "items": {
+              "$ref": "#/components/schemas/SecretResolutionError"
+            }
+          }
+        }
+      },
+      "ResolvedSecret": {
+        "type": "object",
+        "required": [
+          "reference",
+          "value"
+        ],
+        "properties": {
+          "reference": {
+            "type": "string",
+            "description": "The resolved secret reference of the form `camunda.secrets.<name>`."
+          },
+          "value": {
+            "type": "string",
+            "description": "The resolved secret value."
+          }
+        }
+      },
+      "SecretResolutionError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "reference"
+        ],
+        "properties": {
+          "reference": {
+            "type": "string",
+            "description": "The secret reference that could not be resolved."
+          },
+          "code": {
+            "$ref": "#/components/schemas/SecretErrorCode"
+          },
+          "message": {
+            "type": "string",
+            "description": "A human-readable description of the failure. Never contains the secret value;\nonly error metadata (codes, names) is included.\n"
+          }
+        }
+      },
+      "SecretErrorCode": {
+        "type": "string",
+        "description": "The typed reason a reference could not be resolved.\n\n- `NOT_FOUND`: no secret exists for the reference.\n- `ACCESS_DENIED`: the caller lacks `SECRET:REVEAL` on the reference.\n- `INVALID_REFERENCE`: the reference is malformed.\n",
+        "enum": [
+          "NOT_FOUND",
+          "ACCESS_DENIED",
+          "INVALID_REFERENCE"
+        ]
+      },
       "SignalBroadcastRequest": {
         "type": "object",
         "additionalProperties": false,
@@ -41441,6 +41857,16 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/ClusterVariableScopeEnum"
+          }
+        ]
+      },
+      "ClusterVariableKindExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ClusterVariableKindEnum"
           }
         ]
       },

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:16fd114798a5e976be4d3d59829256c4e783a6ab29bc8ca2b4060cd37266c86d",
+  "specHash": "sha256:3fb1bc2818276e0b4ccf61cedabf3dcfbd42d64d13826f0a9de0cedf7115640e",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -1460,6 +1460,22 @@
         }
       ],
       "stableId": "category-filter-property"
+    },
+    {
+      "name": "ClusterVariableKindFilterProperty",
+      "kind": "union-wrapper",
+      "description": "ClusterVariableKindEnum property with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "ClusterVariableKindExactMatch"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AdvancedClusterVariableKindFilter"
+        }
+      ],
+      "stableId": "cluster-variable-kind-filter-property"
     },
     {
       "name": "ClusterVariableScopeFilterProperty",
@@ -9210,6 +9226,42 @@
       }
     },
     {
+      "operationId": "resolveSecrets",
+      "path": "/secrets/resolve",
+      "method": "post",
+      "tags": [
+        "Secret"
+      ],
+      "summary": "Resolve secrets (alpha)",
+      "description": "Resolve a deduplicated batch of `camunda.secrets.*` references for the caller's\nphysical tenant in a single round-trip.\n\nEach reference is authorized and resolved independently. For valid requests, the endpoint\nalways responds with HTTP 200: successfully resolved references are returned in `resolved`,\nwhile references that could not be resolved (for example not found, malformed or over-long,\nor the caller lacks `SECRET:REVEAL` on that reference) are returned in `errors`. A failure of\none reference never fails the others. Only structurally invalid requests are rejected with\nHTTP 400: a missing or non-array `references` field, more than 20 references, or a null entry.\n\nThis endpoint is an alpha feature and may be subject to change in future releases.\n\nPhase 1: the secret backend is mocked. Only a fixed allow-list of references resolves;\nevery other authorized, valid reference returns `NOT_FOUND`.\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": true,
+      "pathParams": [],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "secrets.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "SecretResolveRequest",
+      "successResponseSchemaRef": "SecretResolveResult",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-permission-enforcement": "filter",
+        "x-required-permissions": [
+          {
+            "resourceType": "SECRET",
+            "permissionType": "REVEAL"
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "createAdminUser",
       "path": "/setup/user",
       "method": "post",
@@ -11347,8 +11399,8 @@
   ],
   "integrity": {
     "totalSemanticKeys": 41,
-    "totalUnions": 64,
-    "totalOperations": 203,
+    "totalUnions": 65,
+    "totalOperations": 204,
     "totalEventuallyConsistent": 92,
     "totalDeprecatedEnumSchemas": 2,
     "totalSemanticProviders": 23

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -5602,9 +5602,12 @@ public partial class CamundaClient
     /// 
     ///     // Successfully resolved references are returned in Resolved; references that
     ///     // could not be resolved are returned in Errors, each with a typed error code.
+    ///     // Never log resolved.Value — it holds secret material. Pass it directly to the
+    ///     // consumer that needs it (HTTP client, DB driver, ...) instead.
     ///     foreach (var resolved in result.Resolved)
     ///     {
-    ///         Console.WriteLine($&quot;Resolved {resolved.Reference}: {resolved.Value}&quot;);
+    ///         Console.WriteLine($&quot;Resolved {resolved.Reference} (value redacted)&quot;);
+    ///         UseSecret(resolved.Value);
     ///     }
     /// 
     ///     foreach (var error in result.Errors)
@@ -5612,6 +5615,9 @@ public partial class CamundaClient
     ///         Console.WriteLine($&quot;Failed to resolve {error.Reference}: {error.Code} - {error.Message}&quot;);
     ///     }
     /// }
+    /// 
+    /// // Hands the resolved secret to whatever needs it, without logging it.
+    /// private static void UseSecret(string value) { }
     /// </code>
     /// </remarks>
     /// <example>
@@ -5632,9 +5638,12 @@ public partial class CamundaClient
     /// 
     ///     // Successfully resolved references are returned in Resolved; references that
     ///     // could not be resolved are returned in Errors, each with a typed error code.
+    ///     // Never log resolved.Value — it holds secret material. Pass it directly to the
+    ///     // consumer that needs it (HTTP client, DB driver, ...) instead.
     ///     foreach (var resolved in result.Resolved)
     ///     {
-    ///         Console.WriteLine($&quot;Resolved {resolved.Reference}: {resolved.Value}&quot;);
+    ///         Console.WriteLine($&quot;Resolved {resolved.Reference} (value redacted)&quot;);
+    ///         UseSecret(resolved.Value);
     ///     }
     /// 
     ///     foreach (var error in result.Errors)
@@ -5642,6 +5651,9 @@ public partial class CamundaClient
     ///         Console.WriteLine($&quot;Failed to resolve {error.Reference}: {error.Code} - {error.Message}&quot;);
     ///     }
     /// }
+    /// 
+    /// // Hands the resolved secret to whatever needs it, without logging it.
+    /// private static void UseSecret(string value) { }
     /// </code>
     /// </example>
     public async Task<SecretResolveResult> ResolveSecretsAsync(SecretResolveRequest body, CancellationToken ct = default)

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -5566,6 +5566,91 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Resolve secrets (alpha)
+    /// Resolve a deduplicated batch of `camunda.secrets.*` references for the caller&apos;s
+    /// physical tenant in a single round-trip.
+    /// 
+    /// Each reference is authorized and resolved independently. For valid requests, the endpoint
+    /// always responds with HTTP 200: successfully resolved references are returned in `resolved`,
+    /// while references that could not be resolved (for example not found, malformed or over-long,
+    /// or the caller lacks `SECRET:REVEAL` on that reference) are returned in `errors`. A failure of
+    /// one reference never fails the others. Only structurally invalid requests are rejected with
+    /// HTTP 400: a missing or non-array `references` field, more than 20 references, or a null entry.
+    /// 
+    /// This endpoint is an alpha feature and may be subject to change in future releases.
+    /// 
+    /// Phase 1: the secret backend is mocked. Only a fixed allow-list of references resolves;
+    /// every other authorized, valid reference returns `NOT_FOUND`.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: resolveSecrets
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ResolveSecretsExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.ResolveSecretsAsync(new SecretResolveRequest
+    ///     {
+    ///         References = new List&lt;string&gt;
+    ///         {
+    ///             &quot;camunda.secrets.myApiToken&quot;,
+    ///             &quot;camunda.secrets.dbPassword&quot;,
+    ///         },
+    ///     });
+    /// 
+    ///     // Successfully resolved references are returned in Resolved; references that
+    ///     // could not be resolved are returned in Errors, each with a typed error code.
+    ///     foreach (var resolved in result.Resolved)
+    ///     {
+    ///         Console.WriteLine($&quot;Resolved {resolved.Reference}: {resolved.Value}&quot;);
+    ///     }
+    /// 
+    ///     foreach (var error in result.Errors)
+    ///     {
+    ///         Console.WriteLine($&quot;Failed to resolve {error.Reference}: {error.Code} - {error.Message}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ResolveSecretsExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var result = await client.ResolveSecretsAsync(new SecretResolveRequest
+    ///     {
+    ///         References = new List&lt;string&gt;
+    ///         {
+    ///             &quot;camunda.secrets.myApiToken&quot;,
+    ///             &quot;camunda.secrets.dbPassword&quot;,
+    ///         },
+    ///     });
+    /// 
+    ///     // Successfully resolved references are returned in Resolved; references that
+    ///     // could not be resolved are returned in Errors, each with a typed error code.
+    ///     foreach (var resolved in result.Resolved)
+    ///     {
+    ///         Console.WriteLine($&quot;Resolved {resolved.Reference}: {resolved.Value}&quot;);
+    ///     }
+    /// 
+    ///     foreach (var error in result.Errors)
+    ///     {
+    ///         Console.WriteLine($&quot;Failed to resolve {error.Reference}: {error.Code} - {error.Message}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<SecretResolveResult> ResolveSecretsAsync(SecretResolveRequest body, CancellationToken ct = default)
+    {
+        var path = $"/secrets/resolve";
+        return await InvokeWithRetryAsync(() => SendAsync<SecretResolveResult>(HttpMethod.Post, path, body, ct), "resolveSecrets", false, ct);
+    }
+
+    /// <summary>
     /// Restore from a backup
     /// Restores the cluster from a backup. The restore is described either by a single backup ID or by a time range (`from`/`to`) that selects the backups to restore. This endpoint is only accessible while the cluster is in recovery mode; requests are rejected otherwise. The request is validated and acknowledged, but the restore itself is performed asynchronously.
     /// </summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -812,6 +812,25 @@ public enum PartitionRole
 }
 
 /// <summary>
+/// Describes the current operational state of the partition within the cluster configuration.
+/// 
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum PartitionState
+{
+    [JsonPropertyName("unknown")]
+    Unknown,
+    [JsonPropertyName("joining")]
+    Joining,
+    [JsonPropertyName("active")]
+    Active,
+    [JsonPropertyName("leaving")]
+    Leaving,
+    [JsonPropertyName("recovering")]
+    Recovering,
+}
+
+/// <summary>
 /// The field to sort by.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -1745,6 +1764,51 @@ public sealed class AdvancedCategoryFilter
     /// </summary>
     [JsonPropertyName("$in")]
     public List<AuditLogCategoryEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
+/// Advanced ClusterVariableKindEnum filter.
+/// </summary>
+public sealed class AdvancedClusterVariableKindFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public ClusterVariableKindEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public ClusterVariableKindEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<ClusterVariableKindEnum>? In { get; set; }
 
     /// <summary>
     /// Checks if the property matches the provided like value.
@@ -2842,6 +2906,75 @@ public sealed class AdvancedMessageSubscriptionTypeFilter
     /// </summary>
     [JsonPropertyName("$in")]
     public List<MessageSubscriptionTypeEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+}
+
+/// <summary>
+/// Advanced filter on a metadata value (string or number).
+/// </summary>
+public sealed class AdvancedMetadataValueFilter
+{
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public object? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public object? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the metadata key exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Greater than comparison with the provided value.
+    /// </summary>
+    [JsonPropertyName("$gt")]
+    public double? Gt { get; set; }
+
+    /// <summary>
+    /// Greater than or equal comparison with the provided value.
+    /// </summary>
+    [JsonPropertyName("$gte")]
+    public double? Gte { get; set; }
+
+    /// <summary>
+    /// Lower than comparison with the provided value.
+    /// </summary>
+    [JsonPropertyName("$lt")]
+    public double? Lt { get; set; }
+
+    /// <summary>
+    /// Lower than or equal comparison with the provided value.
+    /// </summary>
+    [JsonPropertyName("$lte")]
+    public double? Lte { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<object>? In { get; set; }
 
     /// <summary>
     /// Checks if the property matches the provided like value.
@@ -7917,10 +8050,18 @@ internal sealed class BatchOperationTypeFilterPropertyJsonConverter : global::Sy
 public sealed class BrokerInfo
 {
     /// <summary>
-    /// The unique (within a cluster) node ID for the broker.
+    /// The node ID for the broker. The uniqueness of this identifier depends if the cluster is zone-aware or not. - non zone-aware: (default) nodeId is unique across the cluster - zone-aware:  (opt-in) nodeId is unique only within its zone. If you are migrating to a zone aware cluster, you must use `brokerId` instead. This property is deprecated, as it&apos;s been replaced by `brokerId`.
+    /// 
     /// </summary>
     [JsonPropertyName("nodeId")]
     public int NodeId { get; set; }
+
+    /// <summary>
+    /// The unique (within a cluster) broker identifier. When the cluster is not zoned, then it&apos;s a string that represents the nodeId (an integer). When the cluster is zoned, instead, it&apos;s of the form &quot;$zoneName_$nodeId&quot;, providing uniqueness even across zones.
+    /// 
+    /// </summary>
+    [JsonPropertyName("brokerId")]
+    public string BrokerId { get; set; } = null!;
 
     /// <summary>
     /// The hostname for reaching the broker.
@@ -8378,6 +8519,168 @@ public sealed class ClusterModeChangeResponse
 }
 
 /// <summary>
+/// The kind of a cluster variable. JSON is the default. SECRET_REFERENCE allows the value to contain camunda.secrets.X references that are resolved at job activation time.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ClusterVariableKindEnum
+{
+    [JsonPropertyName("JSON")]
+    JSON,
+    [JsonPropertyName("SECRET_REFERENCE")]
+    SECRETREFERENCE,
+}
+
+/// <summary>
+/// Matches the value exactly.
+/// </summary>
+public readonly record struct ClusterVariableKindExactMatch : global::Camunda.Orchestration.Sdk.ICamundaKey
+{
+    /// <summary>The underlying string value.</summary>
+    public string Value { get; }
+
+    private ClusterVariableKindExactMatch(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="ClusterVariableKindExactMatch"/> from a raw string value.
+    /// Use this when side-loading values not received from an API call.
+    /// </summary>
+    public static ClusterVariableKindExactMatch AssumeExists(string value)
+    {
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.AssertConstraints(value, "ClusterVariableKindExactMatch");
+        return new ClusterVariableKindExactMatch(value);
+    }
+
+    /// <summary>Returns true if the value satisfies this type's constraints.</summary>
+    public static bool IsValid(string value) =>
+        global::Camunda.Orchestration.Sdk.CamundaKeyValidation.CheckConstraints(value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// ClusterVariableKindEnum property with full advanced search capabilities.
+/// </summary>
+[JsonConverter(typeof(ClusterVariableKindFilterPropertyJsonConverter))]
+public sealed class ClusterVariableKindFilterProperty
+{
+    /// <summary>
+    /// Matches the value exactly. Serialized as the bare value — the form
+    /// servers that predate advanced filtering on this field accept.
+    /// </summary>
+    public ClusterVariableKindEnum? ExactMatch { get; set; }
+
+    /// <summary>
+    /// Checks for equality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$eq")]
+    public ClusterVariableKindEnum? Eq { get; set; }
+
+    /// <summary>
+    /// Checks for inequality with the provided value.
+    /// </summary>
+    [JsonPropertyName("$neq")]
+    public ClusterVariableKindEnum? Neq { get; set; }
+
+    /// <summary>
+    /// Checks if the current property exists.
+    /// </summary>
+    [JsonPropertyName("$exists")]
+    public bool? Exists { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches any of the provided values.
+    /// </summary>
+    [JsonPropertyName("$in")]
+    public List<ClusterVariableKindEnum>? In { get; set; }
+
+    /// <summary>
+    /// Checks if the property matches the provided like value.
+    /// 
+    /// Supported wildcard characters are:
+    /// 
+    /// * `*`: matches zero, one, or multiple characters.
+    /// * `?`: matches one, single character.
+    /// 
+    /// Wildcard characters can be escaped with backslash, for instance: `\*`.
+    /// 
+    /// </summary>
+    [JsonPropertyName("$like")]
+    public LikeFilter? Like { get; set; }
+
+    /// <summary>Wraps a bare value as an exact-match filter.</summary>
+    public static implicit operator ClusterVariableKindFilterProperty(ClusterVariableKindEnum value) => new() { ExactMatch = value };
+
+}
+
+/// <summary>Serializes <see cref="ClusterVariableKindFilterProperty"/> as a bare exact-match value or an advanced filter object.</summary>
+internal sealed class ClusterVariableKindFilterPropertyJsonConverter : global::System.Text.Json.Serialization.JsonConverter<ClusterVariableKindFilterProperty>
+{
+    public override ClusterVariableKindFilterProperty? Read(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        if (reader.TokenType == global::System.Text.Json.JsonTokenType.Null) return null;
+        if (reader.TokenType != global::System.Text.Json.JsonTokenType.StartObject)
+            return new ClusterVariableKindFilterProperty { ExactMatch = global::System.Text.Json.JsonSerializer.Deserialize<ClusterVariableKindEnum?>(ref reader, options) };
+        var result = new ClusterVariableKindFilterProperty();
+        while (reader.Read())
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.EndObject) break;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop)
+            {
+                case "$eq": result.Eq = global::System.Text.Json.JsonSerializer.Deserialize<ClusterVariableKindEnum?>(ref reader, options); break;
+                case "$neq": result.Neq = global::System.Text.Json.JsonSerializer.Deserialize<ClusterVariableKindEnum?>(ref reader, options); break;
+                case "$exists": result.Exists = global::System.Text.Json.JsonSerializer.Deserialize<bool?>(ref reader, options); break;
+                case "$in": result.In = global::System.Text.Json.JsonSerializer.Deserialize<List<ClusterVariableKindEnum>?>(ref reader, options); break;
+                case "$like": result.Like = global::System.Text.Json.JsonSerializer.Deserialize<LikeFilter?>(ref reader, options); break;
+                default: reader.Skip(); break;
+            }
+        }
+        return result;
+    }
+
+    public override void Write(global::System.Text.Json.Utf8JsonWriter writer, ClusterVariableKindFilterProperty value, global::System.Text.Json.JsonSerializerOptions options)
+    {
+        var hasAdvanced = value.Eq is not null || value.Neq is not null || value.Exists is not null || value.In is not null || value.Like is not null;
+        if (value.ExactMatch is not null && hasAdvanced)
+            throw new global::System.Text.Json.JsonException("ClusterVariableKindFilterProperty: set either ExactMatch (a bare value) or advanced operators, not both.");
+        if (value.ExactMatch is not null)
+        {
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.ExactMatch, options);
+            return;
+        }
+        writer.WriteStartObject();
+        if (value.Eq is not null)
+        {
+            writer.WritePropertyName("$eq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Eq, options);
+        }
+        if (value.Neq is not null)
+        {
+            writer.WritePropertyName("$neq");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Neq, options);
+        }
+        if (value.Exists is not null)
+        {
+            writer.WritePropertyName("$exists");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Exists, options);
+        }
+        if (value.In is not null)
+        {
+            writer.WritePropertyName("$in");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.In, options);
+        }
+        if (value.Like is not null)
+        {
+            writer.WritePropertyName("$like");
+            global::System.Text.Json.JsonSerializer.Serialize(writer, value.Like, options);
+        }
+        writer.WriteEndObject();
+    }
+}
+
+/// <summary>
 /// The name of a cluster variable. Unique within its scope (global or tenant-specific).
 /// </summary>
 public readonly record struct ClusterVariableName : global::Camunda.Orchestration.Sdk.ICamundaKey
@@ -8440,6 +8743,12 @@ public sealed class ClusterVariableResult
     [JsonPropertyName("metadata")]
     public Dictionary<string, object> Metadata { get; set; } = null!;
 
+    /// <summary>
+    /// The kind of a cluster variable. JSON is the default. SECRET_REFERENCE allows the value to contain camunda.secrets.X references that are resolved at job activation time.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public ClusterVariableKindEnum Kind { get; set; }
+
 }
 
 /// <summary>
@@ -8470,6 +8779,12 @@ public sealed class ClusterVariableResultBase
     /// </summary>
     [JsonPropertyName("metadata")]
     public Dictionary<string, object> Metadata { get; set; } = null!;
+
+    /// <summary>
+    /// The kind of a cluster variable. JSON is the default. SECRET_REFERENCE allows the value to contain camunda.secrets.X references that are resolved at job activation time.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public ClusterVariableKindEnum Kind { get; set; }
 
 }
 
@@ -8671,6 +8986,18 @@ public sealed class ClusterVariableSearchQueryFilterRequest
     [JsonPropertyName("isTruncated")]
     public bool? IsTruncated { get; set; }
 
+    /// <summary>
+    /// Filter by metadata entries. A map of metadata key to an advanced filter on that key&apos;s value. Metadata values are strings or numbers.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, AdvancedMetadataValueFilter>? Metadata { get; set; }
+
+    /// <summary>
+    /// The kind filter for cluster variables.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public ClusterVariableKindFilterProperty? Kind { get; set; }
+
 }
 
 /// <summary>
@@ -8776,6 +9103,12 @@ public sealed class ClusterVariableSearchResult
     /// </summary>
     [JsonPropertyName("metadata")]
     public Dictionary<string, object> Metadata { get; set; } = null!;
+
+    /// <summary>
+    /// The kind of a cluster variable. JSON is the default. SECRET_REFERENCE allows the value to contain camunda.secrets.X references that are resolved at job activation time.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public ClusterVariableKindEnum Kind { get; set; }
 
 }
 
@@ -9147,6 +9480,12 @@ public sealed class CreateClusterVariableRequest
     /// </summary>
     [JsonPropertyName("metadata")]
     public Dictionary<string, object>? Metadata { get; set; }
+
+    /// <summary>
+    /// The kind of the cluster variable. Defaults to JSON if not specified.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public ClusterVariableKindEnum? Kind { get; set; }
 
 }
 
@@ -16065,6 +16404,14 @@ public sealed class JobCompletionRequest
     [JsonPropertyName("leaseToken")]
     public string? LeaseToken { get; set; }
 
+    /// <summary>
+    /// An optional business id to assign to the process instance the job belongs to, as part of completing the job, letting a worker set the identifier from work it just performed.
+    /// The business id can only be assigned to a root process instance: if the job belongs to a child process instance (one started by a call activity), the completion is rejected. An empty business id is likewise rejected. The assignment is single and irreversible and is only accepted while business id uniqueness is disabled. Only artifacts created after the assignment carry the business id; already-existing ones are not enriched. Completing with a business id that differs from one already assigned rejects the whole completion, leaving the job open; re-sending the identical business id is an idempotent no-op.
+    /// 
+    /// </summary>
+    [JsonPropertyName("businessId")]
+    public BusinessId? BusinessId { get; set; }
+
 }
 
 /// <summary>
@@ -19675,6 +20022,13 @@ public sealed class Partition
     [JsonPropertyName("health")]
     public PartitionHealth Health { get; set; }
 
+    /// <summary>
+    /// Describes the current operational state of the partition within the cluster configuration.
+    /// 
+    /// </summary>
+    [JsonPropertyName("state")]
+    public PartitionState State { get; set; }
+
 }
 
 /// <summary>
@@ -19743,6 +20097,8 @@ public enum PermissionTypeEnum
     EVALUATE,
     [JsonPropertyName("MODIFY_PROCESS_INSTANCE")]
     MODIFYPROCESSINSTANCE,
+    [JsonPropertyName("PAUSE")]
+    PAUSE,
     [JsonPropertyName("READ")]
     READ,
     [JsonPropertyName("READ_DECISION_DEFINITION")]
@@ -19761,6 +20117,10 @@ public enum PermissionTypeEnum
     READUSERTASK,
     [JsonPropertyName("READ_TASK_LISTENER")]
     READTASKLISTENER,
+    [JsonPropertyName("RESTORE")]
+    RESTORE,
+    [JsonPropertyName("REVEAL")]
+    REVEAL,
     [JsonPropertyName("SUSPEND_PROCESS_INSTANCE")]
     SUSPENDPROCESSINSTANCE,
     [JsonPropertyName("UPDATE")]
@@ -22648,6 +23008,25 @@ public sealed class ProcessInstanceWaitStateStatisticsResult
 }
 
 /// <summary>
+/// ResolvedSecret
+/// </summary>
+public sealed class ResolvedSecret
+{
+    /// <summary>
+    /// The resolved secret reference of the form `camunda.secrets.&lt;name&gt;`.
+    /// </summary>
+    [JsonPropertyName("reference")]
+    public string Reference { get; set; } = null!;
+
+    /// <summary>
+    /// The resolved secret value.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public string Value { get; set; } = null!;
+
+}
+
+/// <summary>
 /// Resource search filter.
 /// </summary>
 public sealed class ResourceFilter
@@ -23014,6 +23393,8 @@ public enum ResourceTypeEnum
     AUDITLOG,
     [JsonPropertyName("AUTHORIZATION")]
     AUTHORIZATION,
+    [JsonPropertyName("BACKUP")]
+    BACKUP,
     [JsonPropertyName("BATCH")]
     BATCH,
     [JsonPropertyName("CLUSTER_VARIABLE")]
@@ -23026,6 +23407,8 @@ public enum ResourceTypeEnum
     DECISIONREQUIREMENTSDEFINITION,
     [JsonPropertyName("DOCUMENT")]
     DOCUMENT,
+    [JsonPropertyName("EXPORTER")]
+    EXPORTER,
     [JsonPropertyName("EXPRESSION")]
     EXPRESSION,
     [JsonPropertyName("GLOBAL_LISTENER")]
@@ -23042,6 +23425,8 @@ public enum ResourceTypeEnum
     RESOURCE,
     [JsonPropertyName("ROLE")]
     ROLE,
+    [JsonPropertyName("SECRET")]
+    SECRET,
     [JsonPropertyName("SYSTEM")]
     SYSTEM,
     [JsonPropertyName("TENANT")]
@@ -23817,6 +24202,92 @@ public sealed class SearchQueryResponse
     /// </summary>
     [JsonPropertyName("page")]
     public SearchQueryPageResponse Page { get; set; } = null!;
+
+}
+
+/// <summary>
+/// The typed reason a reference could not be resolved.
+/// 
+/// - `NOT_FOUND`: no secret exists for the reference.
+/// - `ACCESS_DENIED`: the caller lacks `SECRET:REVEAL` on the reference.
+/// - `INVALID_REFERENCE`: the reference is malformed.
+/// 
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum SecretErrorCode
+{
+    [JsonPropertyName("NOT_FOUND")]
+    NOTFOUND,
+    [JsonPropertyName("ACCESS_DENIED")]
+    ACCESSDENIED,
+    [JsonPropertyName("INVALID_REFERENCE")]
+    INVALIDREFERENCE,
+}
+
+/// <summary>
+/// SecretResolutionError
+/// </summary>
+public sealed class SecretResolutionError
+{
+    /// <summary>
+    /// The secret reference that could not be resolved.
+    /// </summary>
+    [JsonPropertyName("reference")]
+    public string Reference { get; set; } = null!;
+
+    /// <summary>
+    /// The typed reason a reference could not be resolved.
+    /// 
+    /// - `NOT_FOUND`: no secret exists for the reference.
+    /// - `ACCESS_DENIED`: the caller lacks `SECRET:REVEAL` on the reference.
+    /// - `INVALID_REFERENCE`: the reference is malformed.
+    /// 
+    /// </summary>
+    [JsonPropertyName("code")]
+    public SecretErrorCode Code { get; set; }
+
+    /// <summary>
+    /// A human-readable description of the failure. Never contains the secret value;
+    /// only error metadata (codes, names) is included.
+    /// 
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = null!;
+
+}
+
+/// <summary>
+/// SecretResolveRequest
+/// </summary>
+public sealed class SecretResolveRequest
+{
+    /// <summary>
+    /// The secret references to resolve, each of the form `camunda.secrets.&lt;name&gt;`.
+    /// Duplicate references are deduplicated by the server and resolved once.
+    /// At most 20 references may be requested in a single batch.
+    /// 
+    /// </summary>
+    [JsonPropertyName("references")]
+    public List<string> References { get; set; } = null!;
+
+}
+
+/// <summary>
+/// The per-reference outcome of a resolve request.
+/// </summary>
+public sealed class SecretResolveResult
+{
+    /// <summary>
+    /// The references that were successfully resolved.
+    /// </summary>
+    [JsonPropertyName("resolved")]
+    public List<ResolvedSecret> Resolved { get; set; } = null!;
+
+    /// <summary>
+    /// The references that could not be resolved, each with a typed error code.
+    /// </summary>
+    [JsonPropertyName("errors")]
+    public List<SecretResolutionError> Errors { get; set; } = null!;
 
 }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:16fd114798a5e976be4d3d59829256c4e783a6ab29bc8ca2b4060cd37266c86d";
+    public const string SpecHash = "sha256:3fb1bc2818276e0b4ccf61cedabf3dcfbd42d64d13826f0a9de0cedf7115640e";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -154,6 +154,14 @@ TYPE Camunda.Orchestration.Sdk.AdvancedCategoryFilter : sealed class
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AuditLogCategoryEnum>? In { get; set; } [JsonPropertyName("$in")]
 
+TYPE Camunda.Orchestration.Sdk.AdvancedClusterVariableKindFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableKindEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ClusterVariableKindEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ClusterVariableKindEnum>? In { get; set; } [JsonPropertyName("$in")]
+
 TYPE Camunda.Orchestration.Sdk.AdvancedClusterVariableScopeFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum? Eq { get; set; } [JsonPropertyName("$eq")]
@@ -363,6 +371,18 @@ TYPE Camunda.Orchestration.Sdk.AdvancedMessageSubscriptionTypeFilter : sealed cl
   PROP Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum? Neq { get; set; } [JsonPropertyName("$neq")]
   PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.MessageSubscriptionTypeEnum>? In { get; set; } [JsonPropertyName("$in")]
+
+TYPE Camunda.Orchestration.Sdk.AdvancedMetadataValueFilter : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<System.Object>? In { get; set; } [JsonPropertyName("$in")]
+  PROP System.Double? Gt { get; set; } [JsonPropertyName("$gt")]
+  PROP System.Double? Gte { get; set; } [JsonPropertyName("$gte")]
+  PROP System.Double? Lt { get; set; } [JsonPropertyName("$lt")]
+  PROP System.Double? Lte { get; set; } [JsonPropertyName("$lte")]
+  PROP System.Object? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP System.Object? Neq { get; set; } [JsonPropertyName("$neq")]
 
 TYPE Camunda.Orchestration.Sdk.AdvancedOperationTypeFilter : sealed class
   CTOR ()
@@ -1495,6 +1515,7 @@ TYPE Camunda.Orchestration.Sdk.BrokerInfo : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.Partition> Partitions { get; set; } [JsonPropertyName("partitions")]
   PROP System.Int32 NodeId { get; set; } [JsonPropertyName("nodeId")]
   PROP System.Int32 Port { get; set; } [JsonPropertyName("port")]
+  PROP System.String BrokerId { get; set; } [JsonPropertyName("brokerId")]
   PROP System.String Host { get; set; } [JsonPropertyName("host")]
   PROP System.String Version { get; set; } [JsonPropertyName("version")]
 
@@ -1706,6 +1727,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleSearchQueryResult> SearchRolesAsync(Camunda.Orchestration.Sdk.RoleSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleUpdateResult> UpdateRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.RoleUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleUserSearchResult> SearchUsersForRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.RoleUserSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleUserSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SecretResolveResult> ResolveSecretsAsync(Camunda.Orchestration.Sdk.SecretResolveRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SignalBroadcastResult> BroadcastSignalAsync(Camunda.Orchestration.Sdk.SignalBroadcastRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SystemConfigurationResponse> GetSystemConfigurationAsync(System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantClientSearchResult> SearchClientsForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.TenantClientSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.TenantClientSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1875,6 +1897,31 @@ TYPE Camunda.Orchestration.Sdk.ClusterModeChangeResponse : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ClusterModeChangeOperation> PlannedChanges { get; set; } [JsonPropertyName("plannedChanges")]
   PROP System.String ChangeId { get; set; } [JsonPropertyName("changeId")]
 
+TYPE Camunda.Orchestration.Sdk.ClusterVariableKindEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER JSON = 0 json="JSON"
+  MEMBER SECRETREFERENCE = 1 json="SECRET_REFERENCE"
+
+TYPE Camunda.Orchestration.Sdk.ClusterVariableKindExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ClusterVariableKindExactMatch>]
+  PROP System.String Value { get; }
+  METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.ClusterVariableKindExactMatch other)
+  METHOD static Camunda.Orchestration.Sdk.ClusterVariableKindExactMatch AssumeExists(System.String value)
+  METHOD static System.Boolean IsValid(System.String value)
+  METHOD virtual System.Boolean Equals(System.Object obj)
+  METHOD virtual System.Int32 GetHashCode()
+  METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.ClusterVariableKindFilterProperty : sealed class
+  ATTR JsonConverter Camunda.Orchestration.Sdk.ClusterVariableKindFilterPropertyJsonConverter
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableKindEnum? Eq { get; set; } [JsonPropertyName("$eq")]
+  PROP Camunda.Orchestration.Sdk.ClusterVariableKindEnum? ExactMatch { get; set; }
+  PROP Camunda.Orchestration.Sdk.ClusterVariableKindEnum? Neq { get; set; } [JsonPropertyName("$neq")]
+  PROP Camunda.Orchestration.Sdk.LikeFilter? Like { get; set; } [JsonPropertyName("$like")]
+  PROP System.Boolean? Exists { get; set; } [JsonPropertyName("$exists")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ClusterVariableKindEnum>? In { get; set; } [JsonPropertyName("$in")]
+
 TYPE Camunda.Orchestration.Sdk.ClusterVariableName : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ClusterVariableName>]
   PROP System.String Value { get; }
   METHOD System.Boolean Equals(Camunda.Orchestration.Sdk.ClusterVariableName other)
@@ -1886,6 +1933,7 @@ TYPE Camunda.Orchestration.Sdk.ClusterVariableName : struct interfaces=[Camunda.
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableKindEnum Kind { get; set; } [JsonPropertyName("kind")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum Scope { get; set; } [JsonPropertyName("scope")]
   PROP System.Collections.Generic.Dictionary<System.String,System.Object> Metadata { get; set; } [JsonPropertyName("metadata")]
@@ -1894,6 +1942,7 @@ TYPE Camunda.Orchestration.Sdk.ClusterVariableResult : sealed class
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableResultBase : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableKindEnum Kind { get; set; } [JsonPropertyName("kind")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum Scope { get; set; } [JsonPropertyName("scope")]
   PROP System.Collections.Generic.Dictionary<System.String,System.Object> Metadata { get; set; } [JsonPropertyName("metadata")]
@@ -1926,11 +1975,13 @@ TYPE Camunda.Orchestration.Sdk.ClusterVariableScopeFilterProperty : sealed class
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableSearchQueryFilterRequest : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableKindFilterProperty? Kind { get; set; } [JsonPropertyName("kind")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeFilterProperty? Scope { get; set; } [JsonPropertyName("scope")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? Value { get; set; } [JsonPropertyName("value")]
   PROP System.Boolean? IsTruncated { get; set; } [JsonPropertyName("isTruncated")]
+  PROP System.Collections.Generic.Dictionary<System.String,Camunda.Orchestration.Sdk.AdvancedMetadataValueFilter>? Metadata { get; set; } [JsonPropertyName("metadata")]
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableSearchQueryRequest : sealed class
   CTOR ()
@@ -1958,6 +2009,7 @@ TYPE Camunda.Orchestration.Sdk.ClusterVariableSearchQuerySortRequestField : enum
 
 TYPE Camunda.Orchestration.Sdk.ClusterVariableSearchResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableKindEnum Kind { get; set; } [JsonPropertyName("kind")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableScopeEnum Scope { get; set; } [JsonPropertyName("scope")]
   PROP System.Boolean IsTruncated { get; set; } [JsonPropertyName("isTruncated")]
@@ -2082,6 +2134,7 @@ TYPE Camunda.Orchestration.Sdk.CorrelatedMessageSubscriptionSearchQuerySortReque
 
 TYPE Camunda.Orchestration.Sdk.CreateClusterVariableRequest : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ClusterVariableKindEnum? Kind { get; set; } [JsonPropertyName("kind")]
   PROP Camunda.Orchestration.Sdk.ClusterVariableName Name { get; set; } [JsonPropertyName("name")]
   PROP System.Collections.Generic.Dictionary<System.String,System.Object>? Metadata { get; set; } [JsonPropertyName("metadata")]
   PROP System.Object Value { get; set; } [JsonPropertyName("value")]
@@ -3687,6 +3740,7 @@ TYPE Camunda.Orchestration.Sdk.JobChangeset : sealed class
 
 TYPE Camunda.Orchestration.Sdk.JobCompletionRequest : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.BusinessId? BusinessId { get; set; } [JsonPropertyName("businessId")]
   PROP Camunda.Orchestration.Sdk.JobResult? Result { get; set; } [JsonPropertyName("result")]
   PROP System.Object? Variables { get; set; } [JsonPropertyName("variables")]
   PROP System.String? LeaseToken { get; set; } [JsonPropertyName("leaseToken")]
@@ -4507,6 +4561,7 @@ TYPE Camunda.Orchestration.Sdk.Partition : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.PartitionHealth Health { get; set; } [JsonPropertyName("health")]
   PROP Camunda.Orchestration.Sdk.PartitionRole Role { get; set; } [JsonPropertyName("role")]
+  PROP Camunda.Orchestration.Sdk.PartitionState State { get; set; } [JsonPropertyName("state")]
   PROP System.Int32 PartitionId { get; set; } [JsonPropertyName("partitionId")]
 
 TYPE Camunda.Orchestration.Sdk.PartitionHealth : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
@@ -4522,6 +4577,15 @@ TYPE Camunda.Orchestration.Sdk.PartitionRole : enum interfaces=[System.IComparab
   MEMBER Leader = 0 json="leader"
   MEMBER Follower = 1 json="follower"
   MEMBER Inactive = 2 json="inactive"
+
+TYPE Camunda.Orchestration.Sdk.PartitionState : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER Unknown = 0 json="unknown"
+  MEMBER Joining = 1 json="joining"
+  MEMBER Active = 2 json="active"
+  MEMBER Leaving = 3 json="leaving"
+  MEMBER Recovering = 4 json="recovering"
 
 TYPE Camunda.Orchestration.Sdk.PermissionTypeEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
@@ -4556,20 +4620,23 @@ TYPE Camunda.Orchestration.Sdk.PermissionTypeEnum : enum interfaces=[System.ICom
   MEMBER DELETETASKLISTENER = 27 json="DELETE_TASK_LISTENER"
   MEMBER EVALUATE = 28 json="EVALUATE"
   MEMBER MODIFYPROCESSINSTANCE = 29 json="MODIFY_PROCESS_INSTANCE"
-  MEMBER READ = 30 json="READ"
-  MEMBER READDECISIONDEFINITION = 31 json="READ_DECISION_DEFINITION"
-  MEMBER READDECISIONINSTANCE = 32 json="READ_DECISION_INSTANCE"
-  MEMBER READJOBMETRIC = 33 json="READ_JOB_METRIC"
-  MEMBER READPROCESSDEFINITION = 34 json="READ_PROCESS_DEFINITION"
-  MEMBER READPROCESSINSTANCE = 35 json="READ_PROCESS_INSTANCE"
-  MEMBER READUSAGEMETRIC = 36 json="READ_USAGE_METRIC"
-  MEMBER READUSERTASK = 37 json="READ_USER_TASK"
-  MEMBER READTASKLISTENER = 38 json="READ_TASK_LISTENER"
-  MEMBER SUSPENDPROCESSINSTANCE = 39 json="SUSPEND_PROCESS_INSTANCE"
-  MEMBER UPDATE = 40 json="UPDATE"
-  MEMBER UPDATEPROCESSINSTANCE = 41 json="UPDATE_PROCESS_INSTANCE"
-  MEMBER UPDATEUSERTASK = 42 json="UPDATE_USER_TASK"
-  MEMBER UPDATETASKLISTENER = 43 json="UPDATE_TASK_LISTENER"
+  MEMBER PAUSE = 30 json="PAUSE"
+  MEMBER READ = 31 json="READ"
+  MEMBER READDECISIONDEFINITION = 32 json="READ_DECISION_DEFINITION"
+  MEMBER READDECISIONINSTANCE = 33 json="READ_DECISION_INSTANCE"
+  MEMBER READJOBMETRIC = 34 json="READ_JOB_METRIC"
+  MEMBER READPROCESSDEFINITION = 35 json="READ_PROCESS_DEFINITION"
+  MEMBER READPROCESSINSTANCE = 36 json="READ_PROCESS_INSTANCE"
+  MEMBER READUSAGEMETRIC = 37 json="READ_USAGE_METRIC"
+  MEMBER READUSERTASK = 38 json="READ_USER_TASK"
+  MEMBER READTASKLISTENER = 39 json="READ_TASK_LISTENER"
+  MEMBER RESTORE = 40 json="RESTORE"
+  MEMBER REVEAL = 41 json="REVEAL"
+  MEMBER SUSPENDPROCESSINSTANCE = 42 json="SUSPEND_PROCESS_INSTANCE"
+  MEMBER UPDATE = 43 json="UPDATE"
+  MEMBER UPDATEPROCESSINSTANCE = 44 json="UPDATE_PROCESS_INSTANCE"
+  MEMBER UPDATEUSERTASK = 45 json="UPDATE_USER_TASK"
+  MEMBER UPDATETASKLISTENER = 46 json="UPDATE_TASK_LISTENER"
 
 TYPE Camunda.Orchestration.Sdk.ProblemDetail : sealed class
   CTOR ()
@@ -5172,6 +5239,11 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceWaitStateStatisticsResult : sealed
   PROP Camunda.Orchestration.Sdk.ElementId ElementId { get; set; } [JsonPropertyName("elementId")]
   PROP System.Int64 WaitingCount { get; set; } [JsonPropertyName("waitingCount")]
 
+TYPE Camunda.Orchestration.Sdk.ResolvedSecret : sealed class
+  CTOR ()
+  PROP System.String Reference { get; set; } [JsonPropertyName("reference")]
+  PROP System.String Value { get; set; } [JsonPropertyName("value")]
+
 TYPE Camunda.Orchestration.Sdk.ResourceFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DeploymentKeyFilterProperty? DeploymentKey { get; set; } [JsonPropertyName("deploymentKey")]
@@ -5251,24 +5323,27 @@ TYPE Camunda.Orchestration.Sdk.ResourceTypeEnum : enum interfaces=[System.ICompa
   underlying=System.Int32
   MEMBER AUDITLOG = 0 json="AUDIT_LOG"
   MEMBER AUTHORIZATION = 1 json="AUTHORIZATION"
-  MEMBER BATCH = 2 json="BATCH"
-  MEMBER CLUSTERVARIABLE = 3 json="CLUSTER_VARIABLE"
-  MEMBER COMPONENT = 4 json="COMPONENT"
-  MEMBER DECISIONDEFINITION = 5 json="DECISION_DEFINITION"
-  MEMBER DECISIONREQUIREMENTSDEFINITION = 6 json="DECISION_REQUIREMENTS_DEFINITION"
-  MEMBER DOCUMENT = 7 json="DOCUMENT"
-  MEMBER EXPRESSION = 8 json="EXPRESSION"
-  MEMBER GLOBALLISTENER = 9 json="GLOBAL_LISTENER"
-  MEMBER GROUP = 10 json="GROUP"
-  MEMBER MAPPINGRULE = 11 json="MAPPING_RULE"
-  MEMBER MESSAGE = 12 json="MESSAGE"
-  MEMBER PROCESSDEFINITION = 13 json="PROCESS_DEFINITION"
-  MEMBER RESOURCE = 14 json="RESOURCE"
-  MEMBER ROLE = 15 json="ROLE"
-  MEMBER SYSTEM = 16 json="SYSTEM"
-  MEMBER TENANT = 17 json="TENANT"
-  MEMBER USER = 18 json="USER"
-  MEMBER USERTASK = 19 json="USER_TASK"
+  MEMBER BACKUP = 2 json="BACKUP"
+  MEMBER BATCH = 3 json="BATCH"
+  MEMBER CLUSTERVARIABLE = 4 json="CLUSTER_VARIABLE"
+  MEMBER COMPONENT = 5 json="COMPONENT"
+  MEMBER DECISIONDEFINITION = 6 json="DECISION_DEFINITION"
+  MEMBER DECISIONREQUIREMENTSDEFINITION = 7 json="DECISION_REQUIREMENTS_DEFINITION"
+  MEMBER DOCUMENT = 8 json="DOCUMENT"
+  MEMBER EXPORTER = 9 json="EXPORTER"
+  MEMBER EXPRESSION = 10 json="EXPRESSION"
+  MEMBER GLOBALLISTENER = 11 json="GLOBAL_LISTENER"
+  MEMBER GROUP = 12 json="GROUP"
+  MEMBER MAPPINGRULE = 13 json="MAPPING_RULE"
+  MEMBER MESSAGE = 14 json="MESSAGE"
+  MEMBER PROCESSDEFINITION = 15 json="PROCESS_DEFINITION"
+  MEMBER RESOURCE = 16 json="RESOURCE"
+  MEMBER ROLE = 17 json="ROLE"
+  MEMBER SECRET = 18 json="SECRET"
+  MEMBER SYSTEM = 19 json="SYSTEM"
+  MEMBER TENANT = 20 json="TENANT"
+  MEMBER USER = 21 json="USER"
+  MEMBER USERTASK = 22 json="USER_TASK"
 
 TYPE Camunda.Orchestration.Sdk.RestoreRequest : sealed class
   CTOR ()
@@ -5480,6 +5555,28 @@ TYPE Camunda.Orchestration.Sdk.SearchQueryRequest : sealed class
 TYPE Camunda.Orchestration.Sdk.SearchQueryResponse : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
+
+TYPE Camunda.Orchestration.Sdk.SecretErrorCode : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER NOTFOUND = 0 json="NOT_FOUND"
+  MEMBER ACCESSDENIED = 1 json="ACCESS_DENIED"
+  MEMBER INVALIDREFERENCE = 2 json="INVALID_REFERENCE"
+
+TYPE Camunda.Orchestration.Sdk.SecretResolutionError : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.SecretErrorCode Code { get; set; } [JsonPropertyName("code")]
+  PROP System.String Message { get; set; } [JsonPropertyName("message")]
+  PROP System.String Reference { get; set; } [JsonPropertyName("reference")]
+
+TYPE Camunda.Orchestration.Sdk.SecretResolveRequest : sealed class
+  CTOR ()
+  PROP System.Collections.Generic.List<System.String> References { get; set; } [JsonPropertyName("references")]
+
+TYPE Camunda.Orchestration.Sdk.SecretResolveResult : sealed class
+  CTOR ()
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ResolvedSecret> Resolved { get; set; } [JsonPropertyName("resolved")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.SecretResolutionError> Errors { get; set; } [JsonPropertyName("errors")]
 
 TYPE Camunda.Orchestration.Sdk.SetVariableRequest : sealed class
   CTOR ()


### PR DESCRIPTION
## What

Adds example coverage for the `resolveSecrets` operation (`POST /secrets/resolve`, added in 8.10), resolving #346.

The operation was not yet exposed in the SDK, so this PR regenerates the SDK from the latest upstream spec and adds a hand-written, compilable example.

### Hand-written change (`docs:` commit)
- `examples/Secret.cs` — new region-tagged, type-checked example (`ResolveSecrets`) demonstrating `ResolveSecretsAsync`, iterating over `Resolved` and `Errors`.
- `examples/operation-map.json` — maps `resolveSecrets` → `Secret.cs#ResolveSecrets`. No ergonomic helper exists, so it points at the generated method directly.
- `docs/overwrite/CamundaClient.md` — DocFX overwrite entry for `ResolveSecretsAsync` (grouped with the other `Resolve*` entries).

### Regenerated output (`chore(gen):` commit)
- Regenerated the bundled spec, `Generated/*`, and refreshed the `PublicApi.shipped.txt` baseline.
- New public surface: `ResolveSecretsAsync` + `SecretResolveRequest`, `SecretResolveResult`, `ResolvedSecret`, `SecretResolutionError`, `SecretErrorCode`.

## Unrelated upstream drift (please note)

Regenerating pulls the latest upstream spec, so this PR also surfaces changes **unrelated** to secrets that landed on upstream `main`:

- New `ClusterVariableKindEnum` enum + `ClusterVariableKindExactMatch`, `AdvancedClusterVariableKindFilter`, `ClusterVariableKindFilterProperty`
- New `AdvancedMetadataValueFilter`
- New `PartitionState` enum
- One removed doc-comment line (broker node ID)

These are expected regeneration side effects and, per `AGENTS.md`, belong in the same PR.

## Validation

- `dotnet build --configuration Release` — 0 warnings, 0 errors
- `dotnet build docs/examples/Examples.csproj` — example compiles
- `node scripts/check-example-coverage.js` — 100% coverage
- `node scripts/check-overwrite-completeness.js` — all public methods have overwrite entries
- `dotnet test` — 1123 passed on net8.0 and net10.0

Closes #346
