### PR TITLE
build: restore always-green wall (drop blanket TreatWarningsAsErrors opt-outs)

### DIFF
--- a/docs/examples/Examples.csproj
+++ b/docs/examples/Examples.csproj
@@ -9,7 +9,9 @@
     <OutputType>Library</OutputType>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
     <RootNamespace>Camunda.Orchestration.Sdk.Examples</RootNamespace>
-    <!-- Suppress analyser rules that aren't meaningful for compile-only example code -->
+    <!-- Suppress analyser rules that aren't meaningful for compile-only example code:
+         CA1050 (Declare types in namespaces): example snippets use top-level statements.
+         CA1305 (Specify IFormatProvider): example output is illustrative, not locale-sensitive. -->
     <NoWarn>CA1050;CA1305</NoWarn>
   </PropertyGroup>
 

--- a/src/Camunda.Orchestration.Sdk.Generator/Camunda.Orchestration.Sdk.Generator.csproj
+++ b/src/Camunda.Orchestration.Sdk.Generator/Camunda.Orchestration.Sdk.Generator.csproj
@@ -7,6 +7,8 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Camunda.Orchestration.Sdk.Generator</RootNamespace>
     <LangVersion>12</LangVersion>
+    <!-- CA1305 (Specify IFormatProvider): the generator builds source text from spec
+         identifiers, not locale-sensitive data; culture-specific formatting is not applicable. -->
     <NoWarn>CA1305</NoWarn>
   </PropertyGroup>
 

--- a/src/Camunda.Orchestration.Sdk/Camunda.Orchestration.Sdk.csproj
+++ b/src/Camunda.Orchestration.Sdk/Camunda.Orchestration.Sdk.csproj
@@ -10,6 +10,8 @@
 
     <!-- XML documentation for DocFX API docs -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- CS1591 (Missing XML comment for publicly visible type or member): the generated API
+         surface has no doc comments; the doc file is still emitted for the hand-written runtime. -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <!-- NuGet Package Metadata -->

--- a/test/Camunda.Orchestration.Sdk.Changelog.Tests/Camunda.Orchestration.Sdk.Changelog.Tests.csproj
+++ b/test/Camunda.Orchestration.Sdk.Changelog.Tests/Camunda.Orchestration.Sdk.Changelog.Tests.csproj
@@ -8,7 +8,6 @@
     <IsTestProject>true</IsTestProject>
     <!-- Relax style enforcement for tool tests -->
     <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Camunda.Orchestration.Sdk.Changelog/Camunda.Orchestration.Sdk.Changelog.csproj
+++ b/tools/Camunda.Orchestration.Sdk.Changelog/Camunda.Orchestration.Sdk.Changelog.csproj
@@ -7,7 +7,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- Tool project — relax style enforcement inherited from Directory.Build.props -->
     <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Restores the always-green wall by removing the blanket `TreatWarningsAsErrors=false` overrides and documenting the remaining warning suppressions.

- Drop `TreatWarningsAsErrors=false` from `Camunda.Orchestration.Sdk.Changelog.Tests.csproj` and `Camunda.Orchestration.Sdk.Changelog.csproj` (the audit named only the test project; the tool project had the same crack). Both build clean under the global `TreatWarningsAsErrors=true` from `Directory.Build.props`, so no scoped `NoWarn`/`WarningsNotAsErrors` was needed.
- Add a per-diagnostic-ID rationale comment to each remaining `NoWarn`:
  - Generator — `CA1305` (Specify IFormatProvider)
  - Examples — `CA1050` (Declare types in namespaces), `CA1305`
  - SDK — `CS1591` (Missing XML comment)

## Why

`Directory.Build.props` makes warnings fatal repo-wide, but the two Changelog projects opted out silently, letting them accumulate warnings unchecked. Removing the opt-out re-enforces the policy everywhere; the inline rationales make the surviving suppressions auditable.

## Verification

- `dotnet build --configuration Release --no-incremental` → 0 warnings, 0 errors.
- Clean rebuilds of both Changelog projects (now warnings-as-errors) → green.
- `dotnet test` on `Changelog.Tests` → 43 passed.

Closes #340. Relates to #337 (rec #3).
