### PR TITLE
ci: add CodeQL SAST and NuGet dependency-vulnerability surfacing

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,5 +26,5 @@
       "automerge": true
     }
   ],
-  "vulnerabilityAlerts": { "enabled": false }
+  "vulnerabilityAlerts": { "enabled": true }
 }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+# Static analysis (SAST) for the SDK sources. Runs off the merge-blocking path:
+# weekly on a schedule plus manual dispatch. Uses build-mode "none" so the scan
+# analyses the committed sources (hand-written runtime + committed Generated/)
+# without needing the full spec-fetch/generate pipeline.
+
+on:
+  schedule:
+    # Mondays 05:17 UTC (off-peak, avoids the top-of-hour cron stampede).
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      # required for CodeQL to upload results
+      security-events: write
+      # required to read the Actions workflow status
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,61 @@
+name: Dependency Audit
+
+# Surfaces known-vulnerable NuGet dependencies (direct + transitive). Runs off the
+# merge-blocking path (weekly schedule + manual dispatch) since CVE disclosure is a
+# longer-tail signal than PR CI. Fails the job on High/Critical advisories so the
+# scheduled run turns red and notifies maintainers; Moderate/Low are reported only.
+
+on:
+  schedule:
+    # Mondays 05:47 UTC (staggered from the CodeQL scan).
+    - cron: '47 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: NuGet vulnerability audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: List vulnerable packages
+        id: audit
+        run: |
+          set -o pipefail
+          dotnet list package --vulnerable --include-transitive 2>&1 | tee _vuln.txt
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo '### NuGet vulnerability audit';
+            echo '';
+            echo '```';
+            cat _vuln.txt 2>/dev/null || echo '(no output)';
+            echo '```';
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail on High/Critical advisories
+        if: always()
+        run: |
+          if grep -qiE '\b(High|Critical)\b' _vuln.txt; then
+            echo "::error::High or Critical vulnerable dependency detected. See the job summary." >&2
+            grep -iE '\b(High|Critical)\b' _vuln.txt >&2 || true
+            exit 1
+          fi
+          echo 'No High/Critical vulnerable dependencies detected.'

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -51,7 +51,10 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail on High/Critical advisories
-        if: always()
+        # Only meaningful when the audit step actually ran and produced _vuln.txt.
+        # A failed restore/audit already turns the job red on its own; gating here
+        # avoids a misleading "no vulnerabilities" pass when _vuln.txt is missing.
+        if: steps.audit.outcome == 'success'
         run: |
           if grep -qiE '\b(High|Critical)\b' _vuln.txt; then
             echo "::error::High or Critical vulnerable dependency detected. See the job summary." >&2


### PR DESCRIPTION
## What

Adds automated security surfacing that runs **off the merge-blocking path** (scheduled + `workflow_dispatch`), plus turns on Renovate security PRs.

1. **CodeQL SAST** — new `.github/workflows/codeql.yml`. Weekly cron (Mon 05:17 UTC) + manual dispatch, analysing `csharp`, `javascript-typescript`, and `python` with `build-mode: none` (scans committed sources incl. `Generated/` without the spec-fetch/generate pipeline). Equivalent to CodeQL default setup but committed as code, per the issue's alternative.
2. **NuGet dependency audit** — new `.github/workflows/dependency-audit.yml`. Weekly cron (Mon 05:47 UTC) + manual dispatch, runs `dotnet list package --vulnerable --include-transitive`, fails on **High/Critical** advisories, reports all findings to the job summary. Longer-tail check, deliberately not a required PR gate.
3. **Renovate** — flip `.github/renovate.json` `vulnerabilityAlerts` from `false` → `true`, so Renovate raises security-update PRs (auto-merged on green by the existing `minor`/`patch` `automerge: true` rule).

## Why

Security/CVE handling was neither automated nor surfaced: code scanning was `not-configured`, Renovate would not raise vulnerability-fix PRs, and no dependency-audit job existed. This closes the canonical "remove review work that doesn't change the outcome" gap from the PLE audit.

## Verification

- `renovate.json` parses as valid JSON.
- Both workflow YAMLs parse cleanly.
- `dotnet list package --vulnerable --include-transitive` locally → no vulnerable packages across all 6 projects (audit currently green).

## Note on CodeQL default setup

If the repo's **CodeQL default setup** is later enabled via repo settings, this workflow (advanced setup) should be removed to avoid a conflict — the two are mutually exclusive. Committed as a workflow here because that path is code-actionable; enabling default setup is an admin action.

Closes #339. Relates to #337 (rec #2). Extends #159.
