### PR TITLE
chore(gen): regenerate SDK for upstream spec drift

### DIFF
--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -12525,7 +12525,7 @@
           }
         ],
         "summary": "Resume process instances (batch)",
-        "description": "Resumes multiple suspended process instances.\nSince only SUSPENDED root instances can be resumed, any given filters for state and\nparentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
+        "description": "Resumes multiple suspended process instances.\nSince only SUSPENDED root instances can be resumed, any given\nfilters for state and parentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "requestBody": {
           "required": true,
           "content": {
@@ -12724,7 +12724,7 @@
           }
         ],
         "summary": "Suspend process instances (batch)",
-        "description": "Suspends multiple running process instances.\nSince only ACTIVE root instances can be suspended, any given filters for state and\nparentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
+        "description": "Suspends multiple running process instances.\nSince only ACTIVE root instances can be suspended, any given\nfilters for state and parentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
         "requestBody": {
           "required": true,
           "content": {
@@ -37511,6 +37511,7 @@
               "parentElementInstanceKey",
               "startDate",
               "endDate",
+              "suspendedDate",
               "state",
               "hasIncident",
               "tenantId",
@@ -37583,6 +37584,14 @@
           "hasIncident": {
             "type": "boolean",
             "description": "Whether this process instance has a related incident or not."
+          },
+          "suspendedDate": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTimeFilterProperty"
+              }
+            ],
+            "description": "The time this process instance most recently entered the SUSPENDED state.\nThis is cleared (null) again once the process instance is resumed.\n"
           },
           "tenantId": {
             "allOf": [
@@ -37708,6 +37717,10 @@
           {
             "propertyName": "hasIncident",
             "addedInVersion": "8.8"
+          },
+          {
+            "propertyName": "suspendedDate",
+            "addedInVersion": "8.10"
           },
           {
             "propertyName": "tenantId",
@@ -37929,6 +37942,7 @@
           "rootProcessInstanceKey",
           "startDate",
           "state",
+          "suspendedDate",
           "tags",
           "tenantId"
         ],
@@ -37964,6 +37978,12 @@
           },
           "state": {
             "$ref": "#/components/schemas/ProcessInstanceStateEnum"
+          },
+          "suspendedDate": {
+            "description": "The time this process instance most recently entered the `SUSPENDED` state.\nThis is `null` if the process instance is not currently suspended.\n",
+            "nullable": true,
+            "type": "string",
+            "format": "date-time"
           },
           "hasIncident": {
             "type": "boolean",
@@ -38056,6 +38076,10 @@
           {
             "propertyName": "state",
             "addedInVersion": "8.6"
+          },
+          {
+            "propertyName": "suspendedDate",
+            "addedInVersion": "8.10"
           },
           {
             "propertyName": "hasIncident",
@@ -38698,6 +38722,7 @@
         "enum": [
           "ACTIVE",
           "COMPLETED",
+          "SUSPENDED",
           "TERMINATED"
         ]
       },

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:3fb1bc2818276e0b4ccf61cedabf3dcfbd42d64d13826f0a9de0cedf7115640e",
+  "specHash": "sha256:d13bc9d204c7e72691377d7ac75c580db83acec006dbd3f4635c4fbe05245865",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -7655,7 +7655,7 @@
         "Process instance"
       ],
       "summary": "Resume process instances (batch)",
-      "description": "Resumes multiple suspended process instances.\nSince only SUSPENDED root instances can be resumed, any given filters for state and\nparentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
+      "description": "Resumes multiple suspended process instances.\nSince only SUSPENDED root instances can be resumed, any given\nfilters for state and parentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
       "eventuallyConsistent": false,
       "hasRequestBody": true,
       "requestBodyUnion": false,
@@ -7734,7 +7734,7 @@
         "Process instance"
       ],
       "summary": "Suspend process instances (batch)",
-      "description": "Suspends multiple running process instances.\nSince only ACTIVE root instances can be suspended, any given filters for state and\nparentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
+      "description": "Suspends multiple running process instances.\nSince only ACTIVE root instances can be suspended, any given\nfilters for state and parentProcessInstanceKey are ignored and overridden during this batch operation.\nThis is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).\n",
       "eventuallyConsistent": false,
       "hasRequestBody": true,
       "requestBodyUnion": false,

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -5798,8 +5798,8 @@ public partial class CamundaClient
     /// <summary>
     /// Resume process instances (batch)
     /// Resumes multiple suspended process instances.
-    /// Since only SUSPENDED root instances can be resumed, any given filters for state and
-    /// parentProcessInstanceKey are ignored and overridden during this batch operation.
+    /// Since only SUSPENDED root instances can be resumed, any given
+    /// filters for state and parentProcessInstanceKey are ignored and overridden during this batch operation.
     /// This is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
     /// 
     /// </summary>
@@ -8446,8 +8446,8 @@ public partial class CamundaClient
     /// <summary>
     /// Suspend process instances (batch)
     /// Suspends multiple running process instances.
-    /// Since only ACTIVE root instances can be suspended, any given filters for state and
-    /// parentProcessInstanceKey are ignored and overridden during this batch operation.
+    /// Since only ACTIVE root instances can be suspended, any given
+    /// filters for state and parentProcessInstanceKey are ignored and overridden during this batch operation.
     /// This is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
     /// 
     /// </summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -912,6 +912,8 @@ public enum ProcessInstanceSearchQuerySortRequestField
     StartDate,
     [JsonPropertyName("endDate")]
     EndDate,
+    [JsonPropertyName("suspendedDate")]
+    SuspendedDate,
     [JsonPropertyName("state")]
     State,
     [JsonPropertyName("hasIncident")]
@@ -6861,6 +6863,14 @@ public sealed class BaseProcessInstanceFilterFields
     /// </summary>
     [JsonPropertyName("hasIncident")]
     public bool? HasIncident { get; set; }
+
+    /// <summary>
+    /// The time this process instance most recently entered the SUSPENDED state.
+    /// This is cleared (null) again once the process instance is resumed.
+    /// 
+    /// </summary>
+    [JsonPropertyName("suspendedDate")]
+    public DateTimeFilterProperty? SuspendedDate { get; set; }
 
     /// <summary>
     /// The tenant id.
@@ -21092,6 +21102,14 @@ public sealed class ProcessDefinitionStatisticsFilter
     public bool? HasIncident { get; set; }
 
     /// <summary>
+    /// The time this process instance most recently entered the SUSPENDED state.
+    /// This is cleared (null) again once the process instance is resumed.
+    /// 
+    /// </summary>
+    [JsonPropertyName("suspendedDate")]
+    public DateTimeFilterProperty? SuspendedDate { get; set; }
+
+    /// <summary>
     /// The tenant id.
     /// </summary>
     [JsonPropertyName("tenantId")]
@@ -21772,6 +21790,14 @@ public sealed class ProcessInstanceFilter
     public bool? HasIncident { get; set; }
 
     /// <summary>
+    /// The time this process instance most recently entered the SUSPENDED state.
+    /// This is cleared (null) again once the process instance is resumed.
+    /// 
+    /// </summary>
+    [JsonPropertyName("suspendedDate")]
+    public DateTimeFilterProperty? SuspendedDate { get; set; }
+
+    /// <summary>
     /// The tenant id.
     /// </summary>
     [JsonPropertyName("tenantId")]
@@ -21959,6 +21985,14 @@ public sealed class ProcessInstanceFilterFields
     /// </summary>
     [JsonPropertyName("hasIncident")]
     public bool? HasIncident { get; set; }
+
+    /// <summary>
+    /// The time this process instance most recently entered the SUSPENDED state.
+    /// This is cleared (null) again once the process instance is resumed.
+    /// 
+    /// </summary>
+    [JsonPropertyName("suspendedDate")]
+    public DateTimeFilterProperty? SuspendedDate { get; set; }
 
     /// <summary>
     /// The tenant id.
@@ -22583,6 +22617,14 @@ public sealed class ProcessInstanceResult
     public ProcessInstanceStateEnum State { get; set; }
 
     /// <summary>
+    /// The time this process instance most recently entered the `SUSPENDED` state.
+    /// This is `null` if the process instance is not currently suspended.
+    /// 
+    /// </summary>
+    [JsonPropertyName("suspendedDate")]
+    public DateTimeOffset? SuspendedDate { get; set; }
+
+    /// <summary>
     /// Whether this process instance has a related incident or not.
     /// </summary>
     [JsonPropertyName("hasIncident")]
@@ -22800,6 +22842,8 @@ public enum ProcessInstanceStateEnum
     ACTIVE,
     [JsonPropertyName("COMPLETED")]
     COMPLETED,
+    [JsonPropertyName("SUSPENDED")]
+    SUSPENDED,
     [JsonPropertyName("TERMINATED")]
     TERMINATED,
 }

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:3fb1bc2818276e0b4ccf61cedabf3dcfbd42d64d13826f0a9de0cedf7115640e";
+    public const string SpecHash = "sha256:d13bc9d204c7e72691377d7ac75c580db83acec006dbd3f4635c4fbe05245865";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -1242,6 +1242,7 @@ TYPE Camunda.Orchestration.Sdk.BaseProcessInstanceFilterFields : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? EndDate { get; set; } [JsonPropertyName("endDate")]
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? StartDate { get; set; } [JsonPropertyName("startDate")]
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? SuspendedDate { get; set; } [JsonPropertyName("suspendedDate")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ParentElementInstanceKey { get; set; } [JsonPropertyName("parentElementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceStateFilterProperty? ElementInstanceState { get; set; } [JsonPropertyName("elementInstanceState")]
   PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? IncidentErrorHashCode { get; set; } [JsonPropertyName("incidentErrorHashCode")]
@@ -4857,6 +4858,7 @@ TYPE Camunda.Orchestration.Sdk.ProcessDefinitionStatisticsFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? EndDate { get; set; } [JsonPropertyName("endDate")]
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? StartDate { get; set; } [JsonPropertyName("startDate")]
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? SuspendedDate { get; set; } [JsonPropertyName("suspendedDate")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ParentElementInstanceKey { get; set; } [JsonPropertyName("parentElementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceStateFilterProperty? ElementInstanceState { get; set; } [JsonPropertyName("elementInstanceState")]
   PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? IncidentErrorHashCode { get; set; } [JsonPropertyName("incidentErrorHashCode")]
@@ -4978,6 +4980,7 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceFilter : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? EndDate { get; set; } [JsonPropertyName("endDate")]
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? StartDate { get; set; } [JsonPropertyName("startDate")]
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? SuspendedDate { get; set; } [JsonPropertyName("suspendedDate")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ParentElementInstanceKey { get; set; } [JsonPropertyName("parentElementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceStateFilterProperty? ElementInstanceState { get; set; } [JsonPropertyName("elementInstanceState")]
   PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? IncidentErrorHashCode { get; set; } [JsonPropertyName("incidentErrorHashCode")]
@@ -5006,6 +5009,7 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceFilterFields : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? EndDate { get; set; } [JsonPropertyName("endDate")]
   PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? StartDate { get; set; } [JsonPropertyName("startDate")]
+  PROP Camunda.Orchestration.Sdk.DateTimeFilterProperty? SuspendedDate { get; set; } [JsonPropertyName("suspendedDate")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKeyFilterProperty? ParentElementInstanceKey { get; set; } [JsonPropertyName("parentElementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceStateFilterProperty? ElementInstanceState { get; set; } [JsonPropertyName("elementInstanceState")]
   PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? IncidentErrorHashCode { get; set; } [JsonPropertyName("incidentErrorHashCode")]
@@ -5142,6 +5146,7 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceResult : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.Tag> Tags { get; set; } [JsonPropertyName("tags")]
   PROP System.DateTimeOffset StartDate { get; set; } [JsonPropertyName("startDate")]
   PROP System.DateTimeOffset? EndDate { get; set; } [JsonPropertyName("endDate")]
+  PROP System.DateTimeOffset? SuspendedDate { get; set; } [JsonPropertyName("suspendedDate")]
   PROP System.Int32 ProcessDefinitionVersion { get; set; } [JsonPropertyName("processDefinitionVersion")]
   PROP System.String? ProcessDefinitionName { get; set; } [JsonPropertyName("processDefinitionName")]
   PROP System.String? ProcessDefinitionVersionTag { get; set; } [JsonPropertyName("processDefinitionVersionTag")]
@@ -5180,10 +5185,11 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceSearchQuerySortRequestField : enum
   MEMBER ParentElementInstanceKey = 7 json="parentElementInstanceKey"
   MEMBER StartDate = 8 json="startDate"
   MEMBER EndDate = 9 json="endDate"
-  MEMBER State = 10 json="state"
-  MEMBER HasIncident = 11 json="hasIncident"
-  MEMBER TenantId = 12 json="tenantId"
-  MEMBER BusinessId = 13 json="businessId"
+  MEMBER SuspendedDate = 10 json="suspendedDate"
+  MEMBER State = 11 json="state"
+  MEMBER HasIncident = 12 json="hasIncident"
+  MEMBER TenantId = 13 json="tenantId"
+  MEMBER BusinessId = 14 json="businessId"
 
 TYPE Camunda.Orchestration.Sdk.ProcessInstanceSequenceFlowResult : sealed class
   CTOR ()
@@ -5204,7 +5210,8 @@ TYPE Camunda.Orchestration.Sdk.ProcessInstanceStateEnum : enum interfaces=[Syste
   underlying=System.Int32
   MEMBER ACTIVE = 0 json="ACTIVE"
   MEMBER COMPLETED = 1 json="COMPLETED"
-  MEMBER TERMINATED = 2 json="TERMINATED"
+  MEMBER SUSPENDED = 2 json="SUSPENDED"
+  MEMBER TERMINATED = 3 json="TERMINATED"
 
 TYPE Camunda.Orchestration.Sdk.ProcessInstanceStateExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ProcessInstanceStateExactMatch>]
   PROP System.String Value { get; }


### PR DESCRIPTION
## Summary

Regenerates the C# SDK against the current upstream OpenAPI spec (`SPEC_REF=main`) and refreshes the public API baseline. This unblocks **all** PRs in the repo.

## Why CI is red on every PR

CI regenerates the SDK from the live upstream spec on each run, then asserts the regenerated public surface matches the committed baseline (`PublicApiSurfaceTests.PublicApiSurface_MatchesShippedBaseline`). Upstream `camunda/camunda` has drifted since the baseline was last refreshed, so that test now fails on every PR — including unrelated ones (e.g. #348, #349).

Because `ci.yml` runs `on: push` with `branches-ignore: [main]`, **main never runs this workflow**, so the drift accumulated silently until it began blocking PRs. The `Detect Generation Drift` step is non-blocking and does not catch it.

## Changes

- `chore(gen)`: regenerate `Generated/` + bundled spec.
- `test`: refresh `PublicApi.shipped.txt`.

Net public API delta (additive):
- `SuspendedDate` (`DateTimeFilterProperty?` / `DateTimeOffset?`) added to process-instance filter/result/sort types.
- `SUSPENDED = 2` added to `ProcessInstanceStateEnum` (`TERMINATED` 2 to 3).
- `SuspendedDate = 10` added to `ProcessInstanceSearchQuerySortRequestField` (subsequent members renumbered).

## Validation

- Release build: 0 warnings, 0 errors.
- Unit tests: 1123 passed on both net8.0 and net10.0.
- `PublicApiSurface` test passes against the refreshed baseline.

After merge, #348 and #349 should be rebased onto updated main and go green.