### PR TITLE
ci: add scheduled generation-drift check on main

### DIFF
--- a/.github/workflows/scheduled-generation-drift.yml
+++ b/.github/workflows/scheduled-generation-drift.yml
@@ -25,7 +25,16 @@ env:
   SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'main' }}
 
 jobs:
+  spec-ref-guard:
+    uses: camunda/sdk-infra/.github/workflows/sdk-spec-ref-guard.yml@v1
+    with:
+      spec-ref: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'main' }}
+      default-ref: 'main'
+      ack: ${{ vars.SPEC_REF_OVERRIDE_ACK || '' }}
+      expires: ${{ vars.SPEC_REF_OVERRIDE_EXPIRES || '' }}
+
   drift:
+    needs: [spec-ref-guard]
     name: Regenerate and check for drift
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/scheduled-generation-drift.yml
+++ b/.github/workflows/scheduled-generation-drift.yml
@@ -80,7 +80,9 @@ jobs:
           {
             echo '### Scheduled generation drift';
             echo '';
-            if [ "${{ steps.drift.outputs.drift }}" = 'true' ]; then
+            if [ "${{ steps.drift.outcome }}" != 'success' ]; then
+              echo "Drift check did not run — an earlier step failed (outcome: \`${{ steps.drift.outcome }}\`). See the job logs.";
+            elif [ "${{ steps.drift.outputs.drift }}" = 'true' ]; then
               echo "Regeneration from upstream \`${SPEC_REF}\` produced changes — committed generated output is stale.";
               echo '';
               echo 'Regenerate locally (`bash scripts/build.sh`) and commit, or open a regeneration PR.';

--- a/.github/workflows/scheduled-generation-drift.yml
+++ b/.github/workflows/scheduled-generation-drift.yml
@@ -77,7 +77,7 @@ jobs:
           if ! git diff --quiet; then
             echo 'drift=true' >> "$GITHUB_OUTPUT"
             git diff --name-only | sed 's/^/CHANGED: /'
-            git diff > _gen-drift.patch || true
+            git diff > _gen-drift.patch
           else
             echo 'drift=false' >> "$GITHUB_OUTPUT"
             echo 'No generation drift.'

--- a/.github/workflows/scheduled-generation-drift.yml
+++ b/.github/workflows/scheduled-generation-drift.yml
@@ -1,0 +1,107 @@
+name: Scheduled Generation Drift
+
+# Regenerates the SDK from the upstream OpenAPI spec on a schedule and fails if the
+# committed output drifts from what the generator produces. This closes the blind spot
+# where PR/branch CI uses `branches-ignore: [main]` and the PR-time drift step is
+# non-blocking (reporting only), so upstream spec changes stay invisible on main until
+# they ambush an unrelated PR. Fails the job on drift so the scheduled run turns red and
+# notifies maintainers (mirrors the Dependency Audit off-merge-path signal pattern).
+
+on:
+  schedule:
+    # Daily 04:23 UTC (staggered from the weekly Dependency Audit + CodeQL scans).
+    - cron: '23 4 * * *'
+  workflow_dispatch:
+    inputs:
+      spec_ref:
+        description: 'Git ref (branch/tag/SHA) in camunda/camunda to fetch spec from'
+        required: false
+        default: 'main'
+
+permissions:
+  contents: read
+
+env:
+  SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'main' }}
+
+jobs:
+  drift:
+    name: Regenerate and check for drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Fetch & Bundle spec
+        run: bash scripts/bundle-spec.sh
+
+      - name: Generate SDK
+        run: dotnet run --project src/Camunda.Orchestration.Sdk.Generator
+
+      - name: Format Generated Code
+        run: dotnet format src/Camunda.Orchestration.Sdk/Camunda.Orchestration.Sdk.csproj --no-restore
+
+      - name: Detect generation drift
+        id: drift
+        run: |
+          if ! git diff --quiet; then
+            echo 'drift=true' >> "$GITHUB_OUTPUT"
+            git diff --name-only | sed 's/^/CHANGED: /'
+            git diff > _gen-drift.patch || true
+          else
+            echo 'drift=false' >> "$GITHUB_OUTPUT"
+            echo 'No generation drift.'
+          fi
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo '### Scheduled generation drift';
+            echo '';
+            if [ "${{ steps.drift.outputs.drift }}" = 'true' ]; then
+              echo "Regeneration from upstream \`${SPEC_REF}\` produced changes — committed generated output is stale.";
+              echo '';
+              echo 'Regenerate locally (`bash scripts/build.sh`) and commit, or open a regeneration PR.';
+              echo '';
+              echo '```';
+              git --no-pager diff --stat 2>/dev/null || echo '(diff unavailable)';
+              echo '```';
+            else
+              echo "No drift — committed output matches regeneration from upstream \`${SPEC_REF}\`.";
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload drift patch
+        if: steps.drift.outputs.drift == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: generation-drift
+          path: _gen-drift.patch
+
+      - name: Fail on drift
+        if: steps.drift.outputs.drift == 'true'
+        run: |
+          echo "::error::Committed generated output drifts from upstream ${SPEC_REF}. See the job summary and the generation-drift patch artifact." >&2
+          exit 1


### PR DESCRIPTION
## Description

Adds a scheduled workflow that regenerates the SDK from the upstream OpenAPI spec daily and **fails (turns the run red)** when the committed generated output drifts from what the generator produces.

### Why

`ci.yml` uses `push: branches-ignore: [main]`, and its PR-time "Detect Generation Drift" step is non-blocking (reporting only). As a result, upstream spec drift is invisible on `main` until it ambushes an unrelated PR. This is the Lens‑7 gap called out in the PLE repo-audit (#337).

### What

- `on: schedule` daily at `23 4 * * *` (staggered from the weekly Dependency Audit `47 5 * * 1` and CodeQL), plus `workflow_dispatch` with a `spec_ref` input.
- `permissions: contents: read`.
- Runs the real pipeline: `dotnet restore` → `npm ci` → `bash scripts/bundle-spec.sh` → generator → `dotnet format`.
- Diffs the working tree; on drift writes a job summary, uploads a `_gen-drift.patch` artifact, and `exit 1` so the scheduled run goes red and notifies maintainers (mirrors the `dependency-audit.yml` fail-to-signal pattern).

### Notes

Detection-only; it does not auto-open a regeneration PR. Reuses this repo's existing action versions (`checkout@v6`, `setup-dotnet@v5`, `setup-node@v6`, `upload-artifact@v7`).

Relates to #337.
