### PR TITLE
chore(gen): regenerate SDK for upstream spec drift

### DIFF
--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -31409,6 +31409,7 @@
           "JOB_NO_RETRIES",
           "MESSAGE_SIZE_EXCEEDED",
           "RESOURCE_NOT_FOUND",
+          "SECRET_RESOLUTION_ERROR",
           "TASK_LISTENER_NO_RETRIES",
           "UNHANDLED_ERROR_EVENT",
           "UNKNOWN",
@@ -36562,14 +36563,18 @@
             "description": "Indicates whether the start event of the process has an associated Form Key.",
             "type": "boolean"
           },
-          "isDeleted": {
-            "description": "Filter by whether the process definition has been deleted.\nWhen not set, both deleted and non-deleted process definitions are returned.\nSet to `false` to exclude deleted definitions (recommended for most use cases).\nSet to `true` to return only deleted definitions that are still retained in secondary storage.\n",
-            "type": "boolean"
+          "state": {
+            "description": "Filter by the process definition's state.\nWhen not set, process definitions in any state are returned.\nSet to `ACTIVE` to exclude deleted definitions (recommended for most use cases).\nSet to `DELETED` to return only definitions that have been deleted but are still\nretained in secondary storage.\n",
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "DELETED"
+            ]
           }
         },
         "x-properties-added-in-version": [
           {
-            "propertyName": "isDeleted",
+            "propertyName": "state",
             "addedInVersion": "8.10"
           }
         ]
@@ -36598,11 +36603,11 @@
         "type": "object",
         "required": [
           "hasStartForm",
-          "isDeleted",
           "name",
           "processDefinitionId",
           "processDefinitionKey",
           "resourceName",
+          "state",
           "tenantId",
           "version",
           "versionTag"
@@ -36655,14 +36660,18 @@
             "description": "Indicates whether the start event of the process has an associated Form Key.",
             "type": "boolean"
           },
-          "isDeleted": {
-            "description": "Whether this process definition has been deleted but is still retained in secondary storage.",
-            "type": "boolean"
+          "state": {
+            "description": "The state of this process definition.",
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "DELETED"
+            ]
           }
         },
         "x-properties-added-in-version": [
           {
-            "propertyName": "isDeleted",
+            "propertyName": "state",
             "addedInVersion": "8.10"
           }
         ]

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:d13bc9d204c7e72691377d7ac75c580db83acec006dbd3f4635c4fbe05245865",
+  "specHash": "sha256:dc1ef7b1e5da255e2693943a9869f29fbca4ce5250eface7865437c113284d5f",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -831,6 +831,23 @@ public enum PartitionState
 }
 
 /// <summary>
+/// Filter by the process definition&apos;s state.
+/// When not set, process definitions in any state are returned.
+/// Set to `ACTIVE` to exclude deleted definitions (recommended for most use cases).
+/// Set to `DELETED` to return only definitions that have been deleted but are still
+/// retained in secondary storage.
+/// 
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ProcessDefinitionFilterState
+{
+    [JsonPropertyName("ACTIVE")]
+    ACTIVE,
+    [JsonPropertyName("DELETED")]
+    DELETED,
+}
+
+/// <summary>
 /// The field to sort by.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -862,6 +879,18 @@ public enum ProcessDefinitionInstanceVersionStatisticsQuerySortRequestField
     ActiveInstancesWithIncidentCount,
     [JsonPropertyName("activeInstancesWithoutIncidentCount")]
     ActiveInstancesWithoutIncidentCount,
+}
+
+/// <summary>
+/// The state of this process definition.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ProcessDefinitionResultState
+{
+    [JsonPropertyName("ACTIVE")]
+    ACTIVE,
+    [JsonPropertyName("DELETED")]
+    DELETED,
 }
 
 /// <summary>
@@ -15257,6 +15286,8 @@ public enum IncidentErrorTypeEnum
     MESSAGESIZEEXCEEDED,
     [JsonPropertyName("RESOURCE_NOT_FOUND")]
     RESOURCENOTFOUND,
+    [JsonPropertyName("SECRET_RESOLUTION_ERROR")]
+    SECRETRESOLUTIONERROR,
     [JsonPropertyName("TASK_LISTENER_NO_RETRIES")]
     TASKLISTENERNORETRIES,
     [JsonPropertyName("UNHANDLED_ERROR_EVENT")]
@@ -20271,14 +20302,15 @@ public sealed class ProcessDefinitionFilter
     public bool? HasStartForm { get; set; }
 
     /// <summary>
-    /// Filter by whether the process definition has been deleted.
-    /// When not set, both deleted and non-deleted process definitions are returned.
-    /// Set to `false` to exclude deleted definitions (recommended for most use cases).
-    /// Set to `true` to return only deleted definitions that are still retained in secondary storage.
+    /// Filter by the process definition&apos;s state.
+    /// When not set, process definitions in any state are returned.
+    /// Set to `ACTIVE` to exclude deleted definitions (recommended for most use cases).
+    /// Set to `DELETED` to return only definitions that have been deleted but are still
+    /// retained in secondary storage.
     /// 
     /// </summary>
-    [JsonPropertyName("isDeleted")]
-    public bool? IsDeleted { get; set; }
+    [JsonPropertyName("state")]
+    public ProcessDefinitionFilterState? State { get; set; }
 
 }
 
@@ -21002,10 +21034,10 @@ public sealed class ProcessDefinitionResult
     public bool HasStartForm { get; set; }
 
     /// <summary>
-    /// Whether this process definition has been deleted but is still retained in secondary storage.
+    /// The state of this process definition.
     /// </summary>
-    [JsonPropertyName("isDeleted")]
-    public bool IsDeleted { get; set; }
+    [JsonPropertyName("state")]
+    public ProcessDefinitionResultState State { get; set; }
 
 }
 

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:d13bc9d204c7e72691377d7ac75c580db83acec006dbd3f4635c4fbe05245865";
+    public const string SpecHash = "sha256:dc1ef7b1e5da255e2693943a9869f29fbca4ce5250eface7865437c113284d5f";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -3502,10 +3502,11 @@ TYPE Camunda.Orchestration.Sdk.IncidentErrorTypeEnum : enum interfaces=[System.I
   MEMBER JOBNORETRIES = 9 json="JOB_NO_RETRIES"
   MEMBER MESSAGESIZEEXCEEDED = 10 json="MESSAGE_SIZE_EXCEEDED"
   MEMBER RESOURCENOTFOUND = 11 json="RESOURCE_NOT_FOUND"
-  MEMBER TASKLISTENERNORETRIES = 12 json="TASK_LISTENER_NO_RETRIES"
-  MEMBER UNHANDLEDERROREVENT = 13 json="UNHANDLED_ERROR_EVENT"
-  MEMBER UNKNOWN = 14 json="UNKNOWN"
-  MEMBER UNSPECIFIED = 15 json="UNSPECIFIED"
+  MEMBER SECRETRESOLUTIONERROR = 12 json="SECRET_RESOLUTION_ERROR"
+  MEMBER TASKLISTENERNORETRIES = 13 json="TASK_LISTENER_NO_RETRIES"
+  MEMBER UNHANDLEDERROREVENT = 14 json="UNHANDLED_ERROR_EVENT"
+  MEMBER UNKNOWN = 15 json="UNKNOWN"
+  MEMBER UNSPECIFIED = 16 json="UNSPECIFIED"
 
 TYPE Camunda.Orchestration.Sdk.IncidentErrorTypeExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.IncidentErrorTypeExactMatch>]
   PROP System.String Value { get; }
@@ -4657,16 +4658,22 @@ TYPE Camunda.Orchestration.Sdk.ProcessDefinitionElementStatisticsQueryResult : s
 
 TYPE Camunda.Orchestration.Sdk.ProcessDefinitionFilter : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionFilterState? State { get; set; } [JsonPropertyName("state")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey? ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? Name { get; set; } [JsonPropertyName("name")]
   PROP Camunda.Orchestration.Sdk.StringFilterProperty? ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.TenantId? TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Boolean? HasStartForm { get; set; } [JsonPropertyName("hasStartForm")]
-  PROP System.Boolean? IsDeleted { get; set; } [JsonPropertyName("isDeleted")]
   PROP System.Boolean? IsLatestVersion { get; set; } [JsonPropertyName("isLatestVersion")]
   PROP System.Int32? Version { get; set; } [JsonPropertyName("version")]
   PROP System.String? ResourceName { get; set; } [JsonPropertyName("resourceName")]
   PROP System.String? VersionTag { get; set; } [JsonPropertyName("versionTag")]
+
+TYPE Camunda.Orchestration.Sdk.ProcessDefinitionFilterState : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER ACTIVE = 0 json="ACTIVE"
+  MEMBER DELETED = 1 json="DELETED"
 
 TYPE Camunda.Orchestration.Sdk.ProcessDefinitionId : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.ProcessDefinitionId>]
   PROP System.String Value { get; }
@@ -4819,13 +4826,19 @@ TYPE Camunda.Orchestration.Sdk.ProcessDefinitionResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionId ProcessDefinitionId { get; set; } [JsonPropertyName("processDefinitionId")]
   PROP Camunda.Orchestration.Sdk.ProcessDefinitionKey ProcessDefinitionKey { get; set; } [JsonPropertyName("processDefinitionKey")]
+  PROP Camunda.Orchestration.Sdk.ProcessDefinitionResultState State { get; set; } [JsonPropertyName("state")]
   PROP Camunda.Orchestration.Sdk.TenantId TenantId { get; set; } [JsonPropertyName("tenantId")]
   PROP System.Boolean HasStartForm { get; set; } [JsonPropertyName("hasStartForm")]
-  PROP System.Boolean IsDeleted { get; set; } [JsonPropertyName("isDeleted")]
   PROP System.Int32 Version { get; set; } [JsonPropertyName("version")]
   PROP System.String ResourceName { get; set; } [JsonPropertyName("resourceName")]
   PROP System.String? Name { get; set; } [JsonPropertyName("name")]
   PROP System.String? VersionTag { get; set; } [JsonPropertyName("versionTag")]
+
+TYPE Camunda.Orchestration.Sdk.ProcessDefinitionResultState : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER ACTIVE = 0 json="ACTIVE"
+  MEMBER DELETED = 1 json="DELETED"
 
 TYPE Camunda.Orchestration.Sdk.ProcessDefinitionSearchQuery : sealed class
   CTOR ()


### PR DESCRIPTION
## What

Regenerates the committed SDK output (`Generated/`, bundled spec, and the `PublicApi.shipped.txt` baseline) from the current upstream `camunda/camunda@main` OpenAPI spec.

## Why

The `test` job regenerates the SDK from the **live** upstream spec (`SPEC_REF: main`) before running unit tests. Upstream `main` has drifted since the committed output was last refreshed, so the generated code no longer matched the committed snapshots — the `EnumWireContractTests` / `PublicApiSurfaceTests` failed on every PR (job summary reported `driftFlag="true"`). This regeneration brings the committed output back in line and unblocks CI across all open PRs.

This is exactly the blind spot #337 (Lens-7) tracks: because CI does not run on push to `main`, upstream drift stays invisible until it surfaces in an unrelated PR. The scheduled drift check in #351 is designed to catch this proactively.

## Changes (upstream spec drift)

- **`IncidentErrorTypeEnum`**: adds `SECRET_RESOLUTION_ERROR` (shifts the ordinals of subsequent members).
- **`ProcessDefinitionFilter` / `ProcessDefinitionResult`**: `isDeleted` (`bool`) replaced by `state` (new `ProcessDefinitionFilterState` / `ProcessDefinitionResultState` enums with `ACTIVE` / `DELETED`). **This is a breaking change originating upstream** — no hand-written code, examples, or README reference the removed `IsDeleted` property, so only generated output + the API baseline changed.

`main` publishes on the alpha prerelease channel, so this lands on the open `10.0.0-alpha.x` line without overshooting the major.

## Validation

- `bash scripts/bundle-spec.sh` → generator → `dotnet format`
- `dotnet build` clean (0 warnings)
- `PublicApi.shipped.txt` baseline refreshed (net8.0) and normalized to LF
- Full unit suite: **1129 passed, 0 failed**

Related: #337, #351
