### PR TITLE
chore(gen): sync upstream spec (cluster mode enum, sealed empty schemas)

### DIFF
--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -1353,6 +1353,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.ListSecretsAsync(Camunda.Orchestration.Sdk.SecretListRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Secret.cs#ListSecrets)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.GetRuntimeBackupAsync(Camunda.Orchestration.Sdk.BackupId,System.Threading.CancellationToken)
 example:
 - *content

--- a/examples/Client.cs
+++ b/examples/Client.cs
@@ -38,7 +38,7 @@ public static class ClientExamples
 
         // Pass dryRun: true to validate the request and inspect the resulting plan
         // without applying it. Omit it (or set it to false) to trigger the transition.
-        var change = await client.ChangeClusterModeAsync("RECOVERING", dryRun: true);
+        var change = await client.ChangeClusterModeAsync(Mode.RECOVERING, dryRun: true);
 
         Console.WriteLine($"Cluster change {change.ChangeId}:");
         foreach (var operation in change.PlannedChanges)

--- a/examples/Secret.cs
+++ b/examples/Secret.cs
@@ -39,4 +39,25 @@ public static class SecretExamples
     private static void UseSecret(string value) { }
     // </ResolveSecrets>
     #endregion ResolveSecrets
+
+    #region ListSecrets
+
+    // <ListSecrets>
+    public static async Task ListSecretsExample()
+    {
+        using var client = CamundaClient.Create();
+
+        // The request body is reserved for future filtering options and currently
+        // takes no properties.
+        var result = await client.ListSecretsAsync(new SecretListRequest());
+
+        // Only the references are returned — never the secret values. Use
+        // ResolveSecretsAsync to fetch a value when one is actually needed.
+        foreach (var reference in result.References)
+        {
+            Console.WriteLine($"Secret available: {reference}");
+        }
+    }
+    // </ListSecrets>
+    #endregion ListSecrets
 }

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -1499,5 +1499,12 @@
       "region": "ResolveSecrets",
       "label": "Resolve secrets"
     }
+  ],
+  "listSecrets": [
+    {
+      "file": "Secret.cs",
+      "region": "ListSecrets",
+      "label": "List secret references"
+    }
   ]
 }

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -17627,6 +17627,102 @@
         "x-added-in-version": "8.10"
       }
     },
+    "/secrets/list": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Secret"
+        ],
+        "operationId": "listSecrets",
+        "x-permission-enforcement": "filter",
+        "x-required-permissions": [
+          {
+            "resourceType": "SECRET",
+            "permissionType": "READ"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "List secrets (alpha)",
+        "description": "List the `camunda.secrets.*` references known for the caller's physical tenant.\n\nOnly references the caller holds `SECRET:READ` on are returned. This endpoint never\nreturns secret values, only the reference names.\n\nThis endpoint is an alpha feature and may be subject to change in future releases.\n",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SecretListRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The references the caller is authorized to see.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretListResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/setup/user": {
       "post": {
         "x-eventually-consistent": false,
@@ -20209,11 +20305,7 @@
             "required": true,
             "description": "The target cluster mode.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "PROCESSING",
-                "RECOVERING"
-              ]
+              "$ref": "#/components/schemas/Mode"
             }
           },
           {
@@ -26885,6 +26977,14 @@
             }
           }
         }
+      },
+      "Mode": {
+        "description": "The operating mode of a cluster's partitions.",
+        "type": "string",
+        "enum": [
+          "PROCESSING",
+          "RECOVERING"
+        ]
       },
       "TopologyResponse": {
         "description": "The response of a topology request.",
@@ -37848,13 +37948,7 @@
               "DELETED"
             ]
           }
-        },
-        "x-properties-added-in-version": [
-          {
-            "propertyName": "state",
-            "addedInVersion": "8.10"
-          }
-        ]
+        }
       },
       "ProcessDefinitionSearchQueryResult": {
         "type": "object",
@@ -37945,13 +38039,7 @@
               "DELETED"
             ]
           }
-        },
-        "x-properties-added-in-version": [
-          {
-            "propertyName": "state",
-            "addedInVersion": "8.10"
-          }
-        ]
+        }
       },
       "ProcessDefinitionElementStatisticsQuery": {
         "description": "Process definition element statistics request.",
@@ -40808,6 +40896,28 @@
           "ACCESS_DENIED",
           "INVALID_REFERENCE"
         ]
+      },
+      "SecretListRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Reserved for future filtering options. Currently takes no properties. The request body is\noptional: omitting it (or sending an empty object) applies no filters.\n"
+      },
+      "SecretListResult": {
+        "type": "object",
+        "required": [
+          "references"
+        ],
+        "description": "The secret references the caller is authorized to see.\n\nUnbounded for now: Phase 1's backend is mocked with at most 3 references. Pagination is\nexpected to land here before GA, once a real secret store can return a tenant's full\nenumeration in one response. This is an alpha endpoint, so that is not yet a\nbreaking-contract concern.\n",
+        "properties": {
+          "references": {
+            "type": "array",
+            "description": "The secret references, each of the form `camunda.secrets.<name>`.",
+            "items": {
+              "type": "string",
+              "description": "A secret reference of the form `camunda.secrets.<name>`."
+            }
+          }
+        }
       },
       "SignalBroadcastRequest": {
         "type": "object",

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:a855a2b8055d58b73113e05937657239fd13e40fd8c5648ce7f84c6db1a99717",
+  "specHash": "sha256:a7939e6269dd779f0b706ea2869d62646eeec0b54b8f35cb0f8185da92e84a9d",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -9562,6 +9562,42 @@
       }
     },
     {
+      "operationId": "listSecrets",
+      "path": "/secrets/list",
+      "method": "post",
+      "tags": [
+        "Secret"
+      ],
+      "summary": "List secrets (alpha)",
+      "description": "List the `camunda.secrets.*` references known for the caller's physical tenant.\n\nOnly references the caller holds `SECRET:READ` on are returned. This endpoint never\nreturns secret values, only the reference names.\n\nThis endpoint is an alpha feature and may be subject to change in future releases.\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": true,
+      "pathParams": [],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "secrets.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "SecretListRequest",
+      "successResponseSchemaRef": "SecretListResult",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-permission-enforcement": "filter",
+        "x-required-permissions": [
+          {
+            "resourceType": "SECRET",
+            "permissionType": "READ"
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "createAdminUser",
       "path": "/setup/user",
       "method": "post",
@@ -11700,7 +11736,7 @@
   "integrity": {
     "totalSemanticKeys": 41,
     "totalUnions": 65,
-    "totalOperations": 213,
+    "totalOperations": 214,
     "totalEventuallyConsistent": 92,
     "totalDeprecatedEnumSchemas": 2,
     "totalSemanticProviders": 23

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -831,7 +831,7 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<ClusterModeChangeResponse> ChangeClusterModeAsync(string mode, bool? dryRun = null, CancellationToken ct = default)
+    public async Task<ClusterModeChangeResponse> ChangeClusterModeAsync(Mode mode, bool? dryRun = null, CancellationToken ct = default)
     {
         var queryParts = new List<string>();
         queryParts.Add("mode=" + Uri.EscapeDataString(mode.ToString()!));
@@ -5332,6 +5332,23 @@ public partial class CamundaClient
         if (prefix != null) queryParts.Add("prefix=" + Uri.EscapeDataString(prefix.ToString()!));
         var path = queryParts.Count > 0 ? $"/backups/runtime?{string.Join("&", queryParts)}" : $"/backups/runtime";
         return await InvokeWithRetryAsync(() => SendAsync<object>(HttpMethod.Get, path, null, ct), "listRuntimeBackups", false, ct);
+    }
+
+    /// <summary>
+    /// List secrets (alpha)
+    /// List the `camunda.secrets.*` references known for the caller&apos;s physical tenant.
+    /// 
+    /// Only references the caller holds `SECRET:READ` on are returned. This endpoint never
+    /// returns secret values, only the reference names.
+    /// 
+    /// This endpoint is an alpha feature and may be subject to change in future releases.
+    /// 
+    /// </summary>
+    /// <remarks>Operation: listSecrets</remarks>
+    public async Task<SecretListResult> ListSecretsAsync(SecretListRequest body, CancellationToken ct = default)
+    {
+        var path = $"/secrets/list";
+        return await InvokeWithRetryAsync(() => SendAsync<SecretListResult>(HttpMethod.Post, path, body, ct), "listSecrets", false, ct);
     }
 
     /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -19951,6 +19951,18 @@ public sealed class MigrateProcessInstanceMappingInstruction
 }
 
 /// <summary>
+/// The operating mode of a cluster&apos;s partitions.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum Mode
+{
+    [JsonPropertyName("PROCESSING")]
+    PROCESSING,
+    [JsonPropertyName("RECOVERING")]
+    RECOVERING,
+}
+
+/// <summary>
 /// Instruction describing which variables to create or update.
 /// </summary>
 public sealed class ModifyProcessInstanceVariableInstruction
@@ -24670,6 +24682,34 @@ public enum SecretErrorCode
     ACCESSDENIED,
     [JsonPropertyName("INVALID_REFERENCE")]
     INVALIDREFERENCE,
+}
+
+/// <summary>
+/// Reserved for future filtering options. Currently takes no properties. The request body is
+/// optional: omitting it (or sending an empty object) applies no filters.
+/// 
+/// </summary>
+public sealed class SecretListRequest
+{
+}
+
+/// <summary>
+/// The secret references the caller is authorized to see.
+/// 
+/// Unbounded for now: Phase 1&apos;s backend is mocked with at most 3 references. Pagination is
+/// expected to land here before GA, once a real secret store can return a tenant&apos;s full
+/// enumeration in one response. This is an alpha endpoint, so that is not yet a
+/// breaking-contract concern.
+/// 
+/// </summary>
+public sealed class SecretListResult
+{
+    /// <summary>
+    /// The secret references, each of the form `camunda.secrets.&lt;name&gt;`.
+    /// </summary>
+    [JsonPropertyName("references")]
+    public List<string> References { get; set; } = null!;
+
 }
 
 /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:a855a2b8055d58b73113e05937657239fd13e40fd8c5648ce7f84c6db1a99717";
+    public const string SpecHash = "sha256:a7939e6269dd779f0b706ea2869d62646eeec0b54b8f35cb0f8185da92e84a9d";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/BareObjectSchemaTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/BareObjectSchemaTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Camunda.Orchestration.Sdk.Generator;
 using Microsoft.OpenApi;
@@ -62,16 +63,25 @@ public class BareObjectSchemaTests
     }
 
     /// <summary>
-    /// Class-scoped sweep: no generated model in the current SDK should be
-    /// an empty sealed class. If a response schema has no properties, it
-    /// should not have been emitted as a class at all.
+    /// Class-scoped sweep: no generated model may be an empty sealed class
+    /// <em>unless</em> the spec deliberately declares it sealed and empty
+    /// (<c>additionalProperties: false</c> with no properties).
+    ///
+    /// The defect this guards is a free-form <c>{ "type": "object" }</c> schema
+    /// producing a useless empty class instead of mapping to <c>object</c> /
+    /// <c>Dictionary&lt;string, …&gt;</c>. A named component that explicitly
+    /// forbids additional properties is a different thing: an intentionally
+    /// empty contract (e.g. a request body reserved for future filters). Those
+    /// stay classes on purpose — when the spec later adds properties, callers
+    /// keep compiling, whereas an <c>object</c> parameter would have to change
+    /// type and break them.
     /// </summary>
     [Fact]
-    public void GeneratedModels_NoEmptyClasses()
+    public void GeneratedModels_NoEmptyClasses_ExceptDeliberatelySealedSchemas()
     {
+        var repoRoot = FindRepoRoot();
         var modelsPath = Path.Combine(
-            FindRepoRoot(),
-            "src", "Camunda.Orchestration.Sdk", "Generated", "Models.Generated.cs");
+            repoRoot, "src", "Camunda.Orchestration.Sdk", "Generated", "Models.Generated.cs");
 
         Assert.True(File.Exists(modelsPath), $"Models.Generated.cs not found at {modelsPath}");
         var content = File.ReadAllText(modelsPath);
@@ -81,14 +91,57 @@ public class BareObjectSchemaTests
             @"public sealed class (\w+)\s*\{\s*\}",
             RegexOptions.Multiline);
 
-        var matches = emptyClassPattern.Matches(content);
-        if (matches.Count > 0)
+        var offenders = emptyClassPattern.Matches(content)
+            .Cast<Match>()
+            .Select(m => m.Groups[1].Value)
+            .Where(name => !IsDeliberatelySealedEmptySchema(repoRoot, name))
+            .ToList();
+
+        if (offenders.Count > 0)
         {
-            var names = string.Join(", ", matches.Cast<Match>().Select(m => m.Groups[1].Value));
             Assert.Fail(
-                $"Found {matches.Count} empty class(es) in Models.Generated.cs: {names}. " +
-                "Bare 'type: object' schemas should map to 'object' or 'Dictionary<string, ...>', not empty classes.");
+                $"Found {offenders.Count} empty class(es) in Models.Generated.cs: {string.Join(", ", offenders)}. " +
+                "Free-form 'type: object' schemas should map to 'object' or 'Dictionary<string, ...>', not empty classes. " +
+                "Only components that declare 'additionalProperties: false' with no properties may be emitted as empty classes.");
         }
+    }
+
+    /// <summary>
+    /// True when the bundled spec declares <paramref name="schemaName"/> as an
+    /// object with no properties and <c>additionalProperties: false</c> — an
+    /// intentionally empty contract rather than a free-form object.
+    /// </summary>
+    private static bool IsDeliberatelySealedEmptySchema(string repoRoot, string schemaName)
+    {
+        var specPath = Path.Combine(repoRoot, "external-spec", "bundled", "rest-api.bundle.json");
+        if (!File.Exists(specPath))
+            return false;
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(specPath));
+        if (!doc.RootElement.TryGetProperty("components", out var components) ||
+            !components.TryGetProperty("schemas", out var schemas) ||
+            !schemas.TryGetProperty(schemaName, out var schema))
+        {
+            // Not a named component (e.g. an inline schema the generator
+            // materialised) — that is the defect this test exists for.
+            return false;
+        }
+
+        var isObject = schema.TryGetProperty("type", out var type) &&
+                       type.ValueKind == JsonValueKind.String &&
+                       type.GetString() == "object";
+
+        var hasNoProperties = !schema.TryGetProperty("properties", out var props) ||
+                              props.EnumerateObject().Any() == false;
+
+        var sealsAdditional = schema.TryGetProperty("additionalProperties", out var addl) &&
+                              addl.ValueKind == JsonValueKind.False;
+
+        var hasNoComposition = !schema.TryGetProperty("allOf", out _) &&
+                               !schema.TryGetProperty("oneOf", out _) &&
+                               !schema.TryGetProperty("anyOf", out _);
+
+        return isObject && hasNoProperties && sealsAdditional && hasNoComposition;
     }
 
     private static string FindRepoRoot()

--- a/test/Camunda.Orchestration.Sdk.Tests/BareObjectSchemaTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/BareObjectSchemaTests.cs
@@ -91,10 +91,12 @@ public class BareObjectSchemaTests
             @"public sealed class (\w+)\s*\{\s*\}",
             RegexOptions.Multiline);
 
+        var sealedEmptySchemas = LoadDeliberatelySealedEmptySchemas(repoRoot);
+
         var offenders = emptyClassPattern.Matches(content)
             .Cast<Match>()
             .Select(m => m.Groups[1].Value)
-            .Where(name => !IsDeliberatelySealedEmptySchema(repoRoot, name))
+            .Where(name => !sealedEmptySchemas.Contains(name))
             .ToList();
 
         if (offenders.Count > 0)
@@ -107,41 +109,53 @@ public class BareObjectSchemaTests
     }
 
     /// <summary>
-    /// True when the bundled spec declares <paramref name="schemaName"/> as an
-    /// object with no properties and <c>additionalProperties: false</c> — an
-    /// intentionally empty contract rather than a free-form object.
+    /// Names of component schemas the bundled spec declares as objects with no
+    /// properties and <c>additionalProperties: false</c> — intentionally empty
+    /// contracts rather than free-form objects. The spec is parsed once per
+    /// call so reporting many offenders does not re-read it per candidate.
+    /// Anything not in this set (including inline schemas the generator
+    /// materialised) is treated as the defect this test guards.
     /// </summary>
-    private static bool IsDeliberatelySealedEmptySchema(string repoRoot, string schemaName)
+    private static HashSet<string> LoadDeliberatelySealedEmptySchemas(string repoRoot)
     {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+
         var specPath = Path.Combine(repoRoot, "external-spec", "bundled", "rest-api.bundle.json");
         if (!File.Exists(specPath))
-            return false;
+            return result;
 
         using var doc = JsonDocument.Parse(File.ReadAllText(specPath));
         if (!doc.RootElement.TryGetProperty("components", out var components) ||
-            !components.TryGetProperty("schemas", out var schemas) ||
-            !schemas.TryGetProperty(schemaName, out var schema))
+            !components.TryGetProperty("schemas", out var schemas))
         {
-            // Not a named component (e.g. an inline schema the generator
-            // materialised) — that is the defect this test exists for.
-            return false;
+            return result;
         }
 
-        var isObject = schema.TryGetProperty("type", out var type) &&
-                       type.ValueKind == JsonValueKind.String &&
-                       type.GetString() == "object";
+        foreach (var entry in schemas.EnumerateObject())
+        {
+            var schema = entry.Value;
+            if (schema.ValueKind != JsonValueKind.Object)
+                continue;
 
-        var hasNoProperties = !schema.TryGetProperty("properties", out var props) ||
-                              props.EnumerateObject().Any() == false;
+            var isObject = schema.TryGetProperty("type", out var type) &&
+                           type.ValueKind == JsonValueKind.String &&
+                           type.GetString() == "object";
 
-        var sealsAdditional = schema.TryGetProperty("additionalProperties", out var addl) &&
-                              addl.ValueKind == JsonValueKind.False;
+            var hasNoProperties = !schema.TryGetProperty("properties", out var props) ||
+                                  !props.EnumerateObject().Any();
 
-        var hasNoComposition = !schema.TryGetProperty("allOf", out _) &&
-                               !schema.TryGetProperty("oneOf", out _) &&
-                               !schema.TryGetProperty("anyOf", out _);
+            var sealsAdditional = schema.TryGetProperty("additionalProperties", out var addl) &&
+                                  addl.ValueKind == JsonValueKind.False;
 
-        return isObject && hasNoProperties && sealsAdditional && hasNoComposition;
+            var hasNoComposition = !schema.TryGetProperty("allOf", out _) &&
+                                   !schema.TryGetProperty("oneOf", out _) &&
+                                   !schema.TryGetProperty("anyOf", out _);
+
+            if (isObject && hasNoProperties && sealsAdditional && hasNoComposition)
+                result.Add(entry.Name);
+        }
+
+        return result;
     }
 
     private static string FindRepoRoot()

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -1676,7 +1676,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationResponse> GetBatchOperationAsync(Camunda.Orchestration.Sdk.BatchOperationKey batchOperationKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationResponse>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult> SearchBatchOperationsAsync(Camunda.Orchestration.Sdk.BatchOperationSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.CamundaUserResult> GetAuthenticationAsync(System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> ChangeClusterModeAsync(System.String mode, System.Boolean? dryRun = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> ChangeClusterModeAsync(Camunda.Orchestration.Sdk.Mode mode, System.Boolean? dryRun = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> RestoreAsync(Camunda.Orchestration.Sdk.RestoreRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> CreateGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.CreateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> CreateTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.CreateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
@@ -1765,6 +1765,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RoleUserSearchResult> SearchUsersForRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, Camunda.Orchestration.Sdk.RoleUserSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.RoleUserSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RuntimeBackupState> GetRuntimeBackupStateAsync(System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.RuntimeBackupState> SyncRuntimeBackupStateAsync(System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SecretListResult> ListSecretsAsync(Camunda.Orchestration.Sdk.SecretListRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SecretResolveResult> ResolveSecretsAsync(Camunda.Orchestration.Sdk.SecretResolveRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SignalBroadcastResult> BroadcastSignalAsync(Camunda.Orchestration.Sdk.SignalBroadcastRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SystemConfigurationResponse> GetSystemConfigurationAsync(System.Threading.CancellationToken ct = null)
@@ -4551,6 +4552,12 @@ TYPE Camunda.Orchestration.Sdk.MigrateProcessInstanceMappingInstruction : sealed
   PROP Camunda.Orchestration.Sdk.ElementId SourceElementId { get; set; } [JsonPropertyName("sourceElementId")]
   PROP Camunda.Orchestration.Sdk.ElementId TargetElementId { get; set; } [JsonPropertyName("targetElementId")]
 
+TYPE Camunda.Orchestration.Sdk.Mode : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER PROCESSING = 0 json="PROCESSING"
+  MEMBER RECOVERING = 1 json="RECOVERING"
+
 TYPE Camunda.Orchestration.Sdk.ModifyProcessInstanceVariableInstruction : sealed class
   CTOR ()
   PROP System.Object Variables { get; set; } [JsonPropertyName("variables")]
@@ -5686,6 +5693,13 @@ TYPE Camunda.Orchestration.Sdk.SecretErrorCode : enum interfaces=[System.ICompar
   MEMBER NOTFOUND = 0 json="NOT_FOUND"
   MEMBER ACCESSDENIED = 1 json="ACCESS_DENIED"
   MEMBER INVALIDREFERENCE = 2 json="INVALID_REFERENCE"
+
+TYPE Camunda.Orchestration.Sdk.SecretListRequest : sealed class
+  CTOR ()
+
+TYPE Camunda.Orchestration.Sdk.SecretListResult : sealed class
+  CTOR ()
+  PROP System.Collections.Generic.List<System.String> References { get; set; } [JsonPropertyName("references")]
 
 TYPE Camunda.Orchestration.Sdk.SecretResolutionError : sealed class
   CTOR ()


### PR DESCRIPTION
## Why

`main` is red for **every** open PR, including dependency PRs that would otherwise auto-merge (#312, #314, #318, #325, #333, #334, #344 are all sitting unmerged for this reason). CI regenerates the SDK from current upstream on each run, and two independent drifts have landed since the last sync:

1. **Cluster mode is now an enum.** The generated signature became `ChangeClusterModeAsync(Mode mode, ...)`, so the hand-written example failed to compile:
   `examples/Client.cs(41,58): error CS1503: Argument 1: cannot convert from 'string' to 'Camunda.Orchestration.Sdk.Mode'`
2. **New `SecretListRequest` schema** is an object with no properties and `additionalProperties: false` — *"Reserved for future filtering options. Currently takes no properties."* The generator emits an empty class, which `BareObjectSchemaTests.GeneratedModels_NoEmptyClasses` rejected.

## What

Three commits:

1. **`test:`** narrow the no-empty-classes guard. It was written to catch free-form `{ "type": "object" }` schemas being materialised as useless empty classes. A *named* component that declares `additionalProperties: false` with no properties is a different thing — an intentionally empty contract. Keeping it a class is the forward-compatible choice: when upstream adds filter properties, callers keep compiling, whereas mapping the body to `object` now would force a breaking parameter-type change later. The sweep now consults the bundled spec and exempts only objects with no properties, no `allOf`/`oneOf`/`anyOf`, and `additionalProperties: false`. Inline (non-component) empty classes still fail, so the original defect class stays covered.
2. **`fix(examples):`** pass `Mode.RECOVERING` instead of `"RECOVERING"`.
3. **`chore(gen):`** the regenerated output + refreshed `PublicApi.shipped.txt`.

## Validation

- `dotnet build` (Release): 0 errors
- `dotnet build docs/examples/Examples.csproj`: 0 errors
- `dotnet test`: **1147 passed**, 0 failed (net8.0 + net10.0)
- `dotnet format --verify-no-changes`: clean

Once this merges, re-running CI on the open PRs should green them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)