### PR TITLE
ci: enable Slack bot-token notifications and merge reactions

### DIFF
--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -4,19 +4,23 @@ on:
   issues:
     types: [opened]
   pull_request_target:
-    types: [opened]
+    types: [opened, closed]
 
 permissions: {}
 
 jobs:
   notify:
+    permissions:
+      pull-requests: write
     uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1
     with:
       repo-name: orchestration-cluster-api-csharp
       mention-group: ${{ vars.SLACK_MENTION_GROUP }}
+      slack-channel-id: ${{ vars.SLACK_SDK_ALERTS_CHANNEL_ID }}
       author-association: ${{ github.event.pull_request.author_association || github.event.issue.author_association }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}
+      slack-bot-token: ${{ secrets.SLACK_SDK_BOT_TOKEN }}
       vault-addr: ${{ secrets.VAULT_ADDR }}
       vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
       vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -10,15 +10,21 @@ permissions: {}
 
 jobs:
   notify:
+    # `closed` fires on every close, not just merges. An unmerged close is a
+    # no-op inside the reusable workflow, so skip the call entirely rather
+    # than producing an empty run and materialising secrets for nothing.
+    if: github.event.action == 'opened' || github.event.pull_request.merged == true
     permissions:
       # The Slack message reference is recorded via the Issues Comments API,
       # which is shared between issues and PRs. Both scopes are granted because
       # GitHub does not document which one is checked for a PR target.
       issues: write
       pull-requests: write
-    # PILOT: temporarily pinned to the sdk-infra feature branch to validate the
-    # merge-reaction flow before v1 is retagged. Revert this commit to restore @v1.
-    uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@feat/slack-reaction-on-merge
+    # PILOT: temporarily pinned to an sdk-infra feature-branch commit to validate
+    # the merge-reaction flow before v1 is retagged. Pinned by SHA rather than by
+    # branch so the executed code is immutable and auditable.
+    # Revert this commit to restore @v1.
+    uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@aaacb8a6f5e536ee80431853a7acbb170ab8b3fb # feat/slack-reaction-on-merge
     with:
       repo-name: orchestration-cluster-api-csharp
       mention-group: ${{ vars.SLACK_MENTION_GROUP }}

--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -11,6 +11,10 @@ permissions: {}
 jobs:
   notify:
     permissions:
+      # The Slack message reference is recorded via the Issues Comments API,
+      # which is shared between issues and PRs. Both scopes are granted because
+      # GitHub does not document which one is checked for a PR target.
+      issues: write
       pull-requests: write
     # PILOT: temporarily pinned to the sdk-infra feature branch to validate the
     # merge-reaction flow before v1 is retagged. Revert this commit to restore @v1.

--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -12,7 +12,9 @@ jobs:
   notify:
     permissions:
       pull-requests: write
-    uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1
+    # PILOT: temporarily pinned to the sdk-infra feature branch to validate the
+    # merge-reaction flow before v1 is retagged. Revert this commit to restore @v1.
+    uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@feat/slack-reaction-on-merge
     with:
       repo-name: orchestration-cluster-api-csharp
       mention-group: ${{ vars.SLACK_MENTION_GROUP }}


### PR DESCRIPTION
## What

Adopts the Slack bot-token notification path so the bot adds a `:white_check_mark:` reaction to its own message when the announced PR is merged.

Requires camunda/sdk-infra#23.

## Changes

- `pull_request_target` now also listens for `closed` (needed to detect a merge).
- The `notify` job declares `permissions: pull-requests: write` so the reusable workflow can record the Slack message reference on the PR. A called workflow cannot escalate beyond the caller's grant, and this repo sets workflow-level `permissions: {}`.
- Passes the new `slack-channel-id` input and `slack-bot-token` secret.

## Pilot

This repo is the pilot for the rollout. The second commit temporarily pins `uses:` to the sdk-infra feature branch instead of `@v1`, because `pull_request_target` workflows always run from the default branch — the change has to be on `main` here before any PR event can exercise it.

**Revert that commit once `v1` is retagged in sdk-infra.** It is isolated for exactly that reason.

The other three callers (c8ctl, js, python) are held back deliberately: they pin `@v1`, and merging them before the retag would pass inputs the current `v1` does not declare, which fails workflow validation.

## Validation plan

1. Merge this PR.
2. Wait for a Dependabot PR; confirm the Slack message posts and a hidden marker comment appears on the PR.
3. Merge that PR; confirm the `:white_check_mark:` lands on the Slack message.
4. Retag `v1` in sdk-infra, then revert the pilot pin commit.

## Prerequisites (already configured)

- `SLACK_SDK_BOT_TOKEN` — repository secret.
- `SLACK_SDK_ALERTS_CHANNEL_ID` — repository variable (must be a variable; `secrets` is unavailable in the `with:` context).
- The bot is invited to the target channel.
