### PR TITLE
ci: restore @v1 pin for the Slack notification workflow

### DIFF
--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -20,11 +20,7 @@ jobs:
       # GitHub does not document which one is checked for a PR target.
       issues: write
       pull-requests: write
-    # PILOT: temporarily pinned to an sdk-infra feature-branch commit to validate
-    # the merge-reaction flow before v1 is retagged. Pinned by SHA rather than by
-    # branch so the executed code is immutable and auditable.
-    # Revert this commit to restore @v1.
-    uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@aaacb8a6f5e536ee80431853a7acbb170ab8b3fb # feat/slack-reaction-on-merge
+    uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1
     with:
       repo-name: orchestration-cluster-api-csharp
       mention-group: ${{ vars.SLACK_MENTION_GROUP }}


### PR DESCRIPTION
## What

Restores `@v1` on the shared Slack notification workflow, removing the pilot
SHA pin.

## Why

The pin existed so the merge-reaction feature could be validated in exactly one
repo before `v1` moved, keeping any defect contained. It earned its keep — the
pilot surfaced two real misconfigurations that would otherwise have taken all
four SDK repos' notifications offline simultaneously:

1. `chat.postMessage failed: missing_scope` — the bot token lacked `chat:write`.
2. `chat.postMessage failed: not_in_channel` — the bot was not a member of the
   target channel. (Incoming webhooks are bound to a channel at creation, so
   this requirement is new with the bot-token path.)

Both are fixed. Validation is complete:

| run | outcome |
| --- | --- |
| [30506026939](https://github.com/camunda/orchestration-cluster-api-csharp/actions/runs/30506026939) | posted the message and recorded the marker comment |
| [30507098721](https://github.com/camunda/orchestration-cluster-api-csharp/actions/runs/30507098721) | `react-on-merge` added the reaction when #363 merged |

`v1` now points at sdk-infra `2b7f4bd` (main), which is the same workflow the
pilot ran plus [sdk-infra#25](https://github.com/camunda/sdk-infra/pull/25),
which makes Slack scope errors report `needed` and `provided` instead of a bare
error code.

## Scope

Only the `uses:` ref and the pilot comment block. No change to triggers, the
job guard, permissions, inputs, or secrets.
