### PR TITLE
fix(ci): put the branch in the agent prompt and catch untracked leftovers

### DIFF
--- a/.github/workflows/agent-pr-followup.yml
+++ b/.github/workflows/agent-pr-followup.yml
@@ -284,6 +284,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR: ${{ needs.triage.outputs.pr }}
+          BRANCH: ${{ needs.triage.outputs.branch }}
           REASON: ${{ needs.triage.outputs.reason }}
         run: |
           set -euo pipefail
@@ -301,8 +302,8 @@ jobs:
 
           Something needs fixing. The trigger and the feedback to act on follow.
           PROMPT_HEAD
-            printf '\n  Repository: %s\n  Pull request: #%s\n  Trigger: %s\n\n' \
-              "$GITHUB_REPOSITORY" "$PR" "$REASON"
+            printf '\n  Repository: %s\n  Pull request: #%s\n  Branch: %s\n  Trigger: %s\n\n' \
+              "$GITHUB_REPOSITORY" "$PR" "$BRANCH" "$REASON"
             echo "  Feedback:"
             sed 's/^/  /' /tmp/feedback.md
             cat <<'PROMPT_TAIL'
@@ -343,8 +344,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! git diff --quiet || ! git diff --cached --quiet; then
-            echo "::error::The agent left uncommitted changes; refusing to push a partial fix."
+          # --porcelain rather than `git diff`, so untracked leftovers (scratch files,
+          # stray build output) also fail the run. The prompt demands a clean tree, and
+          # tracked-only checks let the most common form of mess through. Ignored paths
+          # are still excluded, so normal build artefacts do not trip this.
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::The agent left the working tree dirty; refusing to push a partial fix."
             git status --short
             exit 1
           fi


### PR DESCRIPTION
Follow-up to #368. These two fixes were pushed to that branch in `f2c4b3cf4` but the squash merge landed a few minutes earlier, so they missed `main`. Everything else from the review round (`actions: read`, the anchored `/agent fix` matcher, the empty-log guard) did make it in via `498ec9afb`.

Both came from the last Copilot review on #368:

**Branch missing from the prompt.** The prompt told the agent it was working on "the branch of the pull request named below" but only printed repository, PR and trigger. Adding it required also passing `BRANCH` into the step `env` — the step runs `set -euo pipefail`, so referencing an unset variable would have aborted the run rather than just printing nothing.

**Cleanliness guard only saw tracked paths.** `git diff` plus `git diff --cached` miss untracked files, so an agent leaving scratch files or stray build output passed the check and pushed, despite the prompt requiring a clean tree. Verified in a scratch repo:

```
untracked stray -> DIRTY (correct)
  (old tracked-only check said clean -> would have pushed)
only ignored/ present -> CLEAN (correct)
```

`git status --porcelain` catches untracked files while still excluding gitignored build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)