### PR TITLE
docs: remove technical preview status from the C# SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Camunda 8 Orchestration Cluster API — C# SDK (Technical Preview)
+# Camunda 8 Orchestration Cluster API — C# SDK
 
 <!-- WARNING: The content and specific structure of this file drives Docusaurus generation in camunda-docs. Also, code examples are injected during build. Please refer to MAINTAINER.md before editing. -->
 <!-- docs:cut:start -->
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/github/license/camunda/orchestration-cluster-api-csharp)](LICENSE)
 <!-- docs:cut:end -->
 
-Technical preview of the C# client SDK for the [Camunda 8 Orchestration Cluster REST API](https://docs.camunda.io/docs/apis-tools/camunda-api-rest/camunda-api-rest-overview/).
+The C# client SDK for the [Camunda 8 Orchestration Cluster REST API](https://docs.camunda.io/docs/apis-tools/camunda-api-rest/camunda-api-rest-overview/).
 
 Unified configuration, OAuth/Basic auth, automatic retry, backpressure management, strongly-typed domain keys, and opt-in typed variables.
 
@@ -17,9 +17,9 @@ Full API Documentation available [here](https://camunda.github.io/orchestration-
 
 ## Support status
 
-This is a technical preview of the C# client that will become fully supported in Camunda 8.10.0. 
+The C# SDK is fully supported from Camunda 8.10.
 
-The Technical Preview gives you a stable foundation to build on now, with a clear path to full support. We don't anticipate major changes — and [your feedback](https://github.com/camunda/orchestration-cluster-api-csharp/issues) between now and 8.10 is what closes that gap.
+[Report an issue or share feedback](https://github.com/camunda/orchestration-cluster-api-csharp/issues) on GitHub.
 
 ## Installation
 

--- a/scripts/generate-docusaurus-md.py
+++ b/scripts/generate-docusaurus-md.py
@@ -71,28 +71,6 @@ def _escape_yaml(s: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Technical Preview banner (injected after first H1 on every page)
-# ---------------------------------------------------------------------------
-
-TECH_PREVIEW_BANNER = (
-    "\n:::caution Technical Preview\n"
-    "The C# SDK is a **technical preview** available from Camunda 8.9. "
-    "It will become fully supported in Camunda 8.10. "
-    "Its API surface may change in future releases without following semver.\n"
-    ":::\n"
-)
-
-
-def inject_tech_preview_banner(content: str) -> str:
-    """Insert the Technical Preview banner after the first H1 heading."""
-    m = re.search(r"^#\s+.+$", content, re.MULTILINE)
-    if m:
-        pos = m.end()
-        return content[:pos] + "\n" + TECH_PREVIEW_BANNER + content[pos:]
-    return content
-
-
-# ---------------------------------------------------------------------------
 # Link rewriting: docs.camunda.io → relative
 # ---------------------------------------------------------------------------
 
@@ -1205,8 +1183,8 @@ def _make_section_frontmatter(
 LANDING_FRONTMATTER = textwrap.dedent("""\
     ---
     id: csharp-sdk
-    title: "C# SDK (Technical Preview)"
-    sidebar_label: "C# SDK (Technical Preview)"
+    title: "C# SDK"
+    sidebar_label: "C# SDK"
     sidebar_position: 1
     mdx:
       format: md
@@ -1225,7 +1203,7 @@ def generate_readme_pages(readme_path: Path, output_dir: Path) -> None:
     # Replace the H1 title with a shorter one
     content = re.sub(
         r"^#\s+.*$",
-        "# C# SDK (Technical Preview)",
+        "# C# SDK",
         content,
         count=1,
         flags=re.MULTILINE,
@@ -1240,7 +1218,6 @@ def generate_readme_pages(readme_path: Path, output_dir: Path) -> None:
 
     # --- Landing page: sibling of the section directory ---
     landing_preamble = _rewrite_docs_links(preamble, depth=_LANDING_PAGE_DEPTH)
-    landing_preamble = inject_tech_preview_banner(landing_preamble)
     landing_path = output_dir / "csharp-sdk.md"
     landing_path.write_text(
         LANDING_FRONTMATTER + landing_preamble.strip() + "\n", encoding="utf-8"
@@ -1257,7 +1234,6 @@ def generate_readme_pages(readme_path: Path, output_dir: Path) -> None:
         section_content = _rewrite_docs_links(body, depth=_SECTION_PAGE_DEPTH)
         section_content = _rewrite_internal_anchors(section_content, slug, anchor_map)
         page_content = _promote_headings(section_content)
-        page_content = inject_tech_preview_banner(page_content)
         fm = _make_section_frontmatter(slug, title, position)
         page_path = section_dir / f"{slug}.md"
         page_path.write_text(fm + page_content.strip() + "\n", encoding="utf-8")
@@ -1395,7 +1371,6 @@ def main() -> None:
         for filename, gen_fn in generators.items():
             content = gen_fn()
             content = rewrite_camunda_docs_links(content)
-            content = inject_tech_preview_banner(content)
             out_path = OUTPUT_DIR / filename
             out_path.write_text(content, encoding="utf-8")
             print(f"  Wrote {out_path} ({len(content)} bytes)")


### PR DESCRIPTION
## What

Removes the "Technical Preview" status from the C# SDK docs surface.

- `scripts/generate-docusaurus-md.py`: deletes the hardcoded `TECH_PREVIEW_BANNER`
  constant, the `inject_tech_preview_banner()` helper, and all three call sites
  (landing preamble, section pages, API reference pages). Also drops
  `(Technical Preview)` from `LANDING_FRONTMATTER` (`title` / `sidebar_label`) and
  from the H1 the generator rewrites.
- `README.md`: title and intro no longer say "Technical Preview"; the
  **Support status** section now reads "The C# SDK is fully supported from
  Camunda 8.10."

## Why

The C# SDK is fully supported from Camunda 8.10, so the preview qualifier no
longer applies.

This has to land here, not only in camunda-docs. The banner is injected by the
generator after the first H1 of every generated page, and camunda-docs regenerates
the whole C# tree from this repo via its `Sync C# SDK docs` workflow
(`dotnet docfx metadata` → `python3 scripts/generate-docusaurus-md.py`). Removing
the markers downstream alone would be reverted on the next sync.

## Paired change

camunda/camunda-docs#9552 removes the same markers from the already-synced pages.
Only the `docs/` (8.10) tree changes there — `versioned_docs/version-8.9/` keeps the
preview wording, which was accurate for that release.

## Verification

- `python scripts/generate-docusaurus-md.py --readme-only` regenerates cleanly
  (landing + 14 section pages + `_category_.json`).
- The regenerated landing page and `support-status.md` match the hand-edited
  camunda-docs files byte-for-byte on every changed line.
- `python scripts/sync-readme-snippets.py --check` passes.
- No test in this repo asserts on the banner.
