### PR TITLE
feat(worker): support TenantFilter and CAMUNDA_TENANT_IDS in job workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ CAMUNDA_OAUTH_URL=https://login.cloud.camunda.io/oauth/token
 | `RestAddress` | `CAMUNDA_REST_ADDRESS` |
 | `TokenAudience` | `CAMUNDA_TOKEN_AUDIENCE` |
 | `DefaultTenantId` | `CAMUNDA_DEFAULT_TENANT_ID` |
+| `TenantIds` | `CAMUNDA_TENANT_IDS` (JSON array or comma-separated string) |
 | `LogLevel` | `CAMUNDA_SDK_LOG_LEVEL` |
 | `Validation` | `CAMUNDA_SDK_VALIDATION` |
 | `Auth:Strategy` | `CAMUNDA_AUTH_STRATEGY` |
@@ -294,6 +295,7 @@ The SDK uses environment variables for configuration, matching the [JS SDK](http
 | `CAMUNDA_BASIC_AUTH_USERNAME` | Basic auth username | — |
 | `CAMUNDA_BASIC_AUTH_PASSWORD` | Basic auth password | — |
 | `CAMUNDA_DEFAULT_TENANT_ID` | Default tenant ID | `<default>` |
+| `CAMUNDA_TENANT_IDS` | Comma-separated tenant IDs for job activation (overrides `CAMUNDA_DEFAULT_TENANT_ID` for workers) | — |
 | `CAMUNDA_SDK_LOG_LEVEL` | Log level (`error`, `warn`, `info`, `debug`, `trace`, `silent`) | `error` |
 | `CAMUNDA_SDK_VALIDATION` | Validation mode (see below) | `req:none,res:none` |
 | `CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS` | Total HTTP retry attempts (initial + retries) | `3` |
@@ -873,6 +875,66 @@ client.CreateJobWorker(config, async (job, ct) =>
 | `WorkerName` | auto | Worker name for logging. Falls back to `CAMUNDA_WORKER_NAME` env var. |
 | `AutoStart` | `true` | Start polling on creation |
 | `StartupJitterMaxSeconds` | `0` | Max random delay (seconds) before first poll. Falls back to `CAMUNDA_WORKER_STARTUP_JITTER_MAX_SECONDS` env var. |
+| `TenantIds` | `null` | Tenant IDs to activate jobs for. Falls back to `CAMUNDA_TENANT_IDS`, then `[CAMUNDA_DEFAULT_TENANT_ID]`. Mutually exclusive with `TenantId`. |
+| `TenantId` | `null` | Single-tenant convenience for `TenantIds`. Mutually exclusive with `TenantIds`. |
+| `TenantFilter` | `null` | Tenant filtering strategy (`PROVIDED` / `ASSIGNED`). See [Multi-Tenant Workers](#multi-tenant-workers). Requires Camunda 8.9+. |
+
+### Multi-Tenant Workers
+
+A worker activates jobs for a fixed tenant set (`TenantIds` / `TenantId`), or delegates the choice to the server with `TenantFilter`:
+
+| `TenantFilter` | Behavior |
+|---|---|
+| `null` / `PROVIDED` | Activate jobs for the tenants named in `TenantIds` / `TenantId`, falling back to `CAMUNDA_TENANT_IDS`, then the default tenant. |
+| `ASSIGNED` | Activate jobs for whichever tenants are currently assigned to the authenticated client. No tenant IDs are sent. |
+
+The fixed tenant set can also come from configuration, so a fleet of workers shares one tenant list:
+
+```bash
+export CAMUNDA_TENANT_IDS=acme,globex
+```
+
+```json
+// appsettings.json — array or comma-separated string
+{
+  "Camunda": {
+    "TenantIds": ["acme", "globex"]
+  }
+}
+```
+
+**Tenant precedence** (highest wins): `JobWorkerConfig.TenantIds` / `TenantId` > `CAMUNDA_TENANT_IDS` > `[CAMUNDA_DEFAULT_TENANT_ID]`. An empty `TenantIds` list counts as unset. `TenantFilter = ASSIGNED` opts out of the chain entirely — the configured tenant IDs are ignored, not sent.
+
+<!-- snippet-source: docs/examples/ReadmeExamples.cs | regions: MultiTenantWorker -->
+```csharp
+// Fixed tenant set — activate jobs for these tenants only
+client.CreateJobWorker(
+    new JobWorkerConfig
+    {
+        JobType = "process-order",
+        JobTimeoutMs = 30_000,
+        TenantIds = new[] { "acme", "globex" },
+    },
+    async (job, ct) => null);
+
+// Dynamic tenant set — activate jobs for whichever tenants are currently
+// assigned to the authenticated client. The server re-evaluates the
+// assignment on every activation request, so tenants added or removed in
+// Camunda take effect without restarting the worker.
+client.CreateJobWorker(
+    new JobWorkerConfig
+    {
+        JobType = "process-order",
+        JobTimeoutMs = 30_000,
+        TenantFilter = TenantFilterEnum.ASSIGNED,
+    },
+    async (job, ct) => null);
+```
+
+`ASSIGNED` re-reads the assignment on every activation request, so the worker picks up newly assigned tenants and drops removed ones without restarting and without the application querying or caching the tenant list. Notes:
+
+- `ASSIGNED` cannot be combined with `TenantIds` or `TenantId` — the server would ignore them, so `CreateJobWorker` throws `ArgumentException` instead.
+- `ASSIGNED` requires multi-tenancy to be enabled on the cluster; otherwise the activation request is rejected with HTTP 400.
 
 ### Heritable Worker Defaults
 

--- a/docs/examples/ReadmeExamples.cs
+++ b/docs/examples/ReadmeExamples.cs
@@ -435,6 +435,36 @@ internal static class ReadmeExamples
         // </JobCorrectionsDenied>
     }
 
+    private static void MultiTenantWorkerExample()
+    {
+        using var client = CamundaClient.Create();
+
+        // <MultiTenantWorker>
+        // Fixed tenant set — activate jobs for these tenants only
+        client.CreateJobWorker(
+            new JobWorkerConfig
+            {
+                JobType = "process-order",
+                JobTimeoutMs = 30_000,
+                TenantIds = new[] { "acme", "globex" },
+            },
+            async (job, ct) => null);
+
+        // Dynamic tenant set — activate jobs for whichever tenants are currently
+        // assigned to the authenticated client. The server re-evaluates the
+        // assignment on every activation request, so tenants added or removed in
+        // Camunda take effect without restarting the worker.
+        client.CreateJobWorker(
+            new JobWorkerConfig
+            {
+                JobType = "process-order",
+                JobTimeoutMs = 30_000,
+                TenantFilter = TenantFilterEnum.ASSIGNED,
+            },
+            async (job, ct) => null);
+        // </MultiTenantWorker>
+    }
+
     private static void WorkerDefaultsEnvExample()
     {
         using var client = CamundaClient.Create();

--- a/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
+++ b/src/Camunda.Orchestration.Sdk.Generator/CSharpClientGenerator.cs
@@ -955,6 +955,7 @@ internal static class CSharpClientGenerator
             // Check if this class has an optional tenantId property AND is used as a request body
             var tenantIdInfo = requestSchemaNames.Contains(typeName) ? GetOptionalTenantIdInfo(schema, doc) : null;
             var tenantIdsInfo = requestSchemaNames.Contains(typeName) ? GetOptionalTenantIdsInfo(schema, doc) : null;
+            var tenantFilterGuard = tenantIdsInfo != null ? GetTenantFilterGuardInfo(schema, doc) : null;
             var ifaceList = new List<string>();
             if (tenantIdInfo != null)
                 ifaceList.Add("global::Camunda.Orchestration.Sdk.ITenantIdSettable");
@@ -1014,7 +1015,7 @@ internal static class CSharpClientGenerator
             if (tenantIdInfo != null)
                 EmitSetDefaultTenantIdMethod(sb, tenantIdInfo.Value);
             if (tenantIdsInfo != null)
-                EmitSetDefaultTenantIdsMethod(sb, tenantIdsInfo.Value);
+                EmitSetDefaultTenantIdsMethod(sb, tenantIdsInfo.Value, tenantFilterGuard);
 
             sb.AppendLine("}");
             sb.AppendLine();
@@ -1095,6 +1096,7 @@ internal static class CSharpClientGenerator
     {
         var tenantIdInfo = isRequestSchema ? GetOptionalTenantIdInfo(schema, doc) : null;
         var tenantIdsInfo = isRequestSchema ? GetOptionalTenantIdsInfo(schema, doc) : null;
+        var tenantFilterGuard = tenantIdsInfo != null ? GetTenantFilterGuardInfo(schema, doc) : null;
         var ifaceList = new List<string>();
         if (tenantIdInfo != null)
             ifaceList.Add("global::Camunda.Orchestration.Sdk.ITenantIdSettable");
@@ -1141,7 +1143,7 @@ internal static class CSharpClientGenerator
         if (tenantIdInfo != null)
             EmitSetDefaultTenantIdMethod(sb, tenantIdInfo.Value);
         if (tenantIdsInfo != null)
-            EmitSetDefaultTenantIdsMethod(sb, tenantIdsInfo.Value);
+            EmitSetDefaultTenantIdsMethod(sb, tenantIdsInfo.Value, tenantFilterGuard);
 
         sb.AppendLine("}");
         sb.AppendLine();
@@ -1913,15 +1915,94 @@ internal static class CSharpClientGenerator
     }
 
     /// <summary>
+    /// Detects a sibling tenant-filter enum property (e.g. <c>tenantFilter</c> on
+    /// <c>JobActivationRequest</c>) on a schema that also carries an optional
+    /// <c>tenantIds</c> array. When the caller selects a strategy other than
+    /// <c>PROVIDED</c>, the server derives the tenant set from the authenticated
+    /// principal and ignores the body's tenant IDs — so the default-tenant
+    /// injection emitted by <c>SetDefaultTenantIds</c> must stand down.
+    ///
+    /// Returns the C# property name, the enum type name, and the <c>PROVIDED</c>
+    /// member name, or <c>null</c> when the schema has no such property (in which
+    /// case injection is unconditional, as before).
+    /// </summary>
+    private static (string PropertyName, string EnumTypeName, string ProvidedMember)? GetTenantFilterGuardInfo(IOpenApiSchema schema, OpenApiDocument? doc = null)
+    {
+        // Mirror GetOptionalTenantIdsInfo: for a oneOf/anyOf, every variant must
+        // agree, otherwise the guard would apply inconsistently across variants.
+        var variants = schema.OneOf?.Count > 0 ? schema.OneOf : (schema.AnyOf?.Count > 0 ? schema.AnyOf : null);
+        if (variants is { Count: > 0 })
+        {
+            (string PropertyName, string EnumTypeName, string ProvidedMember)? agreed = null;
+            foreach (var v in variants)
+            {
+                var resolvedVariant = GetRefId(v) != null
+                    && doc?.Components?.Schemas != null
+                    && doc.Components.Schemas.TryGetValue(GetRefId(v)!, out var r)
+                    ? r
+                    : v;
+                var info = GetTenantFilterGuardInfo(resolvedVariant, doc);
+                if (info == null)
+                    return null;
+                if (agreed == null)
+                    agreed = info;
+                else if (agreed.Value != info.Value)
+                    return null;
+            }
+            return agreed;
+        }
+
+        var properties = new Dictionary<string, IOpenApiSchema>(
+            schema.Properties ?? new Dictionary<string, IOpenApiSchema>());
+        var required = new HashSet<string>(
+            schema.Required ?? new HashSet<string>());
+        FlattenAllOf(schema, doc, properties, required);
+
+        if (!properties.TryGetValue("tenantFilter", out var tenantFilterProp))
+            return null;
+
+        // Unwrap the `allOf: [ $ref ]` wrapper the spec uses to attach a
+        // description and default to a shared enum.
+        var refId = GetRefId(tenantFilterProp)
+            ?? (tenantFilterProp.AllOf?.Count == 1 ? GetRefId(tenantFilterProp.AllOf[0]) : null);
+        if (refId == null || doc?.Components?.Schemas == null)
+            return null;
+        if (!doc.Components.Schemas.TryGetValue(refId, out var tenantFilterSchema))
+            return null;
+        if (SchemaTypeName(tenantFilterSchema) != "string" || !(tenantFilterSchema.Enum?.Count > 0))
+            return null;
+
+        // Only guard against an enum that actually models the "caller provided the
+        // tenants" case — without it there is no safe member to compare against.
+        var provided = EnumStringValues(tenantFilterSchema).FirstOrDefault(v => v == "PROVIDED");
+        if (provided == null)
+            return null;
+
+        return (ToPascalCase("tenantFilter"), SanitizeTypeName(refId), ToPascalCase(provided));
+    }
+
+    /// <summary>
     /// Emits the SetDefaultTenantIds method implementation for ITenantIdsSettable.
     /// Mirrors <see cref="EmitSetDefaultTenantIdMethod"/> but for the plural
     /// array shape (e.g. JobActivationRequest.TenantIds).
     /// </summary>
-    private static void EmitSetDefaultTenantIdsMethod(StringBuilder sb, (string ItemCSharpType, bool IsBrandedKey) info)
+    private static void EmitSetDefaultTenantIdsMethod(
+        StringBuilder sb,
+        (string ItemCSharpType, bool IsBrandedKey) info,
+        (string PropertyName, string EnumTypeName, string ProvidedMember)? tenantFilterGuard = null)
     {
         sb.AppendLine("    /// <inheritdoc />");
         sb.AppendLine("    public void SetDefaultTenantIds(string tenantId)");
         sb.AppendLine("    {");
+        if (tenantFilterGuard is { } guard)
+        {
+            // A non-PROVIDED tenant filter means the server resolves the tenant set
+            // itself (ASSIGNED = the authenticated principal's assigned tenants) and
+            // ignores any tenantIds in the body, so injecting the default tenant would
+            // only put a meaningless value on the wire. See issue #376.
+            sb.AppendLine($"        if ({guard.PropertyName} != null && {guard.PropertyName} != {guard.EnumTypeName}.{guard.ProvidedMember})");
+            sb.AppendLine("            return;");
+        }
         sb.AppendLine("        if (TenantIds == null || TenantIds.Count == 0)");
         if (info.IsBrandedKey)
         {

--- a/src/Camunda.Orchestration.Sdk/CamundaClient.Workers.cs
+++ b/src/Camunda.Orchestration.Sdk/CamundaClient.Workers.cs
@@ -24,6 +24,20 @@ public partial class CamundaClient : IAsyncDisposable
     public JobWorker CreateJobWorker(JobWorkerConfig config, JobHandler handler)
     {
         var defaults = _config.WorkerDefaults;
+
+        // Tenant precedence: explicit JobWorkerConfig tenants > CAMUNDA_TENANT_IDS >
+        // [DefaultTenantId] (injected on the activation request). An empty explicit
+        // list counts as unset. Under TenantFilter.ASSIGNED the server picks the
+        // tenants, so the env default must not be applied — it would collide with the
+        // ASSIGNED validation in the JobWorker constructor.
+        var tenantIds = config.TenantIds;
+        if (tenantIds is not { Count: > 0 }
+            && config.TenantId is null
+            && config.TenantFilter is not TenantFilterEnum.ASSIGNED)
+        {
+            tenantIds = _config.TenantIds ?? tenantIds;
+        }
+
         var merged = new JobWorkerConfig
         {
             JobType = config.JobType,
@@ -37,8 +51,9 @@ public partial class CamundaClient : IAsyncDisposable
             StartupJitterMaxSeconds = config.StartupJitterMaxSeconds > 0
                 ? config.StartupJitterMaxSeconds
                 : defaults?.StartupJitterMaxSeconds ?? 0,
-            TenantIds = config.TenantIds,
+            TenantIds = tenantIds,
             TenantId = config.TenantId,
+            TenantFilter = config.TenantFilter,
         };
         var worker = new JobWorker(this, merged, handler, _loggerFactory, _jsonOptions);
         _workers.Add(worker);

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -16586,6 +16586,8 @@ public sealed class JobActivationRequest : global::Camunda.Orchestration.Sdk.ITe
     /// <inheritdoc />
     public void SetDefaultTenantIds(string tenantId)
     {
+        if (TenantFilter != null && TenantFilter != TenantFilterEnum.PROVIDED)
+            return;
         if (TenantIds == null || TenantIds.Count == 0)
             TenantIds = new List<TenantId> { global::Camunda.Orchestration.Sdk.TenantId.AssumeExists(tenantId) };
     }

--- a/src/Camunda.Orchestration.Sdk/Runtime/CamundaConfig.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/CamundaConfig.cs
@@ -30,6 +30,13 @@ public sealed class CamundaConfig
     public string TokenAudience { get; init; } = string.Empty;
     public string DefaultTenantId { get; init; } = ConfigSchema.StringDefault(ConfigKeys.DefaultTenantId);
 
+    /// <summary>
+    /// Tenant ids job workers activate for, from <c>CAMUNDA_TENANT_IDS</c> (comma-separated)
+    /// or the <c>TenantIds</c> configuration path. <c>null</c> when unset, in which case
+    /// activation falls back to <see cref="DefaultTenantId"/>.
+    /// </summary>
+    public IReadOnlyList<string>? TenantIds { get; init; }
+
     public HttpRetryConfig HttpRetry { get; init; } = new();
     public BackpressureConfig Backpressure { get; init; } = new();
     public OAuthConfig OAuth { get; init; } = new();

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigSchema.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigSchema.cs
@@ -10,6 +10,7 @@ internal static class ConfigKeys
     public const string RestAddress = "CAMUNDA_REST_ADDRESS";
     public const string TokenAudience = "CAMUNDA_TOKEN_AUDIENCE";
     public const string DefaultTenantId = "CAMUNDA_DEFAULT_TENANT_ID";
+    public const string TenantIds = "CAMUNDA_TENANT_IDS";
     public const string AuthStrategy = "CAMUNDA_AUTH_STRATEGY";
     public const string ClientId = "CAMUNDA_CLIENT_ID";
     public const string ClientSecret = "CAMUNDA_CLIENT_SECRET";
@@ -104,6 +105,7 @@ internal static class ConfigSchema
         new() { EnvVar = ConfigKeys.RestAddress, Default = "http://localhost:8080/v2", Aliases = ["ZEEBE_REST_ADDRESS"], ConfigPaths = ["RestAddress"], Doc = "Base REST endpoint address." },
         new() { EnvVar = ConfigKeys.TokenAudience, Default = "zeebe.camunda.io", ConfigPaths = ["TokenAudience"], Doc = "Token audience for OAuth flows." },
         new() { EnvVar = ConfigKeys.DefaultTenantId, Default = "<default>", ConfigPaths = ["DefaultTenantId"], Doc = "Default tenant id applied when none is provided." },
+        new() { EnvVar = ConfigKeys.TenantIds, ConfigPaths = ["TenantIds"], Doc = "Comma-separated tenant ids job workers activate for; overrides the single default tenant id." },
         new() { EnvVar = ConfigKeys.AuthStrategy, Type = ConfigValueType.Enum, Choices = ["NONE", "OAUTH", "BASIC"], Default = "NONE", ConfigPaths = ["Auth:Strategy"], Doc = "Authentication strategy." },
         new() { EnvVar = ConfigKeys.ClientId, ConfigPaths = ["Auth:ClientId", "OAuth:ClientId"], Doc = "OAuth client id (required when strategy is OAUTH)." },
         new() { EnvVar = ConfigKeys.ClientSecret, Secret = true, ConfigPaths = ["Auth:ClientSecret", "OAuth:ClientSecret"], Doc = "OAuth client secret (required when strategy is OAUTH)." },

--- a/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/ConfigurationHydrator.cs
@@ -288,6 +288,14 @@ public static class ConfigurationHydrator
         var hasWorkerDefaults = workerTimeout != null || workerMaxConcurrent != null
             || workerRequestTimeout != null || workerName != null || workerJitter != null;
 
+        // Plural tenant ids: comma-separated. Blank entries are dropped, and a value
+        // that yields no entries at all is treated as unset (falls back to the
+        // singular DefaultTenantId).
+        var tenantIds = rawMap.GetValueOrDefault(ConfigKeys.TenantIds)
+            ?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (tenantIds is { Length: 0 })
+            tenantIds = null;
+
         if (errors.Count > 0)
             throw new CamundaConfigurationException(errors);
 
@@ -304,6 +312,7 @@ public static class ConfigurationHydrator
             RestAddress = restAddress,
             TokenAudience = rawMap.GetValueOrDefault(ConfigKeys.TokenAudience, ConfigSchema.StringDefault(ConfigKeys.TokenAudience))!,
             DefaultTenantId = rawMap.GetValueOrDefault(ConfigKeys.DefaultTenantId, ConfigSchema.StringDefault(ConfigKeys.DefaultTenantId))!,
+            TenantIds = tenantIds,
             HttpRetry = new HttpRetryConfig
             {
                 MaxAttempts = retryMaxAttempts,
@@ -465,7 +474,20 @@ public static class ConfigurationHydrator
         {
             var value = configuration[configKey];
             if (!string.IsNullOrEmpty(value))
+            {
                 result[envKey] = value;
+                continue;
+            }
+
+            // A JSON array (e.g. "TenantIds": ["acme", "globex"]) has no scalar value —
+            // it binds as indexed children. Join them into the canonical comma-separated
+            // form the env-var path already uses.
+            var children = configuration.GetSection(configKey).GetChildren()
+                .Select(c => c.Value)
+                .Where(v => !string.IsNullOrEmpty(v))
+                .ToList();
+            if (children.Count > 0)
+                result[envKey] = string.Join(',', children);
         }
 
         return result;

--- a/src/Camunda.Orchestration.Sdk/Runtime/JobWorker.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/JobWorker.cs
@@ -93,9 +93,10 @@ public sealed class JobWorkerConfig
     /// rejected with <see cref="ArgumentException"/>.
     ///
     /// <para>If neither <see cref="TenantIds"/> nor <see cref="TenantId"/> is set
-    /// (or <see cref="TenantIds"/> is empty), the activation request falls back
-    /// to <c>[CamundaConfig.DefaultTenantId]</c> (which itself defaults to
-    /// <c>"&lt;default&gt;"</c> and can be overridden via the
+    /// (or <see cref="TenantIds"/> is empty), the activation request falls back to
+    /// <c>CamundaConfig.TenantIds</c> (from the <c>CAMUNDA_TENANT_IDS</c> environment
+    /// variable, comma-separated), then to <c>[CamundaConfig.DefaultTenantId]</c>
+    /// (which itself defaults to <c>"&lt;default&gt;"</c> and can be overridden via the
     /// <c>CAMUNDA_DEFAULT_TENANT_ID</c> environment variable).</para>
     /// </summary>
     public IReadOnlyList<string>? TenantIds { get; init; }
@@ -106,6 +107,25 @@ public sealed class JobWorkerConfig
     /// <see cref="TenantIds"/>.
     /// </summary>
     public string? TenantId { get; init; }
+
+    /// <summary>
+    /// Tenant filtering strategy for job activation.
+    ///
+    /// <para><see cref="TenantFilterEnum.PROVIDED"/> (the server default when this is
+    /// <c>null</c>) activates jobs for the tenants named in <see cref="TenantIds"/> /
+    /// <see cref="TenantId"/>, falling back to the default tenant.</para>
+    ///
+    /// <para><see cref="TenantFilterEnum.ASSIGNED"/> activates jobs for whichever tenants
+    /// are currently assigned to the authenticated client, re-evaluated by the server on
+    /// every activation request — so tenant assignment changes take effect without
+    /// restarting the worker. No tenant IDs are sent, and
+    /// <see cref="TenantIds"/> / <see cref="TenantId"/> must not be set (the server would
+    /// silently ignore them). Requires multi-tenancy to be enabled on the cluster;
+    /// otherwise the server rejects the activation request with HTTP 400.</para>
+    ///
+    /// <para>Requires Camunda 8.9 or later.</para>
+    /// </summary>
+    public TenantFilterEnum? TenantFilter { get; init; }
 }
 
 /// <summary>
@@ -252,6 +272,16 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
                 "JobWorkerConfig.TenantId must not be empty or whitespace — omit it (null) to use the default tenant.",
                 nameof(config));
 
+        // The server derives the tenant set from the authenticated principal under
+        // ASSIGNED and ignores any tenant IDs in the body. Fail fast rather than let
+        // an explicit tenant list be silently dropped.
+        if (config.TenantFilter is TenantFilterEnum.ASSIGNED
+            && (config.TenantIds is not null || config.TenantId is not null))
+            throw new ArgumentException(
+                "JobWorkerConfig.TenantFilter = ASSIGNED cannot be combined with TenantIds or TenantId — " +
+                "the server activates jobs for the tenants assigned to the authenticated client and ignores provided tenant IDs.",
+                nameof(config));
+
         _resolvedTenantIds = ResolveTenantIds(config);
 
         _jobTimeoutMs = config.JobTimeoutMs.Value;
@@ -373,6 +403,7 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
                         FetchVariable = _config.FetchVariables,
                         RequestTimeout = _config.PollTimeoutMs ?? 0,
                         TenantIds = _resolvedTenantIds,
+                        TenantFilter = _config.TenantFilter,
                     }, ct: ct).ConfigureAwait(false);
 
                     if (response?.Jobs == null || response.Jobs.Count == 0)
@@ -513,7 +544,9 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
             return new List<TenantId> { global::Camunda.Orchestration.Sdk.TenantId.AssumeExists(config.TenantId) };
 
         // Leave null so the generated ActivateJobsAsync injects [DefaultTenantId]
-        // via ITenantIdsSettable.SetDefaultTenantIds.
+        // via ITenantIdsSettable.SetDefaultTenantIds — except under a non-PROVIDED
+        // tenant filter, where SetDefaultTenantIds stands down and the request goes
+        // out with no tenantIds at all.
         return null;
     }
 

--- a/src/Camunda.Orchestration.Sdk/Runtime/JobWorker.cs
+++ b/src/Camunda.Orchestration.Sdk/Runtime/JobWorker.cs
@@ -274,9 +274,10 @@ public sealed class JobWorker : IAsyncDisposable, IDisposable
 
         // The server derives the tenant set from the authenticated principal under
         // ASSIGNED and ignores any tenant IDs in the body. Fail fast rather than let
-        // an explicit tenant list be silently dropped.
+        // an explicit tenant list be silently dropped. An empty TenantIds list counts
+        // as unset here, consistently with ResolveTenantIds and the env-var fallback.
         if (config.TenantFilter is TenantFilterEnum.ASSIGNED
-            && (config.TenantIds is not null || config.TenantId is not null))
+            && (config.TenantIds is { Count: > 0 } || config.TenantId is not null))
             throw new ArgumentException(
                 "JobWorkerConfig.TenantFilter = ASSIGNED cannot be combined with TenantIds or TenantId — " +
                 "the server activates jobs for the tenants assigned to the authenticated client and ignores provided tenant IDs.",

--- a/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/ActivateJobsDefaultTenantIdsTests.cs
@@ -173,6 +173,115 @@ public class ActivateJobsDefaultTenantIdsTests : IDisposable
         Assert.Empty(missing);
     }
 
+    [Fact]
+    public async Task ActivateJobs_AssignedTenantFilter_SendsNoTenantIds()
+    {
+        // Regression for #376: under a non-PROVIDED tenant filter the server derives
+        // the tenant set from the authenticated principal and ignores body tenant IDs,
+        // so the default-tenant injection must stand down rather than put the
+        // configured default on the wire.
+        string? capturedBody = null;
+        _handlerCustom.Enqueue(async req =>
+        {
+            capturedBody = await req.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"jobs\":[]}", System.Text.Encoding.UTF8, "application/json"),
+            };
+        });
+
+        await _clientCustomTenant.ActivateJobsAsync(new JobActivationRequest
+        {
+            Type = "demo-task",
+            Timeout = 30_000,
+            MaxJobsToActivate = 1,
+            TenantFilter = TenantFilterEnum.ASSIGNED,
+        });
+
+        Assert.NotNull(capturedBody);
+        var doc = JsonDocument.Parse(capturedBody!);
+        Assert.False(doc.RootElement.TryGetProperty("tenantIds", out _));
+        Assert.Equal("ASSIGNED", doc.RootElement.GetProperty("tenantFilter").GetString());
+    }
+
+    [Fact]
+    public async Task ActivateJobs_ProvidedTenantFilter_StillInjectsDefaultTenantId()
+    {
+        // PROVIDED is the server-side default, so an explicit PROVIDED must behave
+        // exactly like omitting the filter.
+        string? capturedBody = null;
+        _handlerCustom.Enqueue(async req =>
+        {
+            capturedBody = await req.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"jobs\":[]}", System.Text.Encoding.UTF8, "application/json"),
+            };
+        });
+
+        await _clientCustomTenant.ActivateJobsAsync(new JobActivationRequest
+        {
+            Type = "demo-task",
+            Timeout = 30_000,
+            MaxJobsToActivate = 1,
+            TenantFilter = TenantFilterEnum.PROVIDED,
+        });
+
+        Assert.NotNull(capturedBody);
+        var doc = JsonDocument.Parse(capturedBody!);
+        var tenantIds = doc.RootElement.GetProperty("tenantIds").EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Equal(CustomTenantSingle, tenantIds);
+    }
+
+    [Fact]
+    public void EveryTenantIdsSchemaWithTenantFilter_SuppressesDefaultInjection_UnderNonProvidedFilter()
+    {
+        // Class-scoped guard for #376: every request schema that carries both an
+        // optional `tenantIds` array and a sibling tenant-filter enum must no-op its
+        // SetDefaultTenantIds under a non-PROVIDED filter, and must still inject when
+        // the filter is unset. Today only JobActivationRequest matches; the scan keeps
+        // a future sibling schema from silently regressing.
+        var spec = LoadBundledSpec();
+        var matches = FindRequestSchemasWithOptionalTenantIdsArray(spec);
+        var sdkAssembly = typeof(CamundaClient).Assembly;
+
+        var checkedTypes = new List<string>();
+        foreach (var schemaName in matches)
+        {
+            var typeName = $"Camunda.Orchestration.Sdk.{CSharpClientGenerator.SanitizeTypeName(schemaName)}";
+            var t = sdkAssembly.GetType(typeName);
+            Assert.NotNull(t);
+
+            var filterProp = t!.GetProperty("TenantFilter");
+            var filterEnumType = filterProp == null ? null : Nullable.GetUnderlyingType(filterProp.PropertyType);
+            if (filterProp == null || filterEnumType is not { IsEnum: true })
+                continue; // No tenant filter on this schema — unconditional injection is correct.
+
+            var nonProvided = Enum.GetValues(filterEnumType)
+                .Cast<object>()
+                .FirstOrDefault(v => !string.Equals(v.ToString(), "PROVIDED", StringComparison.Ordinal));
+            Assert.NotNull(nonProvided);
+
+            var setDefaults = t.GetMethod("SetDefaultTenantIds");
+            Assert.NotNull(setDefaults);
+            var tenantIdsProp = t.GetProperty("TenantIds");
+            Assert.NotNull(tenantIdsProp);
+
+            var suppressed = Activator.CreateInstance(t)!;
+            filterProp.SetValue(suppressed, nonProvided);
+            setDefaults!.Invoke(suppressed, new object[] { "tenant-alpha" });
+            Assert.Null(tenantIdsProp!.GetValue(suppressed));
+
+            var injected = Activator.CreateInstance(t)!;
+            setDefaults.Invoke(injected, new object[] { "tenant-alpha" });
+            Assert.NotNull(tenantIdsProp.GetValue(injected));
+
+            checkedTypes.Add(schemaName);
+        }
+
+        Assert.Contains("JobActivationRequest", checkedTypes); // Sanity: upstream spec changed if this fails.
+    }
+
     private static JsonNode LoadBundledSpec()
     {
         // The test process runs from test/.../bin/Debug/net8.0/. Walk up to repo root.

--- a/test/Camunda.Orchestration.Sdk.Tests/AppSettingsConfigurationTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/AppSettingsConfigurationTests.cs
@@ -4,6 +4,8 @@ namespace Camunda.Orchestration.Sdk.Tests;
 
 public class AppSettingsConfigurationTests
 {
+    private static readonly string[] AcmeGlobex = ["acme", "globex"];
+
     [Fact]
     public void BindsTopLevelKeysFromIConfiguration()
     {
@@ -24,6 +26,56 @@ public class AppSettingsConfigurationTests
         Assert.Contains("cluster.example.com", config.RestAddress);
         Assert.Equal("my-tenant", config.DefaultTenantId);
         Assert.Equal("debug", config.LogLevel);
+    }
+
+    /// <summary>
+    /// camunda/orchestration-cluster-api-csharp#122 — `CAMUNDA_TENANT_IDS` binds from
+    /// the `TenantIds` path in either idiomatic JSON shape: a comma-separated string or
+    /// a JSON array (which `IConfiguration` exposes as indexed children, not a scalar).
+    /// </summary>
+    [Fact]
+    public void BindsTenantIdsFromIConfiguration_AsCommaSeparatedString()
+    {
+        var configSection = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Camunda:TenantIds"] = "acme, globex",
+            })
+            .Build()
+            .GetSection("Camunda");
+
+        var config = ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?>(),
+            configuration: configSection);
+
+        Assert.Equal(AcmeGlobex, config.TenantIds);
+    }
+
+    [Fact]
+    public void BindsTenantIdsFromIConfiguration_AsJsonArray()
+    {
+        var configSection = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Camunda:TenantIds:0"] = "acme",
+                ["Camunda:TenantIds:1"] = "globex",
+            })
+            .Build()
+            .GetSection("Camunda");
+
+        var config = ConfigurationHydrator.Hydrate(
+            env: new Dictionary<string, string?>(),
+            configuration: configSection);
+
+        Assert.Equal(AcmeGlobex, config.TenantIds);
+    }
+
+    [Fact]
+    public void TenantIdsIsNull_WhenUnset()
+    {
+        var config = ConfigurationHydrator.Hydrate(env: new Dictionary<string, string?>());
+
+        Assert.Null(config.TenantIds);
     }
 
     [Fact]

--- a/test/Camunda.Orchestration.Sdk.Tests/JobWorkerTenantTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/JobWorkerTenantTests.cs
@@ -418,6 +418,21 @@ public class JobWorkerTenantTests
         Assert.Contains("ASSIGNED cannot be combined", ex.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task AssignedTenantFilter_AcceptsEmptyTenantIds()
+    {
+        // An empty list is "unset" everywhere else (ResolveTenantIds, the env-var
+        // fallback), so it must not trip the ASSIGNED conflict check.
+        var body = await RunOnePollAndCaptureBodyAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+        }, tenantIds: Array.Empty<string>(), tenantFilter: TenantFilterEnum.ASSIGNED);
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("ASSIGNED", doc.RootElement.GetProperty("tenantFilter").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("tenantIds", out _));
+    }
+
     private static ArgumentException AssertCreateJobWorkerThrows(JobWorkerConfig config)
     {
         using var client = new CamundaClient(new CamundaOptions

--- a/test/Camunda.Orchestration.Sdk.Tests/JobWorkerTenantTests.cs
+++ b/test/Camunda.Orchestration.Sdk.Tests/JobWorkerTenantTests.cs
@@ -31,6 +31,20 @@ public class JobWorkerTenantTests
         string? tenantId = null,
         IReadOnlyList<string>? tenantIds = null)
     {
+        var capturedJson = await RunOnePollAndCaptureBodyAsync(config, tenantId, tenantIds);
+
+        using var doc = JsonDocument.Parse(capturedJson);
+        if (!doc.RootElement.TryGetProperty("tenantIds", out var arr))
+            return new List<string>();
+        return arr.EnumerateArray().Select(e => e.GetString() ?? "").ToList();
+    }
+
+    private static async Task<string> RunOnePollAndCaptureBodyAsync(
+        Dictionary<string, string> config,
+        string? tenantId = null,
+        IReadOnlyList<string>? tenantIds = null,
+        TenantFilterEnum? tenantFilter = null)
+    {
         var handler = new MockHttpMessageHandler();
         var firstRequestBody = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -61,6 +75,7 @@ public class JobWorkerTenantTests
             AutoStart = false,
             TenantId = tenantId,
             TenantIds = tenantIds,
+            TenantFilter = tenantFilter,
         };
 
         var worker = client.CreateJobWorker(workerConfig, (_, _) => Task.FromResult<object?>(null));
@@ -69,10 +84,7 @@ public class JobWorkerTenantTests
         var capturedJson = await firstRequestBody.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await worker.StopAsync(TimeSpan.FromSeconds(1));
 
-        using var doc = JsonDocument.Parse(capturedJson);
-        if (!doc.RootElement.TryGetProperty("tenantIds", out var arr))
-            return new List<string>();
-        return arr.EnumerateArray().Select(e => e.GetString() ?? "").ToList();
+        return capturedJson;
     }
 
     [Fact]
@@ -167,6 +179,258 @@ public class JobWorkerTenantTests
         }, tenantIds: Array.Empty<string>());
 
         Assert.Equal(DefaultSentinel, tenantIds);
+    }
+
+    /// <summary>
+    /// Regression for camunda/orchestration-cluster-api-csharp#122 — the plural
+    /// <c>CAMUNDA_TENANT_IDS</c> env var hydrates into the client config and feeds
+    /// worker activation when the worker declares no tenants of its own.
+    /// </summary>
+    [Fact]
+    public async Task PollLoop_UsesEnvTenantIds_WhenWorkerOmitsTenantConfig()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_TENANT_IDS"] = "beta,gamma",
+        });
+
+        Assert.Equal(BetaGamma, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_EnvTenantIds_TolerateWhitespaceAndBlanks()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_TENANT_IDS"] = " beta , , gamma ",
+        });
+
+        Assert.Equal(BetaGamma, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_EnvTenantIds_OverrideEnvDefaultTenantId()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_DEFAULT_TENANT_ID"] = "ignored-default",
+            ["CAMUNDA_TENANT_IDS"] = "beta,gamma",
+        });
+
+        Assert.Equal(BetaGamma, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_ExplicitTenantIds_OverrideEnvTenantIds()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_TENANT_IDS"] = "ignored-1,ignored-2",
+        }, tenantIds: Explicit12);
+
+        Assert.Equal(Explicit12, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_ExplicitSingularTenantId_OverridesEnvTenantIds()
+    {
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_TENANT_IDS"] = "ignored-1,ignored-2",
+        }, tenantId: "alpha");
+
+        Assert.Equal(AlphaOnly, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_EmptyExplicitTenantIds_FallsBackToEnvTenantIds()
+    {
+        // An empty list is "unset", so it must reach the env var rather than skip
+        // straight to the single default tenant.
+        var tenantIds = await RunOnePollAndCaptureTenantIdsAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_TENANT_IDS"] = "beta,gamma",
+        }, tenantIds: Array.Empty<string>());
+
+        Assert.Equal(BetaGamma, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_AssignedTenantFilter_IgnoresEnvTenantIds()
+    {
+        var body = await RunOnePollAndCaptureBodyAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_TENANT_IDS"] = "beta,gamma",
+        }, tenantFilter: TenantFilterEnum.ASSIGNED);
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("ASSIGNED", doc.RootElement.GetProperty("tenantFilter").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("tenantIds", out _));
+    }
+
+    /// <summary>
+    /// The <c>Func&lt;ActivatedJob, CancellationToken, Task&gt;</c> overload delegates to
+    /// the primary overload — the env-var tenant set must reach it too.
+    /// </summary>
+    [Fact]
+    public async Task FuncOverload_UsesEnvTenantIds()
+    {
+        var handler = new MockHttpMessageHandler();
+        var firstRequestBody = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        handler.Enqueue(async req =>
+        {
+            var body = await req.Content!.ReadAsStringAsync();
+            firstRequestBody.TrySetResult(body);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"jobs\":[]}", System.Text.Encoding.UTF8, "application/json"),
+            };
+        });
+        for (var i = 0; i < 8; i++)
+            handler.Enqueue(HttpStatusCode.OK, "{\"jobs\":[]}");
+
+        using var client = new CamundaClient(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+                ["CAMUNDA_TENANT_IDS"] = "beta,gamma",
+            },
+            HttpMessageHandler = handler,
+        });
+
+        var worker = client.CreateJobWorker(
+            new JobWorkerConfig
+            {
+                JobType = "func-env-tenants",
+                JobTimeoutMs = 30_000,
+                MaxConcurrentJobs = 1,
+                AutoStart = false,
+            },
+            (Func<ActivatedJob, CancellationToken, Task>)((_, _) => Task.CompletedTask));
+        worker.Start();
+
+        var capturedJson = await firstRequestBody.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(TimeSpan.FromSeconds(1));
+
+        using var doc = JsonDocument.Parse(capturedJson);
+        var tenantIds = doc.RootElement.GetProperty("tenantIds").EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Equal(BetaGamma, tenantIds);
+    }
+
+    /// <summary>
+    /// Regression for camunda/orchestration-cluster-api-csharp#376 — a worker
+    /// configured with <c>TenantFilter = ASSIGNED</c> must send the filter and no
+    /// tenant IDs at all, so the server activates jobs for whichever tenants are
+    /// currently assigned to the authenticated client.
+    /// </summary>
+    [Fact]
+    public async Task PollLoop_AssignedTenantFilter_SendsFilter_AndOmitsTenantIds()
+    {
+        // A configured default tenant would otherwise be injected — proves the
+        // injection stands down rather than merely being absent by accident.
+        var body = await RunOnePollAndCaptureBodyAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_DEFAULT_TENANT_ID"] = "ignored-default",
+        }, tenantFilter: TenantFilterEnum.ASSIGNED);
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("ASSIGNED", doc.RootElement.GetProperty("tenantFilter").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("tenantIds", out _));
+    }
+
+    [Fact]
+    public async Task PollLoop_ProvidedTenantFilter_SendsFilter_AndKeepsTenantIds()
+    {
+        var body = await RunOnePollAndCaptureBodyAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+        }, tenantIds: BetaGamma, tenantFilter: TenantFilterEnum.PROVIDED);
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal("PROVIDED", doc.RootElement.GetProperty("tenantFilter").GetString());
+        var tenantIds = doc.RootElement.GetProperty("tenantIds").EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Equal(BetaGamma, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_ProvidedTenantFilter_StillFallsBackToDefaultTenant()
+    {
+        var body = await RunOnePollAndCaptureBodyAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            ["CAMUNDA_DEFAULT_TENANT_ID"] = "acme",
+        }, tenantFilter: TenantFilterEnum.PROVIDED);
+
+        using var doc = JsonDocument.Parse(body);
+        var tenantIds = doc.RootElement.GetProperty("tenantIds").EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Equal(AcmeOnly, tenantIds);
+    }
+
+    [Fact]
+    public async Task PollLoop_OmitsTenantFilter_WhenUnset()
+    {
+        // Back-compat: workers that never touch TenantFilter must keep sending the
+        // exact same body as before.
+        var body = await RunOnePollAndCaptureBodyAsync(new Dictionary<string, string>
+        {
+            ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+        });
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.False(doc.RootElement.TryGetProperty("tenantFilter", out _));
+    }
+
+    [Fact]
+    public void CreateJobWorker_RejectsAssignedTenantFilter_With_TenantId()
+    {
+        var ex = AssertCreateJobWorkerThrows(new JobWorkerConfig
+        {
+            JobType = "assigned-conflict",
+            JobTimeoutMs = 30_000,
+            AutoStart = false,
+            TenantId = "alpha",
+            TenantFilter = TenantFilterEnum.ASSIGNED,
+        });
+        Assert.Contains("ASSIGNED cannot be combined", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateJobWorker_RejectsAssignedTenantFilter_With_TenantIds()
+    {
+        var ex = AssertCreateJobWorkerThrows(new JobWorkerConfig
+        {
+            JobType = "assigned-conflict",
+            JobTimeoutMs = 30_000,
+            AutoStart = false,
+            TenantIds = BetaGamma,
+            TenantFilter = TenantFilterEnum.ASSIGNED,
+        });
+        Assert.Contains("ASSIGNED cannot be combined", ex.Message, StringComparison.Ordinal);
+    }
+
+    private static ArgumentException AssertCreateJobWorkerThrows(JobWorkerConfig config)
+    {
+        using var client = new CamundaClient(new CamundaOptions
+        {
+            Config = new Dictionary<string, string>
+            {
+                ["CAMUNDA_REST_ADDRESS"] = "https://mock.local",
+            },
+            HttpMessageHandler = new MockHttpMessageHandler(),
+        });
+
+        return Assert.Throws<ArgumentException>(
+            () => client.CreateJobWorker(config, (_, _) => Task.FromResult<object?>(null)));
     }
 
     [Theory]

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -1818,6 +1818,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaConfig : sealed class
   PROP Camunda.Orchestration.Sdk.TlsConfig? Tls { get; init; }
   PROP Camunda.Orchestration.Sdk.ValidationConfig Validation { get; init; }
   PROP Camunda.Orchestration.Sdk.WorkerDefaultsConfig? WorkerDefaults { get; init; }
+  PROP System.Collections.Generic.IReadOnlyList<System.String>? TenantIds { get; init; }
   PROP System.String DefaultTenantId { get; init; }
   PROP System.String LogLevel { get; init; }
   PROP System.String RestAddress { get; init; }
@@ -4209,6 +4210,7 @@ TYPE Camunda.Orchestration.Sdk.JobWorker : sealed class interfaces=[System.IAsyn
 
 TYPE Camunda.Orchestration.Sdk.JobWorkerConfig : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.TenantFilterEnum? TenantFilter { get; init; }
   PROP System.Boolean AutoStart { get; init; }
   PROP System.Collections.Generic.IReadOnlyList<System.String>? TenantIds { get; init; }
   PROP System.Collections.Generic.List<System.String>? FetchVariables { get; init; }


### PR DESCRIPTION
Plumbs multi-tenant job activation through the ergonomic worker surface, closing both open tenant issues.

Closes #376
Closes #122

## What changed

**`JobWorkerConfig.TenantFilter`** (`TenantFilterEnum?`) is forwarded onto the activation request. `ASSIGNED` lets the server activate jobs for whichever tenants are currently assigned to the authenticated client, re-evaluated per request — so assignment changes take effect without restarting the worker and without the application querying or caching the tenant list.

Combining `ASSIGNED` with `TenantIds`/`TenantId` now throws `ArgumentException`. Upstream (`RequestMapper.resolveTenantIds`) discards body tenant IDs entirely under `ASSIGNED`, so failing fast beats a silently dropped tenant list.

**The generator's default-tenant injector stands down under a non-PROVIDED filter.** `SetDefaultTenantIds` previously refilled `tenantIds` whenever it was null or empty, so a worker had no way to say "send no tenants". It is now emitted with a guard whenever a request schema carries both an optional `tenantIds` array and a sibling tenant-filter enum containing `PROVIDED`:

```csharp
public void SetDefaultTenantIds(string tenantId)
{
    if (TenantFilter != null && TenantFilter != TenantFilterEnum.PROVIDED)
        return;
    if (TenantIds == null || TenantIds.Count == 0)
        TenantIds = new List<TenantId> { TenantId.AssumeExists(tenantId) };
}
```

Detection is spec-driven (unwraps the `allOf: [$ref]` wrapper, mirrors the existing oneOf/anyOf agreement rule), so a future sibling schema gets the same treatment. Only `JobActivationRequest` matches today — the regenerated diff is two lines.

**`CAMUNDA_TENANT_IDS`** (comma-separated) hydrates into `CamundaConfig.TenantIds` and feeds workers that declare no tenants of their own. `IConfiguration` binding accepts either shape:

```json
{ "Camunda": { "TenantIds": ["acme", "globex"] } }
```

Tenant precedence: `JobWorkerConfig.TenantIds`/`TenantId` > `CAMUNDA_TENANT_IDS` > `[CAMUNDA_DEFAULT_TENANT_ID]`. An empty `TenantIds` list counts as unset; `ASSIGNED` opts out of the chain entirely.

## Deviation from #122

`CamundaConfig.TenantIds` is `IReadOnlyList<string>`, not `IReadOnlyList<TenantId>` as the issue proposed — it matches `JobWorkerConfig.TenantIds` and keeps branded-type validation at the worker boundary, where the existing malformed-entry rejection already lives.

## Tests

23 new tests, 1183 pass.

- Worker: `ASSIGNED` sends the filter and omits `tenantIds` even with a default tenant configured; `PROVIDED` keeps explicit IDs and the default fallback; unset omits `tenantFilter` (back-compat); both rejection cases; env-only, whitespace/blank tolerance, explicit-beats-env (plural and singular), empty-list-falls-through-to-env, `ASSIGNED`-ignores-env, and the `Func` overload.
- Raw client: `ActivateJobsAsync` equivalents.
- Structural guard: scans the bundled spec for every request schema with an optional `tenantIds` array; for any that also carries a tenant-filter enum, asserts reflectively that `SetDefaultTenantIds` no-ops under a non-`PROVIDED` member and still injects when unset.
- Hydrator: comma-separated string, JSON array, and unset.

README documents the new section, config table rows, and precedence; `docs/examples/ReadmeExamples.cs` carries the compilable snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
