### PR TITLE
chore(gen): sync upstream spec and refresh the public API baseline

### DIFF
--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -423,7 +423,7 @@
           }
         ],
         "summary": "Update agent instance",
-        "description": "Updates the mutable fields of an agent instance: status, metric counters, and\ntools. Metric values are treated as deltas and applied immediately to the\naggregate counters. Tool updates replace the existing tool list.\n",
+        "description": "Updates the mutable fields of an agent instance (status, metric counters, and\ntools) and appends a batch of history items to its conversation history. Metric\nvalues are treated as deltas and applied immediately to the aggregate counters.\nTool updates replace the existing tool list. Each history item created for this\nrequest is echoed back in the response.\n",
         "parameters": [
           {
             "name": "agentInstanceKey",
@@ -446,8 +446,15 @@
           }
         },
         "responses": {
-          "204": {
-            "description": "The agent instance was updated successfully."
+          "200": {
+            "description": "The agent instance was updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstanceUpdateResult"
+                }
+              }
+            }
           },
           "400": {
             "description": "The provided data is not valid.",
@@ -20633,6 +20640,18 @@
         ],
         "summary": "Restore from a backup",
         "description": "Restores the cluster from a backup. The restore is described either by a single backup ID or by a time range (`from`/`to`) that selects the backups to restore. This endpoint is only accessible while the cluster is in recovery mode; requests are rejected otherwise. The request is validated and acknowledged, but the restore itself is performed asynchronously.",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "required": false,
+            "description": "If true, the requested change is only validated and the resulting plan is returned, without applying it to the cluster.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -23271,6 +23290,71 @@
             "items": {
               "$ref": "#/components/schemas/AgentTool"
             }
+          },
+          "jobKey": {
+            "description": "The key of the job activation during which this update is being made.\nRequired whenever history is provided.\n",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobKey"
+              }
+            ]
+          },
+          "jobLease": {
+            "description": "Opaque lease token received from the job activation response. Disambiguates\nthis activation from any other activation of the same job: if the job is\nlater retried, history items submitted under a superseded lease are discarded\nrather than committed.\n",
+            "nullable": true,
+            "type": "string"
+          },
+          "history": {
+            "description": "A batch of history items to append to the agent instance's conversation\nhistory, in request order. Each created item is echoed back in the\nresponse's createdHistory, positionally correlated.\n",
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceHistoryItem"
+            }
+          }
+        }
+      },
+      "AgentInstanceUpdateResult": {
+        "description": "Response returned after successfully updating an agent instance.",
+        "type": "object",
+        "required": [
+          "createdHistory"
+        ],
+        "properties": {
+          "createdHistory": {
+            "description": "One entry per history item submitted in the request, in request order.\nEmpty when no history items were submitted.\n",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceCreatedHistoryItem"
+            }
+          }
+        }
+      },
+      "AgentInstanceCreatedHistoryItem": {
+        "description": "The outcome of appending a single history item from an update request's\nhistory batch.\n",
+        "type": "object",
+        "required": [
+          "historyItemId",
+          "historyItemKey",
+          "isDuplicate"
+        ],
+        "properties": {
+          "historyItemId": {
+            "description": "The historyItemId of the corresponding item in the request, echoed back\nso callers can correlate response entries with request items by id.\n",
+            "type": "string"
+          },
+          "historyItemKey": {
+            "description": "The system-generated key for the history item. When isDuplicate is true,\nthis is the key of the original entry, not a new one.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentHistoryItemKey"
+              }
+            ]
+          },
+          "isDuplicate": {
+            "description": "True if this item had already been recorded and no new AGENT_HISTORY event\nwas created for it; false if a new event was created.\n",
+            "type": "boolean"
           }
         }
       },
@@ -23355,7 +23439,7 @@
             "type": "string"
           },
           "loopIteration": {
-            "description": "The loopIteration this item belongs to. A loopIteration is one pass through the agent\nfeedback loop: one LLM call, its tool dispatches, and their results. Omit if not grouping\nitems by loopIteration.\n",
+            "description": "The loop iteration this item belongs to. Omit if not grouping items by\nloopIteration.\n",
             "nullable": true,
             "allOf": [
               {
@@ -23379,7 +23463,7 @@
             }
           },
           "toolCalls": {
-            "description": "Tool calls associated with this history item.\nFor ASSISTANT items: tool calls dispatched by this LLM response, with arguments populated.\nFor TOOL_RESULT items: single-entry array referencing the originating tool call, with arguments null.\nOmit for USER items.\n",
+            "description": "Tool calls associated with this history item.\nFor ASSISTANT items: tool calls dispatched by this LLM response.\nFor TOOL_RESULT items: single-entry array referencing the originating tool call.\nOmit for USER items.\n",
             "type": "array",
             "nullable": true,
             "items": {
@@ -23396,7 +23480,69 @@
             ]
           },
           "producedAt": {
-            "description": "The connector-side timestamp of when this message was produced.",
+            "description": "The agent-side timestamp of when this message was produced.",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AgentInstanceHistoryItem": {
+        "description": "A single history item to append to the agent instance's conversation history,\nsubmitted as part of the batch on an agent instance update request.\n",
+        "type": "object",
+        "required": [
+          "content",
+          "historyItemId",
+          "loopIteration",
+          "producedAt",
+          "role"
+        ],
+        "properties": {
+          "historyItemId": {
+            "description": "Caller-assigned identifier used to detect and dedupe retries of the same\nitem. For example, when a retried job activation resubmits history items\nit already sent in an earlier attempt, those items are not rejected; they\nare flagged via isDuplicate in the response instead. Must be non-blank.\n",
+            "type": "string"
+          },
+          "loopIteration": {
+            "description": "The loop iteration this item belongs to.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoopIterationId"
+              }
+            ]
+          },
+          "role": {
+            "description": "The role of this history item in the conversation.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryRoleEnum"
+              }
+            ]
+          },
+          "content": {
+            "description": "The content blocks of this history item.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceMessageContent"
+            }
+          },
+          "toolCalls": {
+            "description": "Tool calls associated with this history item.\nFor ASSISTANT items: tool calls dispatched by this LLM response.\nFor TOOL_RESULT items: single-entry array referencing the originating tool call.\nOmit for USER items.\n",
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceToolCall"
+            }
+          },
+          "metrics": {
+            "description": "Per-call token and latency metrics. Present on ASSISTANT items only.",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceHistoryItemMetrics"
+              }
+            ]
+          },
+          "producedAt": {
+            "description": "The agent-side timestamp of when this message was produced.",
             "type": "string",
             "format": "date-time"
           }
@@ -23506,7 +23652,7 @@
             ]
           },
           "loopIteration": {
-            "description": "Filter by loopIteration number. A loopIteration is one pass through the agent feedback loop (one LLM call, its tool dispatches, and their results).",
+            "description": "Filter by loop iteration number.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/IntegerFilterProperty"
@@ -23560,14 +23706,20 @@
           "commitStatus",
           "content",
           "elementInstanceKey",
+          "historyItemId",
           "historyItemKey",
           "jobKey",
           "jobLease",
+          "limits",
           "loopIteration",
           "metrics",
+          "model",
           "producedAt",
+          "provider",
           "role",
-          "toolCalls"
+          "systemPrompt",
+          "toolCalls",
+          "tools"
         ],
         "properties": {
           "historyItemKey": {
@@ -23577,6 +23729,10 @@
                 "$ref": "#/components/schemas/AgentHistoryItemKey"
               }
             ]
+          },
+          "historyItemId": {
+            "description": "The client-supplied identifier this item was created with. Empty for items that don't\ncarry one.\n",
+            "type": "string"
           },
           "agentInstanceKey": {
             "description": "The key of the agent instance this item belongs to.",
@@ -23607,7 +23763,7 @@
             "type": "string"
           },
           "loopIteration": {
-            "description": "The loopIteration this item belongs to. A loopIteration is one pass through the agent\nfeedback loop: one LLM call, its tool dispatches, and their results.\n",
+            "description": "The loop iteration this item belongs to.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/LoopIterationId"
@@ -23630,7 +23786,7 @@
             }
           },
           "toolCalls": {
-            "description": "Tool calls for this item. Empty for USER items and ASSISTANT items with no tool dispatches.\nASSISTANT items: dispatched tool calls with arguments populated.\nTOOL_RESULT items: single-entry array referencing the originating tool call (arguments null).\n",
+            "description": "Tool calls for this item. Empty for USER items and ASSISTANT items with no tool dispatches.\nASSISTANT items: dispatched tool calls.\nTOOL_RESULT items: single-entry array referencing the originating tool call.\n",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/AgentInstanceToolCall"
@@ -23654,9 +23810,41 @@
             ]
           },
           "producedAt": {
-            "description": "The connector-side timestamp of when this message was produced.",
+            "description": "The agent-side timestamp of when this message was produced.",
             "type": "string",
             "format": "date-time"
+          },
+          "tools": {
+            "description": "The complete list of tools available to the agent as of this entry. CONFIGURATION\nitems only; empty for other roles.\n",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentTool"
+            }
+          },
+          "model": {
+            "description": "The LLM model identifier as of this entry. CONFIGURATION items only; null for other\nroles.\n",
+            "type": "string",
+            "nullable": true
+          },
+          "provider": {
+            "description": "The LLM provider as of this entry. CONFIGURATION items only; null for other roles.\n",
+            "type": "string",
+            "nullable": true
+          },
+          "limits": {
+            "description": "The operational limits as of this entry. CONFIGURATION items only; -1 on any field\nmeans \"no limit configured\" for other roles.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentInstanceLimits"
+              }
+            ]
+          },
+          "systemPrompt": {
+            "description": "The system prompt, as content blocks, as of this entry. CONFIGURATION items only;\nempty for other roles.\n",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstanceMessageContent"
+            }
           }
         }
       },
@@ -23666,7 +23854,8 @@
         "enum": [
           "USER",
           "ASSISTANT",
-          "TOOL_RESULT"
+          "TOOL_RESULT",
+          "CONFIGURATION"
         ]
       },
       "AgentInstanceHistoryCommitStatusEnum": {
@@ -23777,7 +23966,7 @@
         ]
       },
       "AgentInstanceToolCall": {
-        "description": "A tool call associated with a history item. Used in both ASSISTANT and TOOL_RESULT items.\nASSISTANT items carry arguments; TOOL_RESULT items carry arguments as null.\n",
+        "description": "A tool call associated with a history item. Used in both ASSISTANT and TOOL_RESULT items.\n",
         "type": "object",
         "required": [
           "arguments",
@@ -23800,7 +23989,7 @@
             "nullable": true
           },
           "arguments": {
-            "description": "The tool call arguments as provided by the LLM. Null on TOOL_RESULT items.",
+            "description": "The tool call arguments as provided by the LLM. May be null or populated on\nany item, including TOOL_RESULT.\n",
             "type": "object",
             "nullable": true,
             "additionalProperties": true
@@ -32911,7 +33100,7 @@
         "example": "order-12345"
       },
       "LoopIterationId": {
-        "description": "A client-provided sequential integer identifying one pass through the agent\nfeedback loop: one LLM call, its tool dispatches, and their results. Must be\na positive integer, increasing with each loopIteration. Established by the\nconnector when appending the first history item of a loopIteration.\n",
+        "description": "A client-provided sequential integer identifying a loop iteration: one pass\nthrough an AI agent's loop, during which the model reasons, selects tools,\nevaluates the result, and decides whether to continue. One iteration covers\nthe input for the LLM call, the call itself, and the tools it dispatches;\nthe results of those tool calls are input to the next iteration. Must be a\npositive integer, increasing with each loopIteration. Established by the\nconnector when appending the first history item of a loopIteration.\n",
         "type": "integer",
         "format": "int32",
         "minimum": 1,

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:e5409e756373e35ebaad932216c4cb7c562be0187a06dea6bde62c1dc57423d1",
+  "specHash": "sha256:8ad022cab102155a1607ad1234615fc4d5588dad645b51dba4d0157291b1b12b",
   "semanticKeys": [
     {
       "name": "AgentHistoryItemKey",
@@ -3090,7 +3090,7 @@
         "Agent instance"
       ],
       "summary": "Update agent instance",
-      "description": "Updates the mutable fields of an agent instance: status, metric counters, and\ntools. Metric values are treated as deltas and applied immediately to the\naggregate counters. Tool updates replace the existing tool list.\n",
+      "description": "Updates the mutable fields of an agent instance (status, metric counters, and\ntools) and appends a batch of history items to its conversation history. Metric\nvalues are treated as deltas and applied immediately to the aggregate counters.\nTool updates replace the existing tool list. Each history item created for this\nrequest is echoed back in the response.\n",
       "eventuallyConsistent": false,
       "hasRequestBody": true,
       "requestBodyUnion": false,
@@ -3106,7 +3106,8 @@
         "application/json"
       ],
       "requestBodySchemaRef": "AgentInstanceUpdateRequest",
-      "successStatus": 204,
+      "successResponseSchemaRef": "AgentInstanceUpdateResult",
+      "successStatus": 200,
       "vendorExtensions": {
         "x-eventually-consistent": false,
         "x-required-permissions": [
@@ -10920,9 +10921,14 @@
       "eventuallyConsistent": false,
       "hasRequestBody": true,
       "requestBodyUnion": false,
-      "bodyOnly": true,
+      "bodyOnly": false,
       "pathParams": [],
-      "queryParams": [],
+      "queryParams": [
+        {
+          "name": "dryRun",
+          "required": false
+        }
+      ],
       "requestBodyUnionRefs": [],
       "optionalTenantIdInBody": false,
       "sourceFile": "cluster.yaml",

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -6166,9 +6166,11 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task<ClusterModeChangeResponse> RestoreAsync(RestoreRequest body, CancellationToken ct = default)
+    public async Task<ClusterModeChangeResponse> RestoreAsync(RestoreRequest body, bool? dryRun = null, CancellationToken ct = default)
     {
-        var path = $"/restore";
+        var queryParts = new List<string>();
+        if (dryRun != null) queryParts.Add("dryRun=" + Uri.EscapeDataString(dryRun.ToString()!));
+        var path = queryParts.Count > 0 ? $"/restore?{string.Join("&", queryParts)}" : $"/restore";
         return await InvokeWithRetryAsync(() => SendAsync<ClusterModeChangeResponse>(HttpMethod.Post, path, body, ct), "restore", false, ct);
     }
 
@@ -9634,9 +9636,11 @@ public partial class CamundaClient
 
     /// <summary>
     /// Update agent instance
-    /// Updates the mutable fields of an agent instance: status, metric counters, and
-    /// tools. Metric values are treated as deltas and applied immediately to the
-    /// aggregate counters. Tool updates replace the existing tool list.
+    /// Updates the mutable fields of an agent instance (status, metric counters, and
+    /// tools) and appends a batch of history items to its conversation history. Metric
+    /// values are treated as deltas and applied immediately to the aggregate counters.
+    /// Tool updates replace the existing tool list. Each history item created for this
+    /// request is echoed back in the response.
     /// 
     /// </summary>
     /// <remarks>
@@ -9690,10 +9694,10 @@ public partial class CamundaClient
     /// }
     /// </code>
     /// </example>
-    public async Task UpdateAgentInstanceAsync(AgentInstanceKey agentInstanceKey, AgentInstanceUpdateRequest body, CancellationToken ct = default)
+    public async Task<AgentInstanceUpdateResult> UpdateAgentInstanceAsync(AgentInstanceKey agentInstanceKey, AgentInstanceUpdateRequest body, CancellationToken ct = default)
     {
         var path = $"/agent-instances/{Uri.EscapeDataString(agentInstanceKey.ToString()!)}";
-        await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Patch, path, body, ct); return 0; }, "updateAgentInstance", false, ct);
+        return await InvokeWithRetryAsync(() => SendAsync<AgentInstanceUpdateResult>(HttpMethod.Patch, path, body, ct), "updateAgentInstance", false, ct);
     }
 
     /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -3806,6 +3806,39 @@ internal sealed class AgentHistoryItemKeyFilterPropertyJsonConverter : global::S
 }
 
 /// <summary>
+/// The outcome of appending a single history item from an update request&apos;s
+/// history batch.
+/// 
+/// </summary>
+public sealed class AgentInstanceCreatedHistoryItem
+{
+    /// <summary>
+    /// The historyItemId of the corresponding item in the request, echoed back
+    /// so callers can correlate response entries with request items by id.
+    /// 
+    /// </summary>
+    [JsonPropertyName("historyItemId")]
+    public string HistoryItemId { get; set; } = null!;
+
+    /// <summary>
+    /// The system-generated key for the history item. When isDuplicate is true,
+    /// this is the key of the original entry, not a new one.
+    /// 
+    /// </summary>
+    [JsonPropertyName("historyItemKey")]
+    public AgentHistoryItemKey HistoryItemKey { get; set; }
+
+    /// <summary>
+    /// True if this item had already been recorded and no new AGENT_HISTORY event
+    /// was created for it; false if a new event was created.
+    /// 
+    /// </summary>
+    [JsonPropertyName("isDuplicate")]
+    public bool IsDuplicate { get; set; }
+
+}
+
+/// <summary>
 /// Request to create a new agent instance.
 /// </summary>
 public sealed class AgentInstanceCreationRequest
@@ -4159,7 +4192,7 @@ public sealed class AgentInstanceHistoryFilter
     public JobKeyFilterProperty? JobKey { get; set; }
 
     /// <summary>
-    /// Filter by loopIteration number. A loopIteration is one pass through the agent feedback loop (one LLM call, its tool dispatches, and their results).
+    /// Filter by loop iteration number.
     /// </summary>
     [JsonPropertyName("loopIteration")]
     public IntegerFilterProperty? LoopIteration { get; set; }
@@ -4177,6 +4210,65 @@ public sealed class AgentInstanceHistoryFilter
     /// </summary>
     [JsonPropertyName("producedAt")]
     public DateTimeFilterProperty? ProducedAt { get; set; }
+
+}
+
+/// <summary>
+/// A single history item to append to the agent instance&apos;s conversation history,
+/// submitted as part of the batch on an agent instance update request.
+/// 
+/// </summary>
+public sealed class AgentInstanceHistoryItem
+{
+    /// <summary>
+    /// Caller-assigned identifier used to detect and dedupe retries of the same
+    /// item. For example, when a retried job activation resubmits history items
+    /// it already sent in an earlier attempt, those items are not rejected; they
+    /// are flagged via isDuplicate in the response instead. Must be non-blank.
+    /// 
+    /// </summary>
+    [JsonPropertyName("historyItemId")]
+    public string HistoryItemId { get; set; } = null!;
+
+    /// <summary>
+    /// The loop iteration this item belongs to.
+    /// </summary>
+    [JsonPropertyName("loopIteration")]
+    public LoopIterationId LoopIteration { get; set; }
+
+    /// <summary>
+    /// The role of this history item in the conversation.
+    /// </summary>
+    [JsonPropertyName("role")]
+    public AgentInstanceHistoryRoleEnum Role { get; set; }
+
+    /// <summary>
+    /// The content blocks of this history item.
+    /// </summary>
+    [JsonPropertyName("content")]
+    public List<AgentInstanceMessageContent> Content { get; set; } = null!;
+
+    /// <summary>
+    /// Tool calls associated with this history item.
+    /// For ASSISTANT items: tool calls dispatched by this LLM response.
+    /// For TOOL_RESULT items: single-entry array referencing the originating tool call.
+    /// Omit for USER items.
+    /// 
+    /// </summary>
+    [JsonPropertyName("toolCalls")]
+    public List<AgentInstanceToolCall>? ToolCalls { get; set; }
+
+    /// <summary>
+    /// Per-call token and latency metrics. Present on ASSISTANT items only.
+    /// </summary>
+    [JsonPropertyName("metrics")]
+    public AgentInstanceHistoryItemMetrics? Metrics { get; set; }
+
+    /// <summary>
+    /// The agent-side timestamp of when this message was produced.
+    /// </summary>
+    [JsonPropertyName("producedAt")]
+    public DateTimeOffset ProducedAt { get; set; }
 
 }
 
@@ -4243,9 +4335,8 @@ public sealed class AgentInstanceHistoryItemRequest
     public string JobLease { get; set; } = null!;
 
     /// <summary>
-    /// The loopIteration this item belongs to. A loopIteration is one pass through the agent
-    /// feedback loop: one LLM call, its tool dispatches, and their results. Omit if not grouping
-    /// items by loopIteration.
+    /// The loop iteration this item belongs to. Omit if not grouping items by
+    /// loopIteration.
     /// 
     /// </summary>
     [JsonPropertyName("loopIteration")]
@@ -4265,8 +4356,8 @@ public sealed class AgentInstanceHistoryItemRequest
 
     /// <summary>
     /// Tool calls associated with this history item.
-    /// For ASSISTANT items: tool calls dispatched by this LLM response, with arguments populated.
-    /// For TOOL_RESULT items: single-entry array referencing the originating tool call, with arguments null.
+    /// For ASSISTANT items: tool calls dispatched by this LLM response.
+    /// For TOOL_RESULT items: single-entry array referencing the originating tool call.
     /// Omit for USER items.
     /// 
     /// </summary>
@@ -4280,7 +4371,7 @@ public sealed class AgentInstanceHistoryItemRequest
     public AgentInstanceHistoryItemMetrics? Metrics { get; set; }
 
     /// <summary>
-    /// The connector-side timestamp of when this message was produced.
+    /// The agent-side timestamp of when this message was produced.
     /// </summary>
     [JsonPropertyName("producedAt")]
     public DateTimeOffset ProducedAt { get; set; }
@@ -4297,6 +4388,14 @@ public sealed class AgentInstanceHistoryItemResult
     /// </summary>
     [JsonPropertyName("historyItemKey")]
     public AgentHistoryItemKey HistoryItemKey { get; set; }
+
+    /// <summary>
+    /// The client-supplied identifier this item was created with. Empty for items that don&apos;t
+    /// carry one.
+    /// 
+    /// </summary>
+    [JsonPropertyName("historyItemId")]
+    public string HistoryItemId { get; set; } = null!;
 
     /// <summary>
     /// The key of the agent instance this item belongs to.
@@ -4323,9 +4422,7 @@ public sealed class AgentInstanceHistoryItemResult
     public string JobLease { get; set; } = null!;
 
     /// <summary>
-    /// The loopIteration this item belongs to. A loopIteration is one pass through the agent
-    /// feedback loop: one LLM call, its tool dispatches, and their results.
-    /// 
+    /// The loop iteration this item belongs to.
     /// </summary>
     [JsonPropertyName("loopIteration")]
     public LoopIterationId LoopIteration { get; set; }
@@ -4344,8 +4441,8 @@ public sealed class AgentInstanceHistoryItemResult
 
     /// <summary>
     /// Tool calls for this item. Empty for USER items and ASSISTANT items with no tool dispatches.
-    /// ASSISTANT items: dispatched tool calls with arguments populated.
-    /// TOOL_RESULT items: single-entry array referencing the originating tool call (arguments null).
+    /// ASSISTANT items: dispatched tool calls.
+    /// TOOL_RESULT items: single-entry array referencing the originating tool call.
     /// 
     /// </summary>
     [JsonPropertyName("toolCalls")]
@@ -4364,10 +4461,49 @@ public sealed class AgentInstanceHistoryItemResult
     public AgentInstanceHistoryCommitStatusEnum CommitStatus { get; set; }
 
     /// <summary>
-    /// The connector-side timestamp of when this message was produced.
+    /// The agent-side timestamp of when this message was produced.
     /// </summary>
     [JsonPropertyName("producedAt")]
     public DateTimeOffset ProducedAt { get; set; }
+
+    /// <summary>
+    /// The complete list of tools available to the agent as of this entry. CONFIGURATION
+    /// items only; empty for other roles.
+    /// 
+    /// </summary>
+    [JsonPropertyName("tools")]
+    public List<AgentTool> Tools { get; set; } = null!;
+
+    /// <summary>
+    /// The LLM model identifier as of this entry. CONFIGURATION items only; null for other
+    /// roles.
+    /// 
+    /// </summary>
+    [JsonPropertyName("model")]
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// The LLM provider as of this entry. CONFIGURATION items only; null for other roles.
+    /// 
+    /// </summary>
+    [JsonPropertyName("provider")]
+    public string? Provider { get; set; }
+
+    /// <summary>
+    /// The operational limits as of this entry. CONFIGURATION items only; -1 on any field
+    /// means &quot;no limit configured&quot; for other roles.
+    /// 
+    /// </summary>
+    [JsonPropertyName("limits")]
+    public AgentInstanceLimits Limits { get; set; } = null!;
+
+    /// <summary>
+    /// The system prompt, as content blocks, as of this entry. CONFIGURATION items only;
+    /// empty for other roles.
+    /// 
+    /// </summary>
+    [JsonPropertyName("systemPrompt")]
+    public List<AgentInstanceMessageContent> SystemPrompt { get; set; } = null!;
 
 }
 
@@ -4383,6 +4519,8 @@ public enum AgentInstanceHistoryRoleEnum
     ASSISTANT,
     [JsonPropertyName("TOOL_RESULT")]
     TOOLRESULT,
+    [JsonPropertyName("CONFIGURATION")]
+    CONFIGURATION,
 }
 
 /// <summary>
@@ -5256,7 +5394,6 @@ public sealed class AgentInstanceTextContent : AgentInstanceMessageContent
 
 /// <summary>
 /// A tool call associated with a history item. Used in both ASSISTANT and TOOL_RESULT items.
-/// ASSISTANT items carry arguments; TOOL_RESULT items carry arguments as null.
 /// 
 /// </summary>
 public sealed class AgentInstanceToolCall
@@ -5280,7 +5417,9 @@ public sealed class AgentInstanceToolCall
     public string? ElementId { get; set; }
 
     /// <summary>
-    /// The tool call arguments as provided by the LLM. Null on TOOL_RESULT items.
+    /// The tool call arguments as provided by the LLM. May be null or populated on
+    /// any item, including TOOL_RESULT.
+    /// 
     /// </summary>
     [JsonPropertyName("arguments")]
     public object? Arguments { get; set; }
@@ -5324,6 +5463,48 @@ public sealed class AgentInstanceUpdateRequest
     /// </summary>
     [JsonPropertyName("tools")]
     public List<AgentTool>? Tools { get; set; }
+
+    /// <summary>
+    /// The key of the job activation during which this update is being made.
+    /// Required whenever history is provided.
+    /// 
+    /// </summary>
+    [JsonPropertyName("jobKey")]
+    public JobKey? JobKey { get; set; }
+
+    /// <summary>
+    /// Opaque lease token received from the job activation response. Disambiguates
+    /// this activation from any other activation of the same job: if the job is
+    /// later retried, history items submitted under a superseded lease are discarded
+    /// rather than committed.
+    /// 
+    /// </summary>
+    [JsonPropertyName("jobLease")]
+    public string? JobLease { get; set; }
+
+    /// <summary>
+    /// A batch of history items to append to the agent instance&apos;s conversation
+    /// history, in request order. Each created item is echoed back in the
+    /// response&apos;s createdHistory, positionally correlated.
+    /// 
+    /// </summary>
+    [JsonPropertyName("history")]
+    public List<AgentInstanceHistoryItem>? History { get; set; }
+
+}
+
+/// <summary>
+/// Response returned after successfully updating an agent instance.
+/// </summary>
+public sealed class AgentInstanceUpdateResult
+{
+    /// <summary>
+    /// One entry per history item submitted in the request, in request order.
+    /// Empty when no history items were submitted.
+    /// 
+    /// </summary>
+    [JsonPropertyName("createdHistory")]
+    public List<AgentInstanceCreatedHistoryItem> CreatedHistory { get; set; } = null!;
 
 }
 
@@ -18642,9 +18823,12 @@ public readonly record struct LongKey : global::Camunda.Orchestration.Sdk.ICamun
 }
 
 /// <summary>
-/// A client-provided sequential integer identifying one pass through the agent
-/// feedback loop: one LLM call, its tool dispatches, and their results. Must be
-/// a positive integer, increasing with each loopIteration. Established by the
+/// A client-provided sequential integer identifying a loop iteration: one pass
+/// through an AI agent&apos;s loop, during which the model reasons, selects tools,
+/// evaluates the result, and decides whether to continue. One iteration covers
+/// the input for the LLM call, the call itself, and the tools it dispatches;
+/// the results of those tool calls are input to the next iteration. Must be a
+/// positive integer, increasing with each loopIteration. Established by the
 /// connector when appending the first history item of a loopIteration.
 /// 
 /// </summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:e5409e756373e35ebaad932216c4cb7c562be0187a06dea6bde62c1dc57423d1";
+    public const string SpecHash = "sha256:8ad022cab102155a1607ad1234615fc4d5588dad645b51dba4d0157291b1b12b";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -518,6 +518,12 @@ TYPE Camunda.Orchestration.Sdk.AgentHistoryItemKeyFilterProperty : sealed class
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentHistoryItemKey>? In { get; set; } [JsonPropertyName("$in")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentHistoryItemKey>? NotIn { get; set; } [JsonPropertyName("$notIn")]
 
+TYPE Camunda.Orchestration.Sdk.AgentInstanceCreatedHistoryItem : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey HistoryItemKey { get; set; } [JsonPropertyName("historyItemKey")]
+  PROP System.Boolean IsDuplicate { get; set; } [JsonPropertyName("isDuplicate")]
+  PROP System.String HistoryItemId { get; set; } [JsonPropertyName("historyItemId")]
+
 TYPE Camunda.Orchestration.Sdk.AgentInstanceCreationRequest : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentInstanceDefinition Definition { get; set; } [JsonPropertyName("definition")]
@@ -590,6 +596,16 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryFilter : sealed class
   PROP Camunda.Orchestration.Sdk.IntegerFilterProperty? LoopIteration { get; set; } [JsonPropertyName("loopIteration")]
   PROP Camunda.Orchestration.Sdk.JobKeyFilterProperty? JobKey { get; set; } [JsonPropertyName("jobKey")]
 
+TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItem : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics? Metrics { get; set; } [JsonPropertyName("metrics")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum Role { get; set; } [JsonPropertyName("role")]
+  PROP Camunda.Orchestration.Sdk.LoopIterationId LoopIteration { get; set; } [JsonPropertyName("loopIteration")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceMessageContent> Content { get; set; } [JsonPropertyName("content")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceToolCall>? ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
+  PROP System.DateTimeOffset ProducedAt { get; set; } [JsonPropertyName("producedAt")]
+  PROP System.String HistoryItemId { get; set; } [JsonPropertyName("historyItemId")]
+
 TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemCreationResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.AgentHistoryItemKey HistoryItemKey { get; set; } [JsonPropertyName("historyItemKey")]
@@ -619,13 +635,19 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryItemResult : sealed class
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryItemMetrics? Metrics { get; set; } [JsonPropertyName("metrics")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum Role { get; set; } [JsonPropertyName("role")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceKey AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.AgentInstanceLimits Limits { get; set; } [JsonPropertyName("limits")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
   PROP Camunda.Orchestration.Sdk.JobKey JobKey { get; set; } [JsonPropertyName("jobKey")]
   PROP Camunda.Orchestration.Sdk.LoopIterationId LoopIteration { get; set; } [JsonPropertyName("loopIteration")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceMessageContent> Content { get; set; } [JsonPropertyName("content")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceMessageContent> SystemPrompt { get; set; } [JsonPropertyName("systemPrompt")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceToolCall> ToolCalls { get; set; } [JsonPropertyName("toolCalls")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentTool> Tools { get; set; } [JsonPropertyName("tools")]
   PROP System.DateTimeOffset ProducedAt { get; set; } [JsonPropertyName("producedAt")]
+  PROP System.String HistoryItemId { get; set; } [JsonPropertyName("historyItemId")]
   PROP System.String JobLease { get; set; } [JsonPropertyName("jobLease")]
+  PROP System.String? Model { get; set; } [JsonPropertyName("model")]
+  PROP System.String? Provider { get; set; } [JsonPropertyName("provider")]
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
@@ -633,6 +655,7 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleEnum : enum interfaces=[S
   MEMBER USER = 0 json="USER"
   MEMBER ASSISTANT = 1 json="ASSISTANT"
   MEMBER TOOLRESULT = 2 json="TOOL_RESULT"
+  MEMBER CONFIGURATION = 3 json="CONFIGURATION"
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleExactMatch : struct interfaces=[Camunda.Orchestration.Sdk.ICamundaKey,System.IEquatable<Camunda.Orchestration.Sdk.AgentInstanceHistoryRoleExactMatch>]
   PROP System.String Value { get; }
@@ -837,7 +860,14 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceUpdateRequest : sealed class
   PROP Camunda.Orchestration.Sdk.AgentInstanceMetricsDelta? Metrics { get; set; } [JsonPropertyName("metrics")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceUpdateStatusEnum? Status { get; set; } [JsonPropertyName("status")]
   PROP Camunda.Orchestration.Sdk.ElementInstanceKey ElementInstanceKey { get; set; } [JsonPropertyName("elementInstanceKey")]
+  PROP Camunda.Orchestration.Sdk.JobKey? JobKey { get; set; } [JsonPropertyName("jobKey")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceHistoryItem>? History { get; set; } [JsonPropertyName("history")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentTool>? Tools { get; set; } [JsonPropertyName("tools")]
+  PROP System.String? JobLease { get; set; } [JsonPropertyName("jobLease")]
+
+TYPE Camunda.Orchestration.Sdk.AgentInstanceUpdateResult : sealed class
+  CTOR ()
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.AgentInstanceCreatedHistoryItem> CreatedHistory { get; set; } [JsonPropertyName("createdHistory")]
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceUpdateStatusEnum : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
   ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
@@ -1646,7 +1676,6 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task UnassignUserFromGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UnassignUserFromTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.Username username, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UnassignUserTaskAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task UpdateAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceKey agentInstanceKey, Camunda.Orchestration.Sdk.AgentInstanceUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UpdateAuthorizationAsync(Camunda.Orchestration.Sdk.AuthorizationKey authorizationKey, Camunda.Orchestration.Sdk.AuthorizationRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UpdateJobAsync(Camunda.Orchestration.Sdk.JobKey jobKey, Camunda.Orchestration.Sdk.JobUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task UpdateUserTaskAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskUpdateRequest body, System.Threading.CancellationToken ct = null)
@@ -1655,6 +1684,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQueryResult> SearchAgentInstanceHistoryAsync(Camunda.Orchestration.Sdk.AgentInstanceKey agentInstanceKey, Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AgentInstanceHistorySearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceResult> GetAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceKey agentInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AgentInstanceResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceSearchQueryResult> SearchAgentInstancesAsync(Camunda.Orchestration.Sdk.AgentInstanceSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AgentInstanceSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AgentInstanceUpdateResult> UpdateAgentInstanceAsync(Camunda.Orchestration.Sdk.AgentInstanceKey agentInstanceKey, Camunda.Orchestration.Sdk.AgentInstanceUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AuditLogResult> GetAuditLogAsync(Camunda.Orchestration.Sdk.AuditLogKey auditLogKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AuditLogResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AuditLogSearchQueryResult> SearchAuditLogsAsync(Camunda.Orchestration.Sdk.AuditLogSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AuditLogSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.AuditLogSearchQueryResult> SearchUserTaskAuditLogsAsync(Camunda.Orchestration.Sdk.UserTaskKey userTaskKey, Camunda.Orchestration.Sdk.UserTaskAuditLogSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.AuditLogSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1678,7 +1708,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult> SearchBatchOperationsAsync(Camunda.Orchestration.Sdk.BatchOperationSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.CamundaUserResult> GetAuthenticationAsync(System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> ChangeClusterModeAsync(Camunda.Orchestration.Sdk.Mode mode, System.Boolean? dryRun = null, System.Threading.CancellationToken ct = null)
-  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> RestoreAsync(Camunda.Orchestration.Sdk.RestoreRequest body, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> RestoreAsync(Camunda.Orchestration.Sdk.RestoreRequest body, System.Boolean? dryRun = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterStatusResponse> GetClusterStatusAsync(System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> CreateGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.CreateClusterVariableRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterVariableResult> CreateTenantClusterVariableAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.CreateClusterVariableRequest body, System.Threading.CancellationToken ct = null)


### PR DESCRIPTION
CI regenerates the SDK from `camunda/camunda@main` on every run, so the checked-in generated sources and `PublicApi.shipped.txt` had drifted behind upstream. `PublicApiSurfaceTests.PublicApiSurface_MatchesShippedBaseline` was failing on every PR opened against `main` — the baseline had zero occurrences of `AgentInstanceCreatedHistoryItem` or `isDuplicate`, both of which the current spec now produces.

This refreshes the baseline and the regenerated output. No generator changes.

## Public API surface changes

The baseline diff is 32 insertions / 2 deletions. Worth reading rather than rubber-stamping — this records a real upstream API change, and two of the entries are signature changes.

**New types**

- `AgentInstanceCreatedHistoryItem`
- `AgentInstanceHistoryItem`
- `AgentInstanceUpdateResult`

**New members**

- `AgentInstanceHistoryRoleEnum.CONFIGURATION`
- `AgentInstanceHistoryItemResult` — `Limits`, `SystemPrompt`, `Tools`, `HistoryItemId`, `Model`, `Provider`
- `AgentInstanceUpdateRequest` — `JobKey`, `History`, `JobLease`

**Signature changes — source-compatible, binary-incompatible**

- `UpdateAgentInstanceAsync` now returns `Task<AgentInstanceUpdateResult>` rather than `Task`
- `RestoreAsync` gained an optional `dryRun` parameter

Callers who ignored the `UpdateAgentInstanceAsync` result and never passed `dryRun` recompile unchanged, but anything compiled against the previous assembly needs a rebuild. `main` is on `10.0.0-alpha.*`, and the type is `chore`, so this cuts no release on its own — it ships with whatever `feat`/`fix` lands next.

## Line endings

`PublicApi.shipped.txt` has no `.gitattributes` rule, so the Windows refresh wrote the whole 6.6k-line file as CRLF — a 13k-line diff hiding a 34-line change. It is committed as LF here. A `*.txt text eol=lf` rule (or narrowing to this file) would stop the next person hitting it; not done here to keep the change scoped.

## Verification

Run locally against the regenerated tree:

- `dotnet test test/Camunda.Orchestration.Sdk.Tests --framework net8.0 --configuration Release` — 1190 passed, 0 failed
- `dotnet build --configuration Release` — 0 warnings, 0 errors
- `dotnet build docs/examples/Examples.csproj --configuration Release` — clean
- `dotnet format --verify-no-changes` — exit 0
- `node scripts/check-example-coverage.js` — 218/218, 100%
- `node scripts/check-overwrite-completeness.js` — all public methods have overwrite entries
- `python scripts/sync-readme-snippets.py --check` — in sync

Unblocks #384, which is red on this test alone. #383's last run predates #382 and failed for a different reason, so it needs a rebase before its state is meaningful.
