### PR TITLE
fix(examples): group plannedChanges by physical tenant and cover new operations

### DIFF
--- a/docs/overwrite/CamundaClient.md
+++ b/docs/overwrite/CamundaClient.md
@@ -199,6 +199,16 @@ example:
 
 
 ---
+uid: Camunda.Orchestration.Sdk.CamundaClient.ChangeClusterModeAsClusterAdminAsync(Camunda.Orchestration.Sdk.Mode,System.String,System.Nullable{System.Boolean},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Client.cs#ChangeClusterModeAsClusterAdmin)]
+
+
+---
 uid: Camunda.Orchestration.Sdk.CamundaClient.CompleteJobAsync(Camunda.Orchestration.Sdk.JobKey,Camunda.Orchestration.Sdk.JobCompletionRequest,System.Threading.CancellationToken)
 example:
 - *content
@@ -1410,6 +1420,46 @@ example:
 
 
 [!code-csharp[](../../examples/Backup.cs#DeleteRuntimeBackup)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.TakeHistoryBackupAsync(Camunda.Orchestration.Sdk.TakeHistoryBackupRequest,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Backup.cs#TakeHistoryBackup)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.ListHistoryBackupsAsync(System.Nullable{Camunda.Orchestration.Sdk.BackupIdPrefix},System.Nullable{System.Boolean},System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Backup.cs#ListHistoryBackups)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.GetHistoryBackupAsync(Camunda.Orchestration.Sdk.BackupId,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Backup.cs#GetHistoryBackup)]
+
+
+---
+uid: Camunda.Orchestration.Sdk.CamundaClient.DeleteHistoryBackupAsync(Camunda.Orchestration.Sdk.BackupId,System.Threading.CancellationToken)
+example:
+- *content
+---
+
+
+[!code-csharp[](../../examples/Backup.cs#DeleteHistoryBackup)]
 
 
 ---

--- a/examples/Backup.cs
+++ b/examples/Backup.cs
@@ -119,4 +119,68 @@ public static class BackupExamples
     }
     // </DeleteRuntimeBackupState>
     #endregion DeleteRuntimeBackupState
+
+    #region TakeHistoryBackup
+
+    // <TakeHistoryBackup>
+    public static async Task TakeHistoryBackupExample(BackupId backupId)
+    {
+        using var client = CamundaClient.Create();
+
+        // Backups are logically ordered by id, so each successive backup must use a
+        // higher id than the previous one.
+        var backup = await client.TakeHistoryBackupAsync(
+            new TakeHistoryBackupRequest { BackupId = backupId });
+
+        Console.WriteLine($"Scheduled history backup {backup.BackupId}");
+        foreach (var snapshot in backup.ScheduledSnapshots)
+        {
+            Console.WriteLine($"  {snapshot}");
+        }
+    }
+    // </TakeHistoryBackup>
+    #endregion TakeHistoryBackup
+
+    #region ListHistoryBackups
+
+    // <ListHistoryBackups>
+    public static async Task ListHistoryBackupsExample()
+    {
+        using var client = CamundaClient.Create();
+
+        // `prefix` must end in a single '*'. Omit it to list every history backup.
+        var backups = await client.ListHistoryBackupsAsync(
+            BackupIdPrefix.AssumeExists("10*"));
+
+        Console.WriteLine($"History backups: {backups}");
+    }
+    // </ListHistoryBackups>
+    #endregion ListHistoryBackups
+
+    #region GetHistoryBackup
+
+    // <GetHistoryBackup>
+    public static async Task GetHistoryBackupExample(BackupId backupId)
+    {
+        using var client = CamundaClient.Create();
+
+        var backup = await client.GetHistoryBackupAsync(backupId);
+
+        // The aggregated state is derived from the state of every expected snapshot.
+        Console.WriteLine($"History backup {backup.BackupId}: {backup.State}");
+    }
+    // </GetHistoryBackup>
+    #endregion GetHistoryBackup
+
+    #region DeleteHistoryBackup
+
+    // <DeleteHistoryBackup>
+    public static async Task DeleteHistoryBackupExample(BackupId backupId)
+    {
+        using var client = CamundaClient.Create();
+
+        await client.DeleteHistoryBackupAsync(backupId);
+    }
+    // </DeleteHistoryBackup>
+    #endregion DeleteHistoryBackup
 }

--- a/examples/Client.cs
+++ b/examples/Client.cs
@@ -40,11 +40,18 @@ public static class ClientExamples
         // without applying it. Omit it (or set it to false) to trigger the transition.
         var change = await client.ChangeClusterModeAsync(Mode.RECOVERING, dryRun: true);
 
+        // Operations are grouped by physical tenant; a null tenant means the operation
+        // is not scoped to one, such as a broker lifecycle operation.
         Console.WriteLine($"Cluster change {change.ChangeId}:");
-        foreach (var operation in change.PlannedChanges)
+        foreach (var group in change.PlannedChanges)
         {
-            var suffix = operation.Mode is null ? "" : $" -> {operation.Mode}";
-            Console.WriteLine($"  {operation.Operation}{suffix}");
+            var tenant = group.PhysicalTenantId is null ? "cluster-wide" : group.PhysicalTenantId;
+            Console.WriteLine($"  {tenant}:");
+            foreach (var operation in group.Operations)
+            {
+                var suffix = operation.Mode is null ? "" : $" -> {operation.Mode}";
+                Console.WriteLine($"    {operation.Operation}{suffix}");
+            }
         }
     }
     // </ChangeClusterMode>
@@ -95,10 +102,15 @@ public static class ClientExamples
         });
 
         Console.WriteLine($"Cluster change {change.ChangeId}:");
-        foreach (var operation in change.PlannedChanges)
+        foreach (var group in change.PlannedChanges)
         {
-            var suffix = operation.Mode is null ? "" : $" -> {operation.Mode}";
-            Console.WriteLine($"  {operation.Operation}{suffix}");
+            var tenant = group.PhysicalTenantId is null ? "cluster-wide" : group.PhysicalTenantId;
+            Console.WriteLine($"  {tenant}:");
+            foreach (var operation in group.Operations)
+            {
+                var suffix = operation.Mode is null ? "" : $" -> {operation.Mode}";
+                Console.WriteLine($"    {operation.Operation}{suffix}");
+            }
         }
     }
     // </Restore>

--- a/examples/Client.cs
+++ b/examples/Client.cs
@@ -57,6 +57,33 @@ public static class ClientExamples
     // </ChangeClusterMode>
     #endregion ChangeClusterMode
 
+    #region ChangeClusterModeAsClusterAdmin
+
+    // <ChangeClusterModeAsClusterAdmin>
+    public static async Task ChangeClusterModeAsClusterAdminExample()
+    {
+        using var client = CamundaClient.Create();
+
+        // The cluster-admin variant can target a single physical tenant. Omit
+        // physicalTenantId to apply the change to every physical tenant.
+        var change = await client.ChangeClusterModeAsClusterAdminAsync(
+            Mode.RECOVERING, physicalTenantId: "default", dryRun: true);
+
+        Console.WriteLine($"Cluster change {change.ChangeId}:");
+        foreach (var group in change.PlannedChanges)
+        {
+            var tenant = group.PhysicalTenantId is null ? "cluster-wide" : group.PhysicalTenantId;
+            Console.WriteLine($"  {tenant}:");
+            foreach (var operation in group.Operations)
+            {
+                var suffix = operation.Mode is null ? "" : $" -> {operation.Mode}";
+                Console.WriteLine($"    {operation.Operation}{suffix}");
+            }
+        }
+    }
+    // </ChangeClusterModeAsClusterAdmin>
+    #endregion ChangeClusterModeAsClusterAdmin
+
     #region GetClusterStatus
 
     // <GetClusterStatus>

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -55,6 +55,13 @@
       "label": "Change cluster mode"
     }
   ],
+  "changeClusterModeAsClusterAdmin": [
+    {
+      "file": "Client.cs",
+      "region": "ChangeClusterModeAsClusterAdmin",
+      "label": "Change cluster mode as cluster admin"
+    }
+  ],
   "restore": [
     {
       "file": "Client.cs",
@@ -88,6 +95,34 @@
       "file": "Backup.cs",
       "region": "DeleteRuntimeBackup",
       "label": "Delete a runtime backup"
+    }
+  ],
+  "takeHistoryBackup": [
+    {
+      "file": "Backup.cs",
+      "region": "TakeHistoryBackup",
+      "label": "Take a history backup"
+    }
+  ],
+  "listHistoryBackups": [
+    {
+      "file": "Backup.cs",
+      "region": "ListHistoryBackups",
+      "label": "List history backups"
+    }
+  ],
+  "getHistoryBackup": [
+    {
+      "file": "Backup.cs",
+      "region": "GetHistoryBackup",
+      "label": "Get a history backup"
+    }
+  ],
+  "deleteHistoryBackup": [
+    {
+      "file": "Backup.cs",
+      "region": "DeleteHistoryBackup",
+      "label": "Delete a history backup"
     }
   ],
   "getRuntimeBackupState": [

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -2569,6 +2569,441 @@
         "x-added-in-version": "8.10"
       }
     },
+    "/backups/history": {
+      "post": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Backup"
+        ],
+        "operationId": "takeHistoryBackup",
+        "x-required-permissions": [
+          {
+            "resourceType": "BACKUP",
+            "permissionType": "CREATE"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Take a history backup",
+        "description": "Triggers a backup of the physical tenant's history, by scheduling a snapshot of every\nsecondary storage index it owns.\n\nUnlike runtime backups, history backups have no generated-id mode: `backupId` is always\nrequired.\n\nOnly available on clusters whose secondary storage is Elasticsearch or OpenSearch.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TakeHistoryBackupRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "The backup has been successfully scheduled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TakeHistoryBackupResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The request is forbidden, either because the authenticated caller lacks the required\n`BACKUP` permission, or because the cluster's secondary storage is neither Elasticsearch\nnor OpenSearch and therefore cannot serve history backups. The problem detail says which\nof the two applies.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A backup with the given id already exists, or another backup is already running.\n\nThe \"already running\" check is best-effort and node-local: it only observes backups\nstarted by the gateway that serves the request. Two concurrent requests reaching\ndifferent gateways are narrowed by the duplicate-id check alone.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      },
+      "get": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Backup"
+        ],
+        "operationId": "listHistoryBackups",
+        "x-required-permissions": [
+          {
+            "resourceType": "BACKUP",
+            "permissionType": "READ"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "List history backups",
+        "description": "Returns a list of all available history backups of the physical tenant, with their state\nand additional info, most recent first by snapshot start time.\n\nOnly available on clusters whose secondary storage is Elasticsearch or OpenSearch.\n",
+        "parameters": [
+          {
+            "name": "prefix",
+            "in": "query",
+            "required": false,
+            "description": "A prefix that backup ids must match, ending in a single '*'. If omitted, all\nbackups are returned.\n",
+            "schema": {
+              "$ref": "#/components/schemas/BackupIdPrefix"
+            }
+          },
+          {
+            "name": "verbose",
+            "in": "query",
+            "required": false,
+            "description": "Whether to ask the secondary storage for snapshot-level detail. Setting this to\n`false` makes the query cheaper, but the store then reports neither snapshot state\nnor start time, so both the per-snapshot `details` and the aggregated `state` are\nincomplete and the listing order is unspecified.\n",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of history backups.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HistoryBackupInfo"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The request is forbidden, either because the authenticated caller lacks the required\n`BACKUP` permission, or because the cluster's secondary storage is neither Elasticsearch\nnor OpenSearch and therefore cannot serve history backups. The problem detail says which\nof the two applies.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
+    "/backups/history/{backupId}": {
+      "get": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Backup"
+        ],
+        "operationId": "getHistoryBackup",
+        "x-required-permissions": [
+          {
+            "resourceType": "BACKUP",
+            "permissionType": "READ"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Get history backup",
+        "description": "Returns detailed status of the history backup with the given id.\n\nOnly available on clusters whose secondary storage is Elasticsearch or OpenSearch.\n",
+        "parameters": [
+          {
+            "name": "backupId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the backup.",
+            "schema": {
+              "$ref": "#/components/schemas/BackupId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The history backup.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HistoryBackupInfo"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The request is forbidden, either because the authenticated caller lacks the required\n`BACKUP` permission, or because the cluster's secondary storage is neither Elasticsearch\nnor OpenSearch and therefore cannot serve history backups. The problem detail says which\nof the two applies.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "A backup with the given id does not exist.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      },
+      "delete": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Backup"
+        ],
+        "operationId": "deleteHistoryBackup",
+        "x-required-permissions": [
+          {
+            "resourceType": "BACKUP",
+            "permissionType": "DELETE"
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Delete history backup",
+        "description": "Deletes the history backup with the given id, by deleting every snapshot that makes it\nup.\n\nOnly available on clusters whose secondary storage is Elasticsearch or OpenSearch.\n",
+        "parameters": [
+          {
+            "name": "backupId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the backup.",
+            "schema": {
+              "$ref": "#/components/schemas/BackupId"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The backup has been successfully deleted."
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The request is forbidden, either because the authenticated caller lacks the required\n`BACKUP` permission, or because the cluster's secondary storage is neither Elasticsearch\nnor OpenSearch and therefore cannot serve history backups. The problem detail says which\nof the two applies.\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "A backup with the given id does not exist.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The service is currently unavailable. This may happen only on some requests where the system creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures. In this case, the title of the error object contains `RESOURCE_EXHAUSTED`. Clients are recommended to eventually retry those requests after a backoff period. You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .\n",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/batch-operation-items/search": {
       "post": {
         "x-eventually-consistent": true,
@@ -15823,7 +16258,7 @@
           }
         ],
         "summary": "Delete resource",
-        "description": "Deletes a deployed resource. This can be a process definition, decision requirements\ndefinition, or form definition deployed using the deploy resources endpoint. Specify the\nresource you want to delete in the `resourceKey` parameter.\n\nOnce a resource has been deleted it cannot be recovered. If the resource needs to be\navailable again, a new deployment of the resource is required.\n\nBy default, only the resource itself is deleted from the runtime state. To also delete the\nhistoric data associated with a resource, set the `deleteHistory` flag in the request body\nto `true`. The historic data is deleted asynchronously via a batch operation. The details of\nthe created batch operation are included in the response. Note that history deletion is only\nsupported for process resources; for other resource types this flag is ignored and no history\nwill be deleted.",
+        "description": "Deletes a deployed resource. This can be a process definition, decision requirements\ndefinition, or form definition deployed using the deploy resources endpoint. Specify the\nresource you want to delete in the `resourceKey` parameter.\n\nOnce a resource has been deleted it cannot be recovered. If the resource needs to be\navailable again, a new deployment of the resource is required.\n\nBy default, only the resource itself is deleted from the runtime state. To also delete the\nhistoric data associated with a resource, set the `deleteHistory` flag in the request body\nto `true`. History deletion is supported for process definitions and decision requirements\ndefinitions; for other resource types (forms, generic resources) the flag is ignored and no\nhistory is deleted.\n\nThe two supported types differ in how the history is removed. For a decision requirements\ndefinition the history is deleted asynchronously via a batch operation whose details are\nreturned in the `batchOperation` field of the response. For a process definition the\ndefinition first drains its running instances and its history is deleted asynchronously once\nthe definition is fully removed cluster-wide; no batch operation is returned in the response.",
         "parameters": [
           {
             "name": "resourceKey",
@@ -18296,61 +18731,6 @@
           }
         },
         "x-added-in-version": "8.8"
-      }
-    },
-    "/cluster/v2/status": {
-      "servers": [
-        {
-          "url": "{schema}://{host}:{port}",
-          "variables": {
-            "host": {
-              "default": "localhost",
-              "description": "The hostname of the Orchestration Cluster REST Gateway."
-            },
-            "port": {
-              "default": "8080",
-              "description": "The port of the Orchestration Cluster REST API server."
-            },
-            "schema": {
-              "default": "http",
-              "description": "The schema of the Orchestration Cluster REST API server."
-            }
-          }
-        }
-      ],
-      "get": {
-        "x-eventually-consistent": false,
-        "tags": [
-          "Cluster"
-        ],
-        "operationId": "getClusterStatus",
-        "x-required-permissions": [],
-        "security": [],
-        "summary": "Get the status of the whole cluster",
-        "description": "Checks the health status of the whole cluster, aggregated over all physical tenants. Returns `HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can process work, and `DEGRADED` in every other case. No per-tenant detail is reported; use `GET /cluster/v2/topology` for that.",
-        "responses": {
-          "200": {
-            "description": "The cluster can process work; the body reports whether it is fully healthy or degraded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClusterStatusResponse"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "The cluster is DOWN because no physical tenant can process work.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClusterStatusResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-added-in-version": "8.10"
       }
     },
     "/system/usage-metrics": {
@@ -21009,6 +21389,194 @@
         "x-added-in-version": "8.10"
       }
     },
+    "/cluster/v2/mode": {
+      "servers": [
+        {
+          "url": "{schema}://{host}:{port}",
+          "variables": {
+            "host": {
+              "default": "localhost",
+              "description": "The hostname of the Orchestration Cluster REST Gateway."
+            },
+            "port": {
+              "default": "8080",
+              "description": "The port of the Orchestration Cluster REST API server."
+            },
+            "schema": {
+              "default": "http",
+              "description": "The schema of the Orchestration Cluster REST API server."
+            }
+          }
+        }
+      ],
+      "patch": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Recovery"
+        ],
+        "operationId": "changeClusterModeAsClusterAdmin",
+        "x-required-permissions": [],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "summary": "Change the cluster mode of one or every physical tenant",
+        "description": "Transitions physical tenants between processing and recovery mode.\n\nIf the `physicalTenantId` parameter is not provided, all available physical tenants are transitioned individually.\n\nRequires the cluster-admin security chain. Although this operation lists `bearerAuth` / `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an Orchestration Cluster user's credentials — only the separate cluster-admin credentials are valid here.",
+        "parameters": [
+          {
+            "name": "mode",
+            "in": "query",
+            "required": true,
+            "description": "The target cluster mode.",
+            "schema": {
+              "$ref": "#/components/schemas/Mode"
+            }
+          },
+          {
+            "name": "physicalTenantId",
+            "in": "query",
+            "required": false,
+            "description": "The physical tenant to apply the change to. When omitted, the change is applied to every physical tenant of the cluster.",
+            "schema": {
+              "type": "string",
+              "example": "default"
+            }
+          },
+          {
+            "name": "dryRun",
+            "in": "query",
+            "required": false,
+            "description": "If true, the requested change is only validated and the resulting plan is returned, without applying it to the cluster.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The mode change request was accepted; returns the planned cluster change covering every requested physical tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClusterModeChangeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided data is not valid.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The request lacks valid authentication credentials.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested `physicalTenantId` does not exist in this cluster.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The mode change conflicts with the cluster state, for example because another configuration change is in progress."
+          },
+          "500": {
+            "description": "An internal error occurred while processing the request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
+    "/cluster/v2/status": {
+      "servers": [
+        {
+          "url": "{schema}://{host}:{port}",
+          "variables": {
+            "host": {
+              "default": "localhost",
+              "description": "The hostname of the Orchestration Cluster REST Gateway."
+            },
+            "port": {
+              "default": "8080",
+              "description": "The port of the Orchestration Cluster REST API server."
+            },
+            "schema": {
+              "default": "http",
+              "description": "The schema of the Orchestration Cluster REST API server."
+            }
+          }
+        }
+      ],
+      "get": {
+        "x-eventually-consistent": false,
+        "tags": [
+          "Cluster"
+        ],
+        "operationId": "getClusterStatus",
+        "x-required-permissions": [],
+        "security": [],
+        "summary": "Get the status of the whole cluster",
+        "description": "Checks the health status of the whole cluster, aggregated over all physical tenants. Returns `HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can process work, and `DEGRADED` in every other case. No per-tenant detail is reported; use `GET /cluster/v2/topology` for that.\n\nThis endpoint is public and requires no authentication, unlike `PATCH /cluster/v2/mode` below, which needs cluster-admin credentials.",
+        "responses": {
+          "200": {
+            "description": "The cluster can process work; the body reports whether it is fully healthy or degraded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClusterStatusResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The cluster is DOWN because no physical tenant can process work.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClusterStatusResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-added-in-version": "8.10"
+      }
+    },
     "/users": {
       "post": {
         "x-eventually-consistent": false,
@@ -23387,6 +23955,7 @@
       "AgentInstanceResult": {
         "type": "object",
         "required": [
+          "agentDefinitionKey",
           "agentInstanceKey",
           "completionDate",
           "creationDate",
@@ -23412,6 +23981,14 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/AgentInstanceKey"
+              }
+            ]
+          },
+          "agentDefinitionKey": {
+            "description": "The key of the agent definition this agent instance runs on.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentDefinitionKey"
               }
             ]
           },
@@ -26577,6 +27154,153 @@
           "ranges"
         ]
       },
+      "HistoryBackupStateCode": {
+        "title": "History Backup State",
+        "description": "The aggregated state of a history backup, computed from the state of each of its\nsnapshots.\n",
+        "type": "string",
+        "enum": [
+          "IN_PROGRESS",
+          "COMPLETED",
+          "FAILED",
+          "INCOMPLETE",
+          "INCOMPATIBLE"
+        ],
+        "example": "IN_PROGRESS"
+      },
+      "TakeHistoryBackupRequest": {
+        "title": "TakeHistoryBackupRequest",
+        "description": "Request body for taking a history backup.",
+        "type": "object",
+        "properties": {
+          "backupId": {
+            "description": "The id of the backup to take.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BackupId"
+              }
+            ]
+          }
+        },
+        "required": [
+          "backupId"
+        ]
+      },
+      "TakeHistoryBackupResponse": {
+        "title": "TakeHistoryBackupResponse",
+        "description": "Response body for taking a history backup.",
+        "type": "object",
+        "properties": {
+          "backupId": {
+            "description": "The id of the backup that has been scheduled.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BackupId"
+              }
+            ]
+          },
+          "scheduledSnapshots": {
+            "description": "The names of the snapshots that have been scheduled for this backup.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The name of a scheduled snapshot.",
+              "example": "camunda_webapps_1_8.10.0_part_1_of_6"
+            }
+          }
+        },
+        "required": [
+          "backupId",
+          "scheduledSnapshots"
+        ]
+      },
+      "HistoryBackupInfo": {
+        "title": "History Backup Info",
+        "description": "Detailed status of a history backup. The aggregated state is computed from the state of\neach of its snapshots as:\n- If every expected snapshot exists and all are complete, the overall state is\n  'COMPLETED'.\n- If one snapshot failed or is partial, the overall state is 'FAILED'.\n- Otherwise, if one snapshot is incompatible, the overall state is 'INCOMPATIBLE'.\n- Otherwise, if one snapshot is still running, the overall state is 'IN_PROGRESS'.\n- Otherwise, if snapshots are missing and the backup has not progressed within the\n  configured timeout, the overall state is 'INCOMPLETE'.\n",
+        "type": "object",
+        "properties": {
+          "backupId": {
+            "description": "The id of the backup.",
+            "readOnly": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BackupId"
+              }
+            ]
+          },
+          "state": {
+            "description": "The aggregated state of the backup.",
+            "readOnly": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HistoryBackupStateCode"
+              }
+            ]
+          },
+          "failureReason": {
+            "description": "Reason for failure if the state is 'FAILED'.",
+            "type": "string",
+            "nullable": true,
+            "example": ""
+          },
+          "details": {
+            "readOnly": true,
+            "description": "Detailed status of the backup per snapshot. Always lists every snapshot found for\nthe backup; when the backup was read without snapshot detail, each entry carries\nonly its name.\n",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HistoryBackupSnapshotInfo"
+            }
+          }
+        },
+        "required": [
+          "backupId",
+          "details",
+          "failureReason",
+          "state"
+        ]
+      },
+      "HistoryBackupSnapshotInfo": {
+        "title": "History Backup Snapshot Info",
+        "description": "Detailed info of a single snapshot making up a history backup.",
+        "type": "object",
+        "properties": {
+          "snapshotName": {
+            "description": "The name of the snapshot.",
+            "readOnly": true,
+            "type": "string",
+            "example": "camunda_webapps_1_8.10.0_part_1_of_6"
+          },
+          "state": {
+            "description": "The state of the snapshot, reported verbatim by the secondary storage (for example\n'SUCCESS', 'IN_PROGRESS' or 'PARTIAL'). Deliberately not a closed set: Elasticsearch\nand OpenSearch report different vocabularies. Not reported when the backup was\nlisted without snapshot detail.\n",
+            "readOnly": true,
+            "type": "string",
+            "nullable": true,
+            "example": "SUCCESS"
+          },
+          "startTime": {
+            "description": "The timestamp at which the snapshot was started. Not reported when the backup was\nlisted without snapshot detail.\n",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2022-09-15T13:10:38.176514094Z"
+          },
+          "failures": {
+            "description": "The failures reported for this snapshot. Empty if there were none.",
+            "readOnly": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "A failure reported by the secondary storage for this snapshot."
+            }
+          }
+        },
+        "required": [
+          "failures",
+          "snapshotName",
+          "startTime",
+          "state"
+        ]
+      },
       "BatchOperationCreatedResult": {
         "required": [
           "batchOperationKey",
@@ -27535,6 +28259,25 @@
           "timestamp"
         ]
       },
+      "ClusterStatusResponse": {
+        "description": "The aggregated status of the whole cluster.",
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "description": "`HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can process work, `DEGRADED` in every other case.",
+            "type": "string",
+            "example": "HEALTHY",
+            "enum": [
+              "HEALTHY",
+              "DEGRADED",
+              "DOWN"
+            ]
+          }
+        }
+      },
       "ClusterVariableKindEnum": {
         "type": "string",
         "enum": [
@@ -28034,25 +28777,6 @@
           }
         }
       },
-      "ClusterStatusResponse": {
-        "description": "The aggregated status of the whole cluster.",
-        "type": "object",
-        "required": [
-          "status"
-        ],
-        "properties": {
-          "status": {
-            "description": "`HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can process work, `DEGRADED` in every other case.",
-            "type": "string",
-            "example": "HEALTHY",
-            "enum": [
-              "HEALTHY",
-              "DEGRADED",
-              "DOWN"
-            ]
-          }
-        }
-      },
       "Mode": {
         "description": "The operating mode of a cluster's partitions.",
         "type": "string",
@@ -28271,7 +28995,30 @@
             "example": "7"
           },
           "plannedChanges": {
-            "description": "The ordered list of operations that will be applied to complete the change.",
+            "description": "The operations that will be applied to complete the change, grouped by the physical tenant they belong to. Groups are transitioned in parallel; the operations within a group are applied in the given order.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClusterModeChangePlannedChange"
+            }
+          }
+        }
+      },
+      "ClusterModeChangePlannedChange": {
+        "description": "The operations of a cluster mode change that apply to one physical tenant.",
+        "type": "object",
+        "required": [
+          "operations",
+          "physicalTenantId"
+        ],
+        "properties": {
+          "physicalTenantId": {
+            "description": "The physical tenant the operations apply to; null for operations that are not scoped to a single physical tenant, such as broker lifecycle operations.",
+            "type": "string",
+            "nullable": true,
+            "example": "default"
+          },
+          "operations": {
+            "description": "The ordered list of operations that will be applied to the physical tenant.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ClusterModeChangeOperation"
@@ -30426,7 +31173,7 @@
             "$ref": "#/components/schemas/OperationReference"
           },
           "deleteHistory": {
-            "description": "Indicates if the historic data of a process resource should be deleted via a\nbatch operation asynchronously.\n\nThis flag is only effective for process resources. For other resource types\n(decisions, forms, generic resources), this flag is ignored and no history\nwill be deleted. In those cases, the `batchOperation` field in the response\nwill not be populated.\n",
+            "description": "Indicates if the historic data associated with the resource should also be deleted\nasynchronously.\n\nThis flag is effective for process definitions and decision requirements definitions.\nFor other resource types (forms, generic resources) it is ignored and no history is\ndeleted. For a decision requirements definition the `batchOperation` field in the\nresponse carries the created batch operation. For a process definition the history is\ndeleted as part of the definition's draining/deletion lifecycle and no batch operation is\nreturned.\n",
             "type": "boolean",
             "default": false
           }
@@ -30460,7 +31207,7 @@
                 "$ref": "#/components/schemas/BatchOperationCreatedResult"
               }
             ],
-            "description": "The batch operation created for asynchronously deleting the historic data.\n\nThis field is only populated when the request `deleteHistory` is set to `true` and the resource\nis a process definition. For other resource types (decisions, forms, generic resources),\nthis field will be `null`.\n"
+            "description": "The batch operation created for asynchronously deleting the historic data.\n\nPopulated when `deleteHistory` is `true` and either the resource is a decision\nrequirements definition, or the resource is a process definition that is already fully\ndeleted from the runtime state (its history is purged directly by a batch operation).\n\nFor a process definition that still exists in the runtime state, deletion first drains\nthe definition and its history is removed asynchronously as part of that lifecycle, so no\nbatch operation is returned and this field is `null`. It is also `null` for forms and\ngeneric resources.\n"
           }
         },
         "x-properties-added-in-version": [

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "specHash": "sha256:d21a56ff57b5ac9ea382b871b283d90eb8c93ab92b9ee1e490e616137f7909c5",
+  "specHash": "sha256:2d638fa54edfff38ce1e05e76f1b26575927ac261d240dc8e35843dfe5326846",
   "semanticKeys": [
     {
       "name": "AgentDefinitionKey",
@@ -3903,6 +3903,148 @@
       ],
       "summary": "Delete runtime backup",
       "description": "Deletes the runtime backup with the given id.",
+      "eventuallyConsistent": false,
+      "hasRequestBody": false,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [
+        "backupId"
+      ],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "backups.yaml",
+      "requestBodyContentTypes": [],
+      "successStatus": 204,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [
+          {
+            "resourceType": "BACKUP",
+            "permissionType": "DELETE"
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
+      "operationId": "listHistoryBackups",
+      "path": "/backups/history",
+      "method": "get",
+      "tags": [
+        "Backup"
+      ],
+      "summary": "List history backups",
+      "description": "Returns a list of all available history backups of the physical tenant, with their state\nand additional info, most recent first by snapshot start time.\n\nOnly available on clusters whose secondary storage is Elasticsearch or OpenSearch.\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": false,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [],
+      "queryParams": [
+        {
+          "name": "prefix",
+          "required": false
+        },
+        {
+          "name": "verbose",
+          "required": false
+        }
+      ],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "backups.yaml",
+      "requestBodyContentTypes": [],
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [
+          {
+            "resourceType": "BACKUP",
+            "permissionType": "READ"
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
+      "operationId": "takeHistoryBackup",
+      "path": "/backups/history",
+      "method": "post",
+      "tags": [
+        "Backup"
+      ],
+      "summary": "Take a history backup",
+      "description": "Triggers a backup of the physical tenant's history, by scheduling a snapshot of every\nsecondary storage index it owns.\n\nUnlike runtime backups, history backups have no generated-id mode: `backupId` is always\nrequired.\n\nOnly available on clusters whose secondary storage is Elasticsearch or OpenSearch.\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": true,
+      "requestBodyUnion": false,
+      "bodyOnly": true,
+      "pathParams": [],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "backups.yaml",
+      "requestBodyContentTypes": [
+        "application/json"
+      ],
+      "requestBodySchemaRef": "TakeHistoryBackupRequest",
+      "successResponseSchemaRef": "TakeHistoryBackupResponse",
+      "successStatus": 202,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [
+          {
+            "resourceType": "BACKUP",
+            "permissionType": "CREATE"
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
+      "operationId": "getHistoryBackup",
+      "path": "/backups/history/{backupId}",
+      "method": "get",
+      "tags": [
+        "Backup"
+      ],
+      "summary": "Get history backup",
+      "description": "Returns detailed status of the history backup with the given id.\n\nOnly available on clusters whose secondary storage is Elasticsearch or OpenSearch.\n",
+      "eventuallyConsistent": false,
+      "hasRequestBody": false,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [
+        "backupId"
+      ],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "backups.yaml",
+      "requestBodyContentTypes": [],
+      "successResponseSchemaRef": "HistoryBackupInfo",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [
+          {
+            "resourceType": "BACKUP",
+            "permissionType": "READ"
+          }
+        ],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
+      "operationId": "deleteHistoryBackup",
+      "path": "/backups/history/{backupId}",
+      "method": "delete",
+      "tags": [
+        "Backup"
+      ],
+      "summary": "Delete history backup",
+      "description": "Deletes the history backup with the given id, by deleting every snapshot that makes it\nup.\n\nOnly available on clusters whose secondary storage is Elasticsearch or OpenSearch.\n",
       "eventuallyConsistent": false,
       "hasRequestBody": false,
       "requestBodyUnion": false,
@@ -8927,7 +9069,7 @@
         "Resource"
       ],
       "summary": "Delete resource",
-      "description": "Deletes a deployed resource. This can be a process definition, decision requirements\ndefinition, or form definition deployed using the deploy resources endpoint. Specify the\nresource you want to delete in the `resourceKey` parameter.\n\nOnce a resource has been deleted it cannot be recovered. If the resource needs to be\navailable again, a new deployment of the resource is required.\n\nBy default, only the resource itself is deleted from the runtime state. To also delete the\nhistoric data associated with a resource, set the `deleteHistory` flag in the request body\nto `true`. The historic data is deleted asynchronously via a batch operation. The details of\nthe created batch operation are included in the response. Note that history deletion is only\nsupported for process resources; for other resource types this flag is ignored and no history\nwill be deleted.",
+      "description": "Deletes a deployed resource. This can be a process definition, decision requirements\ndefinition, or form definition deployed using the deploy resources endpoint. Specify the\nresource you want to delete in the `resourceKey` parameter.\n\nOnce a resource has been deleted it cannot be recovered. If the resource needs to be\navailable again, a new deployment of the resource is required.\n\nBy default, only the resource itself is deleted from the runtime state. To also delete the\nhistoric data associated with a resource, set the `deleteHistory` flag in the request body\nto `true`. History deletion is supported for process definitions and decision requirements\ndefinitions; for other resource types (forms, generic resources) the flag is ignored and no\nhistory is deleted.\n\nThe two supported types differ in how the history is removed. For a decision requirements\ndefinition the history is deleted asynchronously via a batch operation whose details are\nreturned in the `batchOperation` field of the response. For a process definition the\ndefinition first drains its running instances and its history is deleted asynchronously once\nthe definition is fully removed cluster-wide; no batch operation is returned in the response.",
       "eventuallyConsistent": false,
       "hasRequestBody": true,
       "requestBodyUnion": false,
@@ -9911,33 +10053,6 @@
         "x-eventually-consistent": false,
         "x-required-permissions": [],
         "x-added-in-version": "8.8"
-      }
-    },
-    {
-      "operationId": "getClusterStatus",
-      "path": "/cluster/v2/status",
-      "method": "get",
-      "tags": [
-        "Cluster"
-      ],
-      "summary": "Get the status of the whole cluster",
-      "description": "Checks the health status of the whole cluster, aggregated over all physical tenants. Returns `HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can process work, and `DEGRADED` in every other case. No per-tenant detail is reported; use `GET /cluster/v2/topology` for that.",
-      "eventuallyConsistent": false,
-      "hasRequestBody": false,
-      "requestBodyUnion": false,
-      "bodyOnly": false,
-      "pathParams": [],
-      "queryParams": [],
-      "requestBodyUnionRefs": [],
-      "optionalTenantIdInBody": false,
-      "sourceFile": "cluster.yaml",
-      "requestBodyContentTypes": [],
-      "successResponseSchemaRef": "ClusterStatusResponse",
-      "successStatus": 200,
-      "vendorExtensions": {
-        "x-eventually-consistent": false,
-        "x-required-permissions": [],
-        "x-added-in-version": "8.10"
       }
     },
     {
@@ -11099,6 +11214,73 @@
       }
     },
     {
+      "operationId": "changeClusterModeAsClusterAdmin",
+      "path": "/cluster/v2/mode",
+      "method": "patch",
+      "tags": [
+        "Recovery"
+      ],
+      "summary": "Change the cluster mode of one or every physical tenant",
+      "description": "Transitions physical tenants between processing and recovery mode.\n\nIf the `physicalTenantId` parameter is not provided, all available physical tenants are transitioned individually.\n\nRequires the cluster-admin security chain. Although this operation lists `bearerAuth` / `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an Orchestration Cluster user's credentials — only the separate cluster-admin credentials are valid here.",
+      "eventuallyConsistent": false,
+      "hasRequestBody": false,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [],
+      "queryParams": [
+        {
+          "name": "mode",
+          "required": true
+        },
+        {
+          "name": "physicalTenantId",
+          "required": false
+        },
+        {
+          "name": "dryRun",
+          "required": false
+        }
+      ],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "cluster-admin.yaml",
+      "requestBodyContentTypes": [],
+      "successResponseSchemaRef": "ClusterModeChangeResponse",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
+      "operationId": "getClusterStatus",
+      "path": "/cluster/v2/status",
+      "method": "get",
+      "tags": [
+        "Cluster"
+      ],
+      "summary": "Get the status of the whole cluster",
+      "description": "Checks the health status of the whole cluster, aggregated over all physical tenants. Returns `HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can process work, and `DEGRADED` in every other case. No per-tenant detail is reported; use `GET /cluster/v2/topology` for that.\n\nThis endpoint is public and requires no authentication, unlike `PATCH /cluster/v2/mode` below, which needs cluster-admin credentials.",
+      "eventuallyConsistent": false,
+      "hasRequestBody": false,
+      "requestBodyUnion": false,
+      "bodyOnly": false,
+      "pathParams": [],
+      "queryParams": [],
+      "requestBodyUnionRefs": [],
+      "optionalTenantIdInBody": false,
+      "sourceFile": "cluster-admin.yaml",
+      "requestBodyContentTypes": [],
+      "successResponseSchemaRef": "ClusterStatusResponse",
+      "successStatus": 200,
+      "vendorExtensions": {
+        "x-eventually-consistent": false,
+        "x-required-permissions": [],
+        "x-added-in-version": "8.10"
+      }
+    },
+    {
       "operationId": "createUser",
       "path": "/users",
       "method": "post",
@@ -12040,7 +12222,7 @@
   "integrity": {
     "totalSemanticKeys": 42,
     "totalUnions": 67,
-    "totalOperations": 220,
+    "totalOperations": 225,
     "totalEventuallyConsistent": 95,
     "totalDeprecatedEnumSchemas": 2,
     "totalSemanticProviders": 23

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/exec": "7.1.0",
         "@semantic-release/git": "10.0.1",
-        "camunda-schema-bundler": "2.4.4",
+        "camunda-schema-bundler": "2.4.5",
         "semantic-release": "25.0.9"
       }
     },
@@ -1488,9 +1488,9 @@
       }
     },
     "node_modules/camunda-schema-bundler": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/camunda-schema-bundler/-/camunda-schema-bundler-2.4.4.tgz",
-      "integrity": "sha512-CX3dl5mhUqqhZc93n2r/Wnit1CmPYlqE1kDJIHq/Bx+t0Eu7OgD0ouetLosD9fDp1qH2ryCXsp++Re4TZZFwOA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/camunda-schema-bundler/-/camunda-schema-bundler-2.4.5.tgz",
+      "integrity": "sha512-ftGu97+3vC8sxrzJZD3J/Wm0lm+a+JQvZmLqeI2fSKCDWA3eHfPryWe/b3oKF5J1Bw3wI0kbE58/D2Rlm1xOTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/exec": "7.1.0",
     "@semantic-release/git": "10.0.1",
-    "camunda-schema-bundler": "2.4.4",
+    "camunda-schema-bundler": "2.4.5",
     "semantic-release": "25.0.9"
   },
   "overrides": {

--- a/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/CamundaClient.Generated.cs
@@ -802,11 +802,18 @@ public partial class CamundaClient
     ///     // without applying it. Omit it (or set it to false) to trigger the transition.
     ///     var change = await client.ChangeClusterModeAsync(Mode.RECOVERING, dryRun: true);
     /// 
+    ///     // Operations are grouped by physical tenant; a null tenant means the operation
+    ///     // is not scoped to one, such as a broker lifecycle operation.
     ///     Console.WriteLine($&quot;Cluster change {change.ChangeId}:&quot;);
-    ///     foreach (var operation in change.PlannedChanges)
+    ///     foreach (var group in change.PlannedChanges)
     ///     {
-    ///         var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
-    ///         Console.WriteLine($&quot;  {operation.Operation}{suffix}&quot;);
+    ///         var tenant = group.PhysicalTenantId is null ? &quot;cluster-wide&quot; : group.PhysicalTenantId;
+    ///         Console.WriteLine($&quot;  {tenant}:&quot;);
+    ///         foreach (var operation in group.Operations)
+    ///         {
+    ///             var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
+    ///             Console.WriteLine($&quot;    {operation.Operation}{suffix}&quot;);
+    ///         }
     ///     }
     /// }
     /// </code>
@@ -822,11 +829,18 @@ public partial class CamundaClient
     ///     // without applying it. Omit it (or set it to false) to trigger the transition.
     ///     var change = await client.ChangeClusterModeAsync(Mode.RECOVERING, dryRun: true);
     /// 
+    ///     // Operations are grouped by physical tenant; a null tenant means the operation
+    ///     // is not scoped to one, such as a broker lifecycle operation.
     ///     Console.WriteLine($&quot;Cluster change {change.ChangeId}:&quot;);
-    ///     foreach (var operation in change.PlannedChanges)
+    ///     foreach (var group in change.PlannedChanges)
     ///     {
-    ///         var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
-    ///         Console.WriteLine($&quot;  {operation.Operation}{suffix}&quot;);
+    ///         var tenant = group.PhysicalTenantId is null ? &quot;cluster-wide&quot; : group.PhysicalTenantId;
+    ///         Console.WriteLine($&quot;  {tenant}:&quot;);
+    ///         foreach (var operation in group.Operations)
+    ///         {
+    ///             var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
+    ///             Console.WriteLine($&quot;    {operation.Operation}{suffix}&quot;);
+    ///         }
     ///     }
     /// }
     /// </code>
@@ -838,6 +852,77 @@ public partial class CamundaClient
         if (dryRun != null) queryParts.Add("dryRun=" + Uri.EscapeDataString(dryRun.ToString()!));
         var path = queryParts.Count > 0 ? $"/mode?{string.Join("&", queryParts)}" : $"/mode";
         return await InvokeWithRetryAsync(() => SendAsync<ClusterModeChangeResponse>(HttpMethod.Patch, path, null, ct), "changeClusterMode", false, ct);
+    }
+
+    /// <summary>
+    /// Change the cluster mode of one or every physical tenant
+    /// Transitions physical tenants between processing and recovery mode.
+    /// 
+    /// If the `physicalTenantId` parameter is not provided, all available physical tenants are transitioned individually.
+    /// 
+    /// Requires the cluster-admin security chain. Although this operation lists `bearerAuth` / `basicAuth` like the rest of the Orchestration Cluster API, it does not accept an Orchestration Cluster user&apos;s credentials — only the separate cluster-admin credentials are valid here.
+    /// </summary>
+    /// <remarks>
+    /// Operation: changeClusterModeAsClusterAdmin
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ChangeClusterModeAsClusterAdminExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     // The cluster-admin variant can target a single physical tenant. Omit
+    ///     // physicalTenantId to apply the change to every physical tenant.
+    ///     var change = await client.ChangeClusterModeAsClusterAdminAsync(
+    ///         Mode.RECOVERING, physicalTenantId: &quot;default&quot;, dryRun: true);
+    /// 
+    ///     Console.WriteLine($&quot;Cluster change {change.ChangeId}:&quot;);
+    ///     foreach (var group in change.PlannedChanges)
+    ///     {
+    ///         var tenant = group.PhysicalTenantId is null ? &quot;cluster-wide&quot; : group.PhysicalTenantId;
+    ///         Console.WriteLine($&quot;  {tenant}:&quot;);
+    ///         foreach (var operation in group.Operations)
+    ///         {
+    ///             var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
+    ///             Console.WriteLine($&quot;    {operation.Operation}{suffix}&quot;);
+    ///         }
+    ///     }
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ChangeClusterModeAsClusterAdminExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     // The cluster-admin variant can target a single physical tenant. Omit
+    ///     // physicalTenantId to apply the change to every physical tenant.
+    ///     var change = await client.ChangeClusterModeAsClusterAdminAsync(
+    ///         Mode.RECOVERING, physicalTenantId: &quot;default&quot;, dryRun: true);
+    /// 
+    ///     Console.WriteLine($&quot;Cluster change {change.ChangeId}:&quot;);
+    ///     foreach (var group in change.PlannedChanges)
+    ///     {
+    ///         var tenant = group.PhysicalTenantId is null ? &quot;cluster-wide&quot; : group.PhysicalTenantId;
+    ///         Console.WriteLine($&quot;  {tenant}:&quot;);
+    ///         foreach (var operation in group.Operations)
+    ///         {
+    ///             var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
+    ///             Console.WriteLine($&quot;    {operation.Operation}{suffix}&quot;);
+    ///         }
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<ClusterModeChangeResponse> ChangeClusterModeAsClusterAdminAsync(Mode mode, string? physicalTenantId = null, bool? dryRun = null, CancellationToken ct = default)
+    {
+        var queryParts = new List<string>();
+        queryParts.Add("mode=" + Uri.EscapeDataString(mode.ToString()!));
+        if (physicalTenantId != null) queryParts.Add("physicalTenantId=" + Uri.EscapeDataString(physicalTenantId.ToString()!));
+        if (dryRun != null) queryParts.Add("dryRun=" + Uri.EscapeDataString(dryRun.ToString()!));
+        var path = queryParts.Count > 0 ? $"/cluster/v2/mode?{string.Join("&", queryParts)}" : $"/cluster/v2/mode";
+        return await InvokeWithRetryAsync(() => SendAsync<ClusterModeChangeResponse>(HttpMethod.Patch, path, null, ct), "changeClusterModeAsClusterAdmin", false, ct);
     }
 
     /// <summary>
@@ -2171,6 +2256,43 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// Delete history backup
+    /// Deletes the history backup with the given id, by deleting every snapshot that makes it
+    /// up.
+    /// 
+    /// Only available on clusters whose secondary storage is Elasticsearch or OpenSearch.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: deleteHistoryBackup
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task DeleteHistoryBackupExample(BackupId backupId)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     await client.DeleteHistoryBackupAsync(backupId);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task DeleteHistoryBackupExample(BackupId backupId)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     await client.DeleteHistoryBackupAsync(backupId);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task DeleteHistoryBackupAsync(BackupId backupId, CancellationToken ct = default)
+    {
+        var path = $"/backups/history/{Uri.EscapeDataString(backupId.ToString()!)}";
+        await InvokeWithRetryAsync(async () => { await SendVoidAsync(HttpMethod.Delete, path, null, ct); return 0; }, "deleteHistoryBackup", false, ct);
+    }
+
+    /// <summary>
     /// Delete a mapping rule
     /// Deletes the mapping rule with the given ID.
     /// 
@@ -2294,10 +2416,15 @@ public partial class CamundaClient
     /// 
     /// By default, only the resource itself is deleted from the runtime state. To also delete the
     /// historic data associated with a resource, set the `deleteHistory` flag in the request body
-    /// to `true`. The historic data is deleted asynchronously via a batch operation. The details of
-    /// the created batch operation are included in the response. Note that history deletion is only
-    /// supported for process resources; for other resource types this flag is ignored and no history
-    /// will be deleted.
+    /// to `true`. History deletion is supported for process definitions and decision requirements
+    /// definitions; for other resource types (forms, generic resources) the flag is ignored and no
+    /// history is deleted.
+    /// 
+    /// The two supported types differ in how the history is removed. For a decision requirements
+    /// definition the history is deleted asynchronously via a batch operation whose details are
+    /// returned in the `batchOperation` field of the response. For a process definition the
+    /// definition first drains its running instances and its history is deleted asynchronously once
+    /// the definition is fully removed cluster-wide; no batch operation is returned in the response.
     /// </summary>
     /// <remarks>
     /// Operation: deleteResource
@@ -3016,6 +3143,8 @@ public partial class CamundaClient
     /// <summary>
     /// Get the status of the whole cluster
     /// Checks the health status of the whole cluster, aggregated over all physical tenants. Returns `HEALTHY` when every physical tenant is healthy, `DOWN` when no physical tenant can process work, and `DEGRADED` in every other case. No per-tenant detail is reported; use `GET /cluster/v2/topology` for that.
+    /// 
+    /// This endpoint is public and requires no authentication, unlike `PATCH /cluster/v2/mode` below, which needs cluster-admin credentials.
     /// </summary>
     /// <remarks>
     /// Operation: getClusterStatus
@@ -3635,6 +3764,48 @@ public partial class CamundaClient
         }
 
         return await InvokeWithRetryAsync(() => SendAsync<GroupResult>(HttpMethod.Get, path, null, ct), "getGroup", false, ct);
+    }
+
+    /// <summary>
+    /// Get history backup
+    /// Returns detailed status of the history backup with the given id.
+    /// 
+    /// Only available on clusters whose secondary storage is Elasticsearch or OpenSearch.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: getHistoryBackup
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task GetHistoryBackupExample(BackupId backupId)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var backup = await client.GetHistoryBackupAsync(backupId);
+    /// 
+    ///     // The aggregated state is derived from the state of every expected snapshot.
+    ///     Console.WriteLine($&quot;History backup {backup.BackupId}: {backup.State}&quot;);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task GetHistoryBackupExample(BackupId backupId)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     var backup = await client.GetHistoryBackupAsync(backupId);
+    /// 
+    ///     // The aggregated state is derived from the state of every expected snapshot.
+    ///     Console.WriteLine($&quot;History backup {backup.BackupId}: {backup.State}&quot;);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<HistoryBackupInfo> GetHistoryBackupAsync(BackupId backupId, CancellationToken ct = default)
+    {
+        var path = $"/backups/history/{Uri.EscapeDataString(backupId.ToString()!)}";
+        return await InvokeWithRetryAsync(() => SendAsync<HistoryBackupInfo>(HttpMethod.Get, path, null, ct), "getHistoryBackup", false, ct);
     }
 
     /// <summary>
@@ -5450,6 +5621,54 @@ public partial class CamundaClient
     }
 
     /// <summary>
+    /// List history backups
+    /// Returns a list of all available history backups of the physical tenant, with their state
+    /// and additional info, most recent first by snapshot start time.
+    /// 
+    /// Only available on clusters whose secondary storage is Elasticsearch or OpenSearch.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: listHistoryBackups
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ListHistoryBackupsExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     // `prefix` must end in a single &apos;*&apos;. Omit it to list every history backup.
+    ///     var backups = await client.ListHistoryBackupsAsync(
+    ///         BackupIdPrefix.AssumeExists(&quot;10*&quot;));
+    /// 
+    ///     Console.WriteLine($&quot;History backups: {backups}&quot;);
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task ListHistoryBackupsExample()
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     // `prefix` must end in a single &apos;*&apos;. Omit it to list every history backup.
+    ///     var backups = await client.ListHistoryBackupsAsync(
+    ///         BackupIdPrefix.AssumeExists(&quot;10*&quot;));
+    /// 
+    ///     Console.WriteLine($&quot;History backups: {backups}&quot;);
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<object> ListHistoryBackupsAsync(BackupIdPrefix? prefix = null, bool? verbose = null, CancellationToken ct = default)
+    {
+        var queryParts = new List<string>();
+        if (prefix != null) queryParts.Add("prefix=" + Uri.EscapeDataString(prefix.ToString()!));
+        if (verbose != null) queryParts.Add("verbose=" + Uri.EscapeDataString(verbose.ToString()!));
+        var path = queryParts.Count > 0 ? $"/backups/history?{string.Join("&", queryParts)}" : $"/backups/history";
+        return await InvokeWithRetryAsync(() => SendAsync<object>(HttpMethod.Get, path, null, ct), "listHistoryBackups", false, ct);
+    }
+
+    /// <summary>
     /// List runtime backups
     /// Returns a list of all available runtime backups of the physical tenant, with their
     /// state and additional info, sorted in descending order of backupId.
@@ -6176,10 +6395,15 @@ public partial class CamundaClient
     ///     });
     /// 
     ///     Console.WriteLine($&quot;Cluster change {change.ChangeId}:&quot;);
-    ///     foreach (var operation in change.PlannedChanges)
+    ///     foreach (var group in change.PlannedChanges)
     ///     {
-    ///         var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
-    ///         Console.WriteLine($&quot;  {operation.Operation}{suffix}&quot;);
+    ///         var tenant = group.PhysicalTenantId is null ? &quot;cluster-wide&quot; : group.PhysicalTenantId;
+    ///         Console.WriteLine($&quot;  {tenant}:&quot;);
+    ///         foreach (var operation in group.Operations)
+    ///         {
+    ///             var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
+    ///             Console.WriteLine($&quot;    {operation.Operation}{suffix}&quot;);
+    ///         }
     ///     }
     /// }
     /// </code>
@@ -6200,10 +6424,15 @@ public partial class CamundaClient
     ///     });
     /// 
     ///     Console.WriteLine($&quot;Cluster change {change.ChangeId}:&quot;);
-    ///     foreach (var operation in change.PlannedChanges)
+    ///     foreach (var group in change.PlannedChanges)
     ///     {
-    ///         var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
-    ///         Console.WriteLine($&quot;  {operation.Operation}{suffix}&quot;);
+    ///         var tenant = group.PhysicalTenantId is null ? &quot;cluster-wide&quot; : group.PhysicalTenantId;
+    ///         Console.WriteLine($&quot;  {tenant}:&quot;);
+    ///         foreach (var operation in group.Operations)
+    ///         {
+    ///             var suffix = operation.Mode is null ? &quot;&quot; : $&quot; -&gt; {operation.Mode}&quot;;
+    ///             Console.WriteLine($&quot;    {operation.Operation}{suffix}&quot;);
+    ///         }
     ///     }
     /// }
     /// </code>
@@ -9185,6 +9414,64 @@ public partial class CamundaClient
     {
         var path = $"/backups/runtime/state/sync";
         return await InvokeWithRetryAsync(() => SendAsync<RuntimeBackupState>(HttpMethod.Post, path, null, ct), "syncRuntimeBackupState", false, ct);
+    }
+
+    /// <summary>
+    /// Take a history backup
+    /// Triggers a backup of the physical tenant&apos;s history, by scheduling a snapshot of every
+    /// secondary storage index it owns.
+    /// 
+    /// Unlike runtime backups, history backups have no generated-id mode: `backupId` is always
+    /// required.
+    /// 
+    /// Only available on clusters whose secondary storage is Elasticsearch or OpenSearch.
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Operation: takeHistoryBackup
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task TakeHistoryBackupExample(BackupId backupId)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     // Backups are logically ordered by id, so each successive backup must use a
+    ///     // higher id than the previous one.
+    ///     var backup = await client.TakeHistoryBackupAsync(
+    ///         new TakeHistoryBackupRequest { BackupId = backupId });
+    /// 
+    ///     Console.WriteLine($&quot;Scheduled history backup {backup.BackupId}&quot;);
+    ///     foreach (var snapshot in backup.ScheduledSnapshots)
+    ///     {
+    ///         Console.WriteLine($&quot;  {snapshot}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    /// public static async Task TakeHistoryBackupExample(BackupId backupId)
+    /// {
+    ///     using var client = CamundaClient.Create();
+    /// 
+    ///     // Backups are logically ordered by id, so each successive backup must use a
+    ///     // higher id than the previous one.
+    ///     var backup = await client.TakeHistoryBackupAsync(
+    ///         new TakeHistoryBackupRequest { BackupId = backupId });
+    /// 
+    ///     Console.WriteLine($&quot;Scheduled history backup {backup.BackupId}&quot;);
+    ///     foreach (var snapshot in backup.ScheduledSnapshots)
+    ///     {
+    ///         Console.WriteLine($&quot;  {snapshot}&quot;);
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public async Task<TakeHistoryBackupResponse> TakeHistoryBackupAsync(TakeHistoryBackupRequest body, CancellationToken ct = default)
+    {
+        var path = $"/backups/history";
+        return await InvokeWithRetryAsync(() => SendAsync<TakeHistoryBackupResponse>(HttpMethod.Post, path, body, ct), "takeHistoryBackup", false, ct);
     }
 
     /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/Models.Generated.cs
@@ -5687,6 +5687,12 @@ public sealed class AgentInstanceResult
     public AgentInstanceKey AgentInstanceKey { get; set; }
 
     /// <summary>
+    /// The key of the agent definition this agent instance runs on.
+    /// </summary>
+    [JsonPropertyName("agentDefinitionKey")]
+    public AgentDefinitionKey AgentDefinitionKey { get; set; }
+
+    /// <summary>
     /// The current status of an agent instance.
     /// </summary>
     [JsonPropertyName("status")]
@@ -9569,6 +9575,25 @@ public sealed class ClusterModeChangeOperation
 }
 
 /// <summary>
+/// The operations of a cluster mode change that apply to one physical tenant.
+/// </summary>
+public sealed class ClusterModeChangePlannedChange
+{
+    /// <summary>
+    /// The physical tenant the operations apply to; null for operations that are not scoped to a single physical tenant, such as broker lifecycle operations.
+    /// </summary>
+    [JsonPropertyName("physicalTenantId")]
+    public string? PhysicalTenantId { get; set; }
+
+    /// <summary>
+    /// The ordered list of operations that will be applied to the physical tenant.
+    /// </summary>
+    [JsonPropertyName("operations")]
+    public List<ClusterModeChangeOperation> Operations { get; set; } = null!;
+
+}
+
+/// <summary>
 /// The planned changes resulting from a cluster mode transition request.
 /// </summary>
 public sealed class ClusterModeChangeResponse
@@ -9580,10 +9605,10 @@ public sealed class ClusterModeChangeResponse
     public string ChangeId { get; set; } = null!;
 
     /// <summary>
-    /// The ordered list of operations that will be applied to complete the change.
+    /// The operations that will be applied to complete the change, grouped by the physical tenant they belong to. Groups are transitioned in parallel; the operations within a group are applied in the given order.
     /// </summary>
     [JsonPropertyName("plannedChanges")]
-    public List<ClusterModeChangeOperation> PlannedChanges { get; set; } = null!;
+    public List<ClusterModeChangePlannedChange> PlannedChanges { get; set; } = null!;
 
 }
 
@@ -12720,13 +12745,15 @@ public sealed class DeleteResourceRequest
     public OperationReference? OperationReference { get; set; }
 
     /// <summary>
-    /// Indicates if the historic data of a process resource should be deleted via a
-    /// batch operation asynchronously.
+    /// Indicates if the historic data associated with the resource should also be deleted
+    /// asynchronously.
     /// 
-    /// This flag is only effective for process resources. For other resource types
-    /// (decisions, forms, generic resources), this flag is ignored and no history
-    /// will be deleted. In those cases, the `batchOperation` field in the response
-    /// will not be populated.
+    /// This flag is effective for process definitions and decision requirements definitions.
+    /// For other resource types (forms, generic resources) it is ignored and no history is
+    /// deleted. For a decision requirements definition the `batchOperation` field in the
+    /// response carries the created batch operation. For a process definition the history is
+    /// deleted as part of the definition&apos;s draining/deletion lifecycle and no batch operation is
+    /// returned.
     /// 
     /// </summary>
     [JsonPropertyName("deleteHistory")]
@@ -12748,9 +12775,14 @@ public sealed class DeleteResourceResponse
     /// <summary>
     /// The batch operation created for asynchronously deleting the historic data.
     /// 
-    /// This field is only populated when the request `deleteHistory` is set to `true` and the resource
-    /// is a process definition. For other resource types (decisions, forms, generic resources),
-    /// this field will be `null`.
+    /// Populated when `deleteHistory` is `true` and either the resource is a decision
+    /// requirements definition, or the resource is a process definition that is already fully
+    /// deleted from the runtime state (its history is purged directly by a batch operation).
+    /// 
+    /// For a process definition that still exists in the runtime state, deletion first drains
+    /// the definition and its history is removed asynchronously as part of that lifecycle, so no
+    /// batch operation is returned and this field is `null`. It is also `null` for forms and
+    /// generic resources.
     /// 
     /// </summary>
     [JsonPropertyName("batchOperation")]
@@ -16332,6 +16364,106 @@ public sealed class GroupUserSearchResult
     [JsonPropertyName("page")]
     public SearchQueryPageResponse Page { get; set; } = null!;
 
+}
+
+/// <summary>
+/// Detailed status of a history backup. The aggregated state is computed from the state of
+/// each of its snapshots as:
+/// - If every expected snapshot exists and all are complete, the overall state is
+///   &apos;COMPLETED&apos;.
+/// - If one snapshot failed or is partial, the overall state is &apos;FAILED&apos;.
+/// - Otherwise, if one snapshot is incompatible, the overall state is &apos;INCOMPATIBLE&apos;.
+/// - Otherwise, if one snapshot is still running, the overall state is &apos;IN_PROGRESS&apos;.
+/// - Otherwise, if snapshots are missing and the backup has not progressed within the
+///   configured timeout, the overall state is &apos;INCOMPLETE&apos;.
+/// 
+/// </summary>
+public sealed class HistoryBackupInfo
+{
+    /// <summary>
+    /// The id of the backup.
+    /// </summary>
+    [JsonPropertyName("backupId")]
+    public BackupId BackupId { get; set; }
+
+    /// <summary>
+    /// The aggregated state of the backup.
+    /// </summary>
+    [JsonPropertyName("state")]
+    public HistoryBackupStateCode State { get; set; }
+
+    /// <summary>
+    /// Reason for failure if the state is &apos;FAILED&apos;.
+    /// </summary>
+    [JsonPropertyName("failureReason")]
+    public string? FailureReason { get; set; }
+
+    /// <summary>
+    /// Detailed status of the backup per snapshot. Always lists every snapshot found for
+    /// the backup; when the backup was read without snapshot detail, each entry carries
+    /// only its name.
+    /// 
+    /// </summary>
+    [JsonPropertyName("details")]
+    public List<HistoryBackupSnapshotInfo> Details { get; set; } = null!;
+
+}
+
+/// <summary>
+/// Detailed info of a single snapshot making up a history backup.
+/// </summary>
+public sealed class HistoryBackupSnapshotInfo
+{
+    /// <summary>
+    /// The name of the snapshot.
+    /// </summary>
+    [JsonPropertyName("snapshotName")]
+    public string SnapshotName { get; set; } = null!;
+
+    /// <summary>
+    /// The state of the snapshot, reported verbatim by the secondary storage (for example
+    /// &apos;SUCCESS&apos;, &apos;IN_PROGRESS&apos; or &apos;PARTIAL&apos;). Deliberately not a closed set: Elasticsearch
+    /// and OpenSearch report different vocabularies. Not reported when the backup was
+    /// listed without snapshot detail.
+    /// 
+    /// </summary>
+    [JsonPropertyName("state")]
+    public string? State { get; set; }
+
+    /// <summary>
+    /// The timestamp at which the snapshot was started. Not reported when the backup was
+    /// listed without snapshot detail.
+    /// 
+    /// </summary>
+    [JsonPropertyName("startTime")]
+    public DateTimeOffset? StartTime { get; set; }
+
+    /// <summary>
+    /// The failures reported for this snapshot. Empty if there were none.
+    /// </summary>
+    [JsonPropertyName("failures")]
+    public List<string> Failures { get; set; } = null!;
+
+}
+
+/// <summary>
+/// The aggregated state of a history backup, computed from the state of each of its
+/// snapshots.
+/// 
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum HistoryBackupStateCode
+{
+    [JsonPropertyName("IN_PROGRESS")]
+    INPROGRESS,
+    [JsonPropertyName("COMPLETED")]
+    COMPLETED,
+    [JsonPropertyName("FAILED")]
+    FAILED,
+    [JsonPropertyName("INCOMPLETE")]
+    INCOMPLETE,
+    [JsonPropertyName("INCOMPATIBLE")]
+    INCOMPATIBLE,
 }
 
 /// <summary>
@@ -26294,6 +26426,38 @@ public readonly record struct Tag : global::Camunda.Orchestration.Sdk.ICamundaKe
 
     /// <inheritdoc />
     public override string ToString() => Value.ToString()!;
+}
+
+/// <summary>
+/// Request body for taking a history backup.
+/// </summary>
+public sealed class TakeHistoryBackupRequest
+{
+    /// <summary>
+    /// The id of the backup to take.
+    /// </summary>
+    [JsonPropertyName("backupId")]
+    public BackupId BackupId { get; set; }
+
+}
+
+/// <summary>
+/// Response body for taking a history backup.
+/// </summary>
+public sealed class TakeHistoryBackupResponse
+{
+    /// <summary>
+    /// The id of the backup that has been scheduled.
+    /// </summary>
+    [JsonPropertyName("backupId")]
+    public BackupId BackupId { get; set; }
+
+    /// <summary>
+    /// The names of the snapshots that have been scheduled for this backup.
+    /// </summary>
+    [JsonPropertyName("scheduledSnapshots")]
+    public List<string> ScheduledSnapshots { get; set; } = null!;
+
 }
 
 /// <summary>

--- a/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
+++ b/src/Camunda.Orchestration.Sdk/Generated/SpecHash.Generated.cs
@@ -10,5 +10,5 @@ public partial class CamundaClient
     /// <summary>
     /// SHA-256 digest of the OpenAPI spec this SDK was generated from.
     /// </summary>
-    public const string SpecHash = "sha256:d21a56ff57b5ac9ea382b871b283d90eb8c93ab92b9ee1e490e616137f7909c5";
+    public const string SpecHash = "sha256:2d638fa54edfff38ce1e05e76f1b26575927ac261d240dc8e35843dfe5326846";
 }

--- a/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
+++ b/test/Camunda.Orchestration.Sdk.Tests/PublicApi.shipped.txt
@@ -890,6 +890,7 @@ TYPE Camunda.Orchestration.Sdk.AgentInstanceObjectContent : sealed class base=Ca
 
 TYPE Camunda.Orchestration.Sdk.AgentInstanceResult : sealed class
   CTOR ()
+  PROP Camunda.Orchestration.Sdk.AgentDefinitionKey AgentDefinitionKey { get; set; } [JsonPropertyName("agentDefinitionKey")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceDefinition Definition { get; set; } [JsonPropertyName("definition")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceKey AgentInstanceKey { get; set; } [JsonPropertyName("agentInstanceKey")]
   PROP Camunda.Orchestration.Sdk.AgentInstanceLimits Limits { get; set; } [JsonPropertyName("limits")]
@@ -1764,6 +1765,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task DeleteGlobalClusterVariableAsync(Camunda.Orchestration.Sdk.ClusterVariableName name, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteGlobalTaskListenerAsync(Camunda.Orchestration.Sdk.GlobalListenerId id, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task DeleteHistoryBackupAsync(Camunda.Orchestration.Sdk.BackupId backupId, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteMappingRuleAsync(Camunda.Orchestration.Sdk.MappingRuleId mappingRuleId, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteProcessInstanceAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.DeleteProcessInstanceRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task DeleteRoleAsync(Camunda.Orchestration.Sdk.RoleId roleId, System.Threading.CancellationToken ct = null)
@@ -1834,6 +1836,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationResponse> GetBatchOperationAsync(Camunda.Orchestration.Sdk.BatchOperationKey batchOperationKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationResponse>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult> SearchBatchOperationsAsync(Camunda.Orchestration.Sdk.BatchOperationSearchQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.BatchOperationSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.CamundaUserResult> GetAuthenticationAsync(System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> ChangeClusterModeAsClusterAdminAsync(Camunda.Orchestration.Sdk.Mode mode, System.String? physicalTenantId = null, System.Boolean? dryRun = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> ChangeClusterModeAsync(Camunda.Orchestration.Sdk.Mode mode, System.Boolean? dryRun = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterModeChangeResponse> RestoreAsync(Camunda.Orchestration.Sdk.RestoreRequest body, System.Boolean? dryRun = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.ClusterStatusResponse> GetClusterStatusAsync(System.Threading.CancellationToken ct = null)
@@ -1881,6 +1884,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupSearchQueryResult> SearchGroupsAsync(Camunda.Orchestration.Sdk.GroupSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GroupSearchQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupUpdateResult> UpdateGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.GroupUpdateRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.GroupUserSearchResult> SearchUsersForGroupAsync(Camunda.Orchestration.Sdk.GroupId groupId, Camunda.Orchestration.Sdk.GroupUserSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.GroupUserSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.HistoryBackupInfo> GetHistoryBackupAsync(Camunda.Orchestration.Sdk.BackupId backupId, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByDefinitionQueryResult> GetProcessInstanceStatisticsByDefinitionAsync(Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByDefinitionQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByDefinitionQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByErrorQueryResult> GetProcessInstanceStatisticsByErrorAsync(Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByErrorQuery body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.IncidentProcessInstanceStatisticsByErrorQueryResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.IncidentResult> GetIncidentAsync(Camunda.Orchestration.Sdk.IncidentKey incidentKey, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.IncidentResult>? consistency = null, System.Threading.CancellationToken ct = null)
@@ -1930,6 +1934,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SecretResolveResult> ResolveSecretsAsync(Camunda.Orchestration.Sdk.SecretResolveRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SignalBroadcastResult> BroadcastSignalAsync(Camunda.Orchestration.Sdk.SignalBroadcastRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.SystemConfigurationResponse> GetSystemConfigurationAsync(System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TakeHistoryBackupResponse> TakeHistoryBackupAsync(Camunda.Orchestration.Sdk.TakeHistoryBackupRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TakeRuntimeBackupResponse> TakeRuntimeBackupAsync(Camunda.Orchestration.Sdk.TakeRuntimeBackupRequest body, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantClientSearchResult> SearchClientsForTenantAsync(Camunda.Orchestration.Sdk.TenantId tenantId, Camunda.Orchestration.Sdk.TenantClientSearchQueryRequest body, Camunda.Orchestration.Sdk.ConsistencyOptions<Camunda.Orchestration.Sdk.TenantClientSearchResult>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<Camunda.Orchestration.Sdk.TenantCreateResult> CreateTenantAsync(Camunda.Orchestration.Sdk.TenantCreateRequest body, System.Threading.CancellationToken ct = null)
@@ -1961,6 +1966,7 @@ TYPE Camunda.Orchestration.Sdk.CamundaClient : class interfaces=[System.IAsyncDi
   METHOD System.Threading.Tasks.Task<System.Object> GetProcessDefinitionXmlAsync(Camunda.Orchestration.Sdk.ProcessDefinitionKey processDefinitionKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetProcessInstanceCallHierarchyAsync(Camunda.Orchestration.Sdk.ProcessInstanceKey processInstanceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> GetResourceContentAsync(Camunda.Orchestration.Sdk.ResourceKey resourceKey, Camunda.Orchestration.Sdk.ConsistencyOptions<System.Object>? consistency = null, System.Threading.CancellationToken ct = null)
+  METHOD System.Threading.Tasks.Task<System.Object> ListHistoryBackupsAsync(Camunda.Orchestration.Sdk.BackupIdPrefix? prefix = null, System.Boolean? verbose = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.Task<System.Object> ListRuntimeBackupsAsync(Camunda.Orchestration.Sdk.BackupIdPrefix? prefix = null, System.Threading.CancellationToken ct = null)
   METHOD System.Threading.Tasks.ValueTask DisposeAsync()
   METHOD System.Void Dispose()
@@ -2110,9 +2116,14 @@ TYPE Camunda.Orchestration.Sdk.ClusterModeChangeOperation : sealed class
   PROP System.String Operation { get; set; } [JsonPropertyName("operation")]
   PROP System.String? Mode { get; set; } [JsonPropertyName("mode")]
 
+TYPE Camunda.Orchestration.Sdk.ClusterModeChangePlannedChange : sealed class
+  CTOR ()
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ClusterModeChangeOperation> Operations { get; set; } [JsonPropertyName("operations")]
+  PROP System.String? PhysicalTenantId { get; set; } [JsonPropertyName("physicalTenantId")]
+
 TYPE Camunda.Orchestration.Sdk.ClusterModeChangeResponse : sealed class
   CTOR ()
-  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ClusterModeChangeOperation> PlannedChanges { get; set; } [JsonPropertyName("plannedChanges")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.ClusterModeChangePlannedChange> PlannedChanges { get; set; } [JsonPropertyName("plannedChanges")]
   PROP System.String ChangeId { get; set; } [JsonPropertyName("changeId")]
 
 TYPE Camunda.Orchestration.Sdk.ClusterStatusResponse : sealed class
@@ -3700,6 +3711,29 @@ TYPE Camunda.Orchestration.Sdk.GroupUserSearchResult : sealed class
   CTOR ()
   PROP Camunda.Orchestration.Sdk.SearchQueryPageResponse Page { get; set; } [JsonPropertyName("page")]
   PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.GroupUserResult> Items { get; set; } [JsonPropertyName("items")]
+
+TYPE Camunda.Orchestration.Sdk.HistoryBackupInfo : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.BackupId BackupId { get; set; } [JsonPropertyName("backupId")]
+  PROP Camunda.Orchestration.Sdk.HistoryBackupStateCode State { get; set; } [JsonPropertyName("state")]
+  PROP System.Collections.Generic.List<Camunda.Orchestration.Sdk.HistoryBackupSnapshotInfo> Details { get; set; } [JsonPropertyName("details")]
+  PROP System.String? FailureReason { get; set; } [JsonPropertyName("failureReason")]
+
+TYPE Camunda.Orchestration.Sdk.HistoryBackupSnapshotInfo : sealed class
+  CTOR ()
+  PROP System.Collections.Generic.List<System.String> Failures { get; set; } [JsonPropertyName("failures")]
+  PROP System.DateTimeOffset? StartTime { get; set; } [JsonPropertyName("startTime")]
+  PROP System.String SnapshotName { get; set; } [JsonPropertyName("snapshotName")]
+  PROP System.String? State { get; set; } [JsonPropertyName("state")]
+
+TYPE Camunda.Orchestration.Sdk.HistoryBackupStateCode : enum interfaces=[System.IComparable,System.IConvertible,System.IFormattable,System.ISpanFormattable]
+  ATTR JsonConverter System.Text.Json.Serialization.JsonStringEnumConverter
+  underlying=System.Int32
+  MEMBER INPROGRESS = 0 json="IN_PROGRESS"
+  MEMBER COMPLETED = 1 json="COMPLETED"
+  MEMBER FAILED = 2 json="FAILED"
+  MEMBER INCOMPLETE = 3 json="INCOMPLETE"
+  MEMBER INCOMPATIBLE = 4 json="INCOMPATIBLE"
 
 TYPE Camunda.Orchestration.Sdk.HttpRetryConfig : sealed class
   CTOR ()
@@ -6057,6 +6091,15 @@ TYPE Camunda.Orchestration.Sdk.Tag : struct interfaces=[Camunda.Orchestration.Sd
   METHOD virtual System.Boolean Equals(System.Object obj)
   METHOD virtual System.Int32 GetHashCode()
   METHOD virtual System.String ToString()
+
+TYPE Camunda.Orchestration.Sdk.TakeHistoryBackupRequest : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.BackupId BackupId { get; set; } [JsonPropertyName("backupId")]
+
+TYPE Camunda.Orchestration.Sdk.TakeHistoryBackupResponse : sealed class
+  CTOR ()
+  PROP Camunda.Orchestration.Sdk.BackupId BackupId { get; set; } [JsonPropertyName("backupId")]
+  PROP System.Collections.Generic.List<System.String> ScheduledSnapshots { get; set; } [JsonPropertyName("scheduledSnapshots")]
 
 TYPE Camunda.Orchestration.Sdk.TakeRuntimeBackupRequest : sealed class
   CTOR ()


### PR DESCRIPTION
## What

Two things, both driven by the same upstream spec change:

1. **Fix the `changeClusterMode` / `restore` examples.** `ClusterModeChangeResponse.plannedChanges`
   is now an array of `ClusterModeChangePlannedChange` — each entry carries a nullable
   `physicalTenantId` plus a nested `operations` array. `ClusterModeChangeOperation` itself is
   unchanged, just one level deeper. The examples read `.operation` / `.mode` directly off
   `plannedChanges`, so they no longer compile.

2. **Add example coverage for the five new operations**, taking coverage back to 100%:
   `changeClusterModeAsClusterAdmin`, `takeHistoryBackup`, `listHistoryBackups`,
   `getHistoryBackup`, `deleteHistoryBackup`.

## Why the `camunda-schema-bundler` 2.4.5 bump is included

`changeClusterModeAsClusterAdmin` declares its `mode` and `dryRun` query parameters as
path-local `$ref`s. Bundler 2.4.4 does not inline those, so the operation generates with
**only** `physicalTenantId` and an example that passes `mode` cannot compile. 2.4.5 inlines
them (`Inlined 3 path-local $refs in parameters arrays`), after which `mode` is required.

There is no single example that compiles under both versions, so the bump is cherry-picked
here rather than left to the separate renovate PR. That renovate PR becomes redundant once
this merges.

## Upstream reference

Upstream commit `e1a2ebce` — "feat: report the physical tenant of every planned mode change
operation" — introduced the regrouping. `ed75bd04` then extracted the cluster-wide endpoints
into a new `cluster-admin.yaml`, which is where the new operations come from.

This is why the scheduled runs on `main` and the bundler renovate PRs are red across the SDKs;
it is not caused by the bundler bump itself.

## Verification

- Regenerated against a freshly bundled upstream `main` spec (225 operations).
- Example type-check passes.
- Example coverage: 225/225, 100%.
